### PR TITLE
Prevent ConfigObj from treating DataModel as a config section

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@
   or the ``Step.export_config`` method for options for generating
   ASDF config files. [#25]
 
+- Prevent ConfigObj from treating DataModel as a config section. [#26]
+
 0.2.0 (2021-04-22)
 ==================
 

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -578,7 +578,7 @@ class Step:
         else:
             config_file = None
 
-        crds_config.merge(kwargs)
+        config_parser.merge_config(crds_config, kwargs)
 
         if 'class' in crds_config:
             del crds_config['class']

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -1,0 +1,33 @@
+from collections.abc import Mapping
+
+from stpipe import config_parser
+from stpipe.extern.configobj.configobj import ConfigObj, Section
+
+
+def test_merge_config_nested_mapping():
+    """
+    Test that non-dict Mapping implementations are not
+    converted to config sections.
+    """
+    config = ConfigObj()
+    config_parser.merge_config(config, {"foo": {"bar": "baz"}})
+    assert isinstance(config["foo"], Section)
+    assert config["foo"]["bar"] == "baz"
+
+    class TestMapping(Mapping):
+        def __init__(self, delegate):
+            self._delegate = delegate
+
+        def __iter__(self):
+            return iter(self._delgate)
+
+        def __getitem__(self, key):
+            return self._delegate[key]
+
+        def __len__(self):
+            return len(self._delegate)
+
+    config = ConfigObj()
+    config_parser.merge_config(config, {"foo": TestMapping({"bar": "baz"})})
+    assert isinstance(config["foo"], TestMapping)
+    assert config["foo"]["bar"] == "baz"


### PR DESCRIPTION
Over in stdatamodels I'm working on making DataModel implement collections.abc.Mapping, but that causes ConfigObj to treat reference overrides as config sections instead of config values.  This PR updates the merge_config function so that only true dicts are treated as config sections.