### PR TITLE
Add mockup of idea for CLI

### DIFF
--- a/cli-mockup/stpipe
+++ b/cli-mockup/stpipe
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+import argparse
+
+
+def parse_args():
+    parser = argparse.ArgumentParser("stpipe", description="stpipe CLI")
+    parser.add_argument("-v", "--version", help="print version information and exit", action="store_true")
+
+    subparsers = parser.add_subparsers(dest="command", title="commands", required=True)
+
+    pipeline_parser = subparsers.add_parser("pipeline", help="operate on pipelines", description="operate on pipelines")
+    pipeline_subparsers = pipeline_parser.add_subparsers(dest="subcommand", title="command", required=True)
+
+    pipeline_describe_parser = pipeline_subparsers.add_parser("describe", help="describe a pipeline", description="describe a pipeline")
+    pipeline_describe_parser.add_argument("pipeline-class", help="pipeline class name")
+
+    pipeline_list_parser = pipeline_subparsers.add_parser("list", help="list available pipelines", description="list available pipelines")
+    pipeline_list_parser.add_argument("pattern", help="(optional) restrict pipelines to glob pattern", nargs="?")
+
+    pipeline_run_parser = pipeline_subparsers.add_parser("run", help="run a pipeline", description="run a pipeline")
+    pipeline_run_parser.add_argument("pipeline-class", help="pipeline class name")
+
+    step_parser = subparsers.add_parser("step", help="operate on steps", description="operate on steps")
+    step_subparsers = step_parser.add_subparsers(dest="subcommand", title="command", required=True)
+
+    step_describe_parser = step_subparsers.add_parser("describe", help="describe a step", description="describe a step")
+
+    step_list_parser = step_subparsers.add_parser("list", help="list available steps", description="list available steps")
+    step_list_parser.add_argument("pattern", help="(optional) restrict steps to glob pattern", nargs="?")
+
+    step_run_parser = step_subparsers.add_parser("run", help="run a step", description="run a step")
+    step_run_parser.add_argument("step-class", help="step class name")
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Here's an outline of a stpipe CLI tool:

The base `stpipe` script asks the user to choose whether to work with `pipeline` or `step` commands:
```
$ stpipe -h
usage: stpipe [-h] [-v] {pipeline,step} ...

stpipe CLI

optional arguments:
  -h, --help       show this help message and exit
  -v, --version    print version information and exit

commands:
  {pipeline,step}
    pipeline       operate on pipelines
    step           operate on steps
```

Pipeline commands might include `list` available pipelines, `describe` a pipeline (various detailed info including a list of steps), and `run` a pipeline:
```
$ stpipe pipeline -h
usage: stpipe pipeline [-h] {describe,list,run} ...

operate on pipelines

optional arguments:
  -h, --help           show this help message and exit

command:
  {describe,list,run}
    describe           describe a pipeline
    list               list available pipelines
    run                run a pipeline
```

The `list` command outputs each available pipeline class (registered via entry point):
```
$ stpipe pipeline list -h
usage: stpipe pipeline list [-h] [pattern]

list available pipelines

positional arguments:
  pattern     (optional) restrict pipelines to glob pattern

optional arguments:
  -h, --help  show this help message and exit
```

The `run` command is similar to existing `strun`:
```
$ stpipe pipeline run -h
usage: stpipe pipeline run [-h] pipeline-class

run a pipeline

positional arguments:
  pipeline-class  pipeline class name

optional arguments:
  -h, --help      show this help message and exit
```

Similar commands would be implemented within `step`.