### PR TITLE
JP-2520: Pull out metadata to avoid passing full data array for crds reference gathering

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+0.3.2 (unreleased)
+==================
+
+- Pass header-only model to steps for CRDS fetching to reduce memory usage [#38]
+
 0.3.1 (2021-11-12)
 ==================
 

--- a/src/stpipe/pipeline.py
+++ b/src/stpipe/pipeline.py
@@ -162,24 +162,28 @@ class Pipeline(Step):
         #
         # Iterate over the steps in the pipeline
         with cls._datamodels_open(dataset, asn_n_members=1) as model:
-            for cal_step in cls.step_defs.keys():
-                cal_step_class = cls.step_defs[cal_step]
-                refcfg['steps'][cal_step] = cal_step_class.get_config_from_reference(model)
-            #
-            # Now merge any config parameters from the step cfg file
-            log.debug(f'Retrieving pipeline {reftype.upper()} parameters from CRDS')
-            try:
-                ref_file = crds_client.get_reference_file(model.get_crds_parameters(),
-                                                        reftype,
-                                                        model.crds_observatory)
-            except (AttributeError, crds_client.CrdsError):
-                log.debug(f'{reftype.upper()}: No parameters found')
+            input_class = model.__class__()
+            metadata = input_class
+            metadata.update(model, only='PRIMARY')
+
+        for cal_step in cls.step_defs.keys():
+            cal_step_class = cls.step_defs[cal_step]
+            refcfg['steps'][cal_step] = cal_step_class.get_config_from_reference(metadata)
+        #
+        # Now merge any config parameters from the step cfg file
+        log.debug(f'Retrieving pipeline {reftype.upper()} parameters from CRDS')
+        try:
+            ref_file = crds_client.get_reference_file(metadata.get_crds_parameters(),
+                                                    reftype,
+                                                    metadata.crds_observatory)
+        except (AttributeError, crds_client.CrdsError):
+            log.debug(f'{reftype.upper()}: No parameters found')
+        else:
+            if ref_file != 'N/A':
+                log.info(f'{reftype.upper()} parameters found: {ref_file}')
+                refcfg = cls.merge_pipeline_config(refcfg, ref_file)
             else:
-                if ref_file != 'N/A':
-                    log.info(f'{reftype.upper()} parameters found: {ref_file}')
-                    refcfg = cls.merge_pipeline_config(refcfg, ref_file)
-                else:
-                    log.debug(f'No {reftype.upper()} reference files found.')
+                log.debug(f'No {reftype.upper()} reference files found.')
 
         return refcfg
 


### PR DESCRIPTION
Addresses [JP-2520](https://jira.stsci.edu/browse/JP-2520)

Calwebb_spec2 was found to require >25 GB of memory during CRDS prefetch with an input dataset of size ~2 GB. 

This PR passes a datamodel containing only the primary header metadata but stripped of the data array to each step for CRDS reference fetching.