### PR TITLE
JP-2520: Bugfix for ModelContainers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,9 @@
 
 - Pass header-only model to steps for CRDS fetching to reduce memory usage [#38]
 
+- Ensure product header is passed for CRDS fetching instead of empty
+  ModelContainer header [#50]
+
 0.3.1 (2021-11-12)
 ==================
 

--- a/src/stpipe/pipeline.py
+++ b/src/stpipe/pipeline.py
@@ -163,17 +163,10 @@ class Pipeline(Step):
         # Iterate over the steps in the pipeline
         with cls._datamodels_open(dataset, asn_n_members=1) as model:
             if isinstance(model, Sequence):
-                for exposure in model.meta.asn_table.products[0].members:
-                    if exposure.exptype.upper() == "SCIENCE":
-                        first_exposure = exposure.expname
-                        break
-                else:
-                    first_exposure = self.meta.asn_table.products[0].members[0].expname
-
-                with cls._datamodels_open(first_exposure) as meta_source:
-                    input_class = meta_source.__class__()
+                for contained_model in model:
+                    input_class = contained_model.__class__()
                     metadata = input_class
-                    metadata.update(meta_source)
+                    metadata.update(contained_model, only='PRIMARY')
             else:
                 input_class = model.__class__()
                 metadata = input_class


### PR DESCRIPTION
The modification made in #38 does not propagate metadata from ModelContainers, as the container itself contains no metadata with which to fetch references from CRDS. Taking from _precache_references() code below the code I added, I'm following in someone's footsteps by selecting ModelContainers on isinstance(input, Sequence). With this, I can grab the metadata from the single asn member (due to asn_n_members=1 in datamodel_open).