### PR TITLE
Create StpipeExitException for exiting CLI with a specific exit status

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
 0.1.0 (unreleased)
 ==================
 
-- Create package and import code from jwst.stpipe. [#2, #11]
+- Create package and import code from jwst.stpipe. [#2, #11, #12]

--- a/scripts/strun
+++ b/scripts/strun
@@ -5,15 +5,15 @@ Run Steps from the command line
 
 Exit Status
 -----------
-    0:  Step completed satisfactorally
+    0:  Step completed satisfactorily
     1:  General error occurred
-    64: No science exists
+
+Other status codes are Step implementation-specific.
 """
 
 import sys
 
 import stpipe
-from stpipe.exceptions import NoDataOnDetectorError
 from stpipe import Step
 
 if __name__ == '__main__':
@@ -24,20 +24,12 @@ if __name__ == '__main__':
 
     try:
         step = Step.from_cmdline(sys.argv[1:])
-
-    except NoDataOnDetectorError:
-        #  No science data is present on a detector. This can happen
-        #  with NIRSpec and the NRS2 detector: Situations occur when no spectra
-        #  disperse across both detectors.
-        #
-        #  Special exit status is provided so that automatic processing can detect
-        #  this situation and act accordingly.
-        #
-        #  Full discussion: https://github.com/spacetelescope/jwst/issues/2336
+    except SystemExit as e:
         import traceback
         traceback.print_exc()
-        sys.exit(64)
-
+        # Re-raising SystemExit allows Step code customize
+        # the exit status code.
+        raise
     except Exception:
         import traceback
         traceback.print_exc()

--- a/scripts/strun
+++ b/scripts/strun
@@ -24,12 +24,6 @@ if __name__ == '__main__':
 
     try:
         step = Step.from_cmdline(sys.argv[1:])
-    except SystemExit as e:
-        import traceback
-        traceback.print_exc()
-        # Re-raising SystemExit allows Step code customize
-        # the exit status code.
-        raise
     except Exception:
         import traceback
         traceback.print_exc()

--- a/scripts/strun
+++ b/scripts/strun
@@ -15,6 +15,8 @@ import sys
 
 import stpipe
 from stpipe import Step
+from stpipe.exceptions import StpipeExitException
+
 
 if __name__ == '__main__':
 
@@ -24,6 +26,8 @@ if __name__ == '__main__':
 
     try:
         step = Step.from_cmdline(sys.argv[1:])
+    except StpipeExitException as e:
+        sys.exit(e.exit_status)
     except Exception:
         import traceback
         traceback.print_exc()

--- a/src/stpipe/exceptions.py
+++ b/src/stpipe/exceptions.py
@@ -3,3 +3,17 @@ class StpipeException(Exception):
     Base class for exceptions from the stpipe package.
     """
     pass
+
+
+class StpipeExitException(StpipeException):
+    """
+    An exception that carries an exit status that is
+    returned by stpipe CLI tools.
+    """
+    def __init__(self, exit_status, *args):
+        super().__init__(exit_status, *args)
+        self._exit_status = exit_status
+
+    @property
+    def exit_status(self):
+        return self._exit_status

--- a/src/stpipe/exceptions.py
+++ b/src/stpipe/exceptions.py
@@ -3,21 +3,3 @@ class StpipeException(Exception):
     Base class for exceptions from the stpipe package.
     """
     pass
-
-
-class NoDataOnDetectorError(StpipeException):
-    """WCS solution indicates no data on detector
-
-    When WCS solutions are available, the solutions indicate that no data
-    will be present, raise this exception.
-
-    Specific example is for NIRSpec and the NRS2 detector. For various
-    configurations of the MSA, it is possible that no dispersed spectra will
-    appear on NRS2. This is not a failure of calibration, but needs to be
-    called out in order for the calling architecture to be aware of this.
-    """
-
-    def __init__(self, message=None):
-        if message is None:
-            message = 'WCS solution indicates that no science is in the data.'
-        super().__init__(message)


### PR DESCRIPTION
@jdavies-st pointed out that `NoDataOnDetectorError` is JWST-specific and probably not useful to keep in stpipe.  ~~This removes that exception from this package and adds more general handling of any `SystemExit` subclass.~~  This removes that exception and adds an `StpipeExitException` base class that jwst can use to cause the CLI to exit with a particular status code.