### PR TITLE
JP-2355: Attempt to record skip into cal_step using alias

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@
 
 - Update astropy min version to 5.0.4. [#52]
 
+- Update datamodel with 'SKIPPED' status when step.skip set to True [#53]
+
 0.3.3 (2022-04-07)
 ==================
 

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -425,7 +425,7 @@ class Step:
                     if isinstance(args[0], AbstractDataModel):
                         if self.class_alias is not None:
                             try:
-                                args[0].meta.cal_step.instance[self.class_alias] = 'SKIPPED'
+                                args[0][f"meta.cal_step.{self.class_alias}"] = 'SKIPPED'
                             except AttributeError as e:
                                 self.log.info(f"Could not record skip into DataModel header: {e}")
                     step_result = args[0]

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -422,6 +422,12 @@ class Step:
                 # Run the Step-specific code.
                 if self.skip:
                     self.log.info('Step skipped.')
+                    if isinstance(args[0], AbstractDataModel):
+                        if self.class_alias is not None:
+                            try:
+                                args[0].meta.cal_step.instance[self.class_alias] = 'SKIPPED'
+                            except AttributeError as e:
+                                self.log.info(f"Could not record skip into DataModel header: {e}")
                     step_result = args[0]
                 else:
                     if self.prefetch_references:
@@ -779,7 +785,7 @@ class Step:
         try:
             model = cls._datamodels_open(dataset)
         except (IOError, TypeError, ValueError):
-            logger.warning('Input dataset is not an instance of  AbstractDataModel.')
+            logger.warning('Input dataset is not an instance of AbstractDataModel.')
             disable = True
 
         # Check if retrieval should be attempted.


### PR DESCRIPTION
This attempts to record a skipped step into the DataModel's cal_step dictionary using the step's alias as the dict key. Need to test against jwst before any thought of merging.