### PR TITLE
JP-1940: Change method to combine kwargs with provided cfg args in .call()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+0.3.0 (unreleased)
+==================
+
+- Change ConfigObj.update() to merge() when combining user-provided
+  config_file and step-specific flags during a step.call() to properly
+  merge dicts of step flags [#22]
+
 0.2.0 (2021-04-22)
 ==================
 

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -578,7 +578,7 @@ class Step:
         else:
             config_file = None
 
-        crds_config.update(kwargs)
+        crds_config.merge(kwargs)
 
         if 'class' in crds_config:
             del crds_config['class']


### PR DESCRIPTION
Fixes [jwst #5789](https://github.com/spacetelescope/jwst/issues/5789)
Resolves [JP-1940](https://jira.stsci.edu/browse/JP-1940)

Not sure if this is the correct procedure, but a JP ticket filed with a jwst repo issue has been traced to an issue in stpipe - specifically, if a user provides both a config_file and specific step flags, the merging of the step flag dicts was not a deep merge but an overwrite. This is easily fixed by using a different, existing method that ensures nested dicts are appropriately merged.