### PR TITLE
change default value of output_ext

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+0.2.0 (Unreleased)
+==================
+
+- Remove the default value of ``output_ext`` so subclsses can define it. [#17]
+  
 0.1.0 (2021-02-08)
 ==================
 

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -43,7 +43,7 @@ class Step:
     post_hooks         = string_list(default=list())
     output_file        = output_file(default=None)   # File to save output to.
     output_dir         = string(default=None)        # Directory path for output files
-    output_ext         = string(default='.fits')     # Default type of output
+    output_ext         = string()                    # Default type of output
     output_use_model   = boolean(default=False)      # When saving use `DataModel.meta.filename`
     output_use_index   = boolean(default=True)       # Append index.
     save_results       = boolean(default=False)      # Force save results


### PR DESCRIPTION
This change allows subclasses to define their own `output_ext`. The extension is used to define what output data format to use.