### PR TITLE
JP-2609: Fix ignored step-pars during cmdline pipeline run

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@
 
 - Update CI workflows to cache test environments and depend upon style and security checks [#55]
 
+- Correctly handle config merges of default spec, any possible step-pars files (from
+  CRDS or the user), and either command line (for strun) or step parameter dictionary (for interactive
+  session Pipeline.call()) parameter specifications [#57]
+
 0.3.3 (2022-04-07)
 ==================
 

--- a/src/stpipe/cmdline.py
+++ b/src/stpipe/cmdline.py
@@ -286,7 +286,7 @@ def just_the_step_from_cmdline(args, cls=None):
     # This is where the step is instantiated
     try:
         step = step_class.from_config_section(
-            config, name=name, cmd_args=args)
+            config, name=name, param_args=args)
     except config_parser.ValidationError as e:
         # If the configobj validator failed, print usage information.
         _print_important_message("ERROR PARSING CONFIGURATION:", str(e))

--- a/src/stpipe/cmdline.py
+++ b/src/stpipe/cmdline.py
@@ -279,7 +279,7 @@ def just_the_step_from_cmdline(args, cls=None):
     # Config is empty if class specified, otherwise contains values from config file specified
     # on command line
 
-    config = step_class.finalize_config(config, config_file=config_file)
+    config = step_class.finalize_config(config, config_file=config_file, validate=False)
 
     _override_config_from_args(config, args)
 

--- a/src/stpipe/cmdline.py
+++ b/src/stpipe/cmdline.py
@@ -278,12 +278,15 @@ def just_the_step_from_cmdline(args, cls=None):
     # This updates config (a ConfigObj) with the values from the command line arguments
     # Config is empty if class specified, otherwise contains values from config file specified
     # on command line
+
+    config = step_class.finalize_config(config, name=name, config_file=config_file)
+
     _override_config_from_args(config, args)
 
     # This is where the step is instantiated
     try:
         step = step_class.from_config_section(
-            config, name=name, config_file=config_file)
+            config, name=name)
     except config_parser.ValidationError as e:
         # If the configobj validator failed, print usage information.
         _print_important_message("ERROR PARSING CONFIGURATION:", str(e))

--- a/src/stpipe/cmdline.py
+++ b/src/stpipe/cmdline.py
@@ -286,7 +286,7 @@ def just_the_step_from_cmdline(args, cls=None):
     # This is where the step is instantiated
     try:
         step = step_class.from_config_section(
-            config, name=name)
+            config, name=name, cmd_args=args)
     except config_parser.ValidationError as e:
         # If the configobj validator failed, print usage information.
         _print_important_message("ERROR PARSING CONFIGURATION:", str(e))

--- a/src/stpipe/cmdline.py
+++ b/src/stpipe/cmdline.py
@@ -279,7 +279,9 @@ def just_the_step_from_cmdline(args, cls=None):
     # Config is empty if class specified, otherwise contains values from config file specified
     # on command line
 
-    config = step_class.finalize_config(config, config_file=config_file, validate=False)
+    _override_config_from_args(config, args)
+
+    config = step_class.finalize_config(config, config_file=config_file)
 
     _override_config_from_args(config, args)
 

--- a/src/stpipe/cmdline.py
+++ b/src/stpipe/cmdline.py
@@ -279,7 +279,7 @@ def just_the_step_from_cmdline(args, cls=None):
     # Config is empty if class specified, otherwise contains values from config file specified
     # on command line
 
-    config = step_class.finalize_config(config, name=name, config_file=config_file)
+    config = step_class.finalize_config(config, config_file=config_file)
 
     _override_config_from_args(config, args)
 

--- a/src/stpipe/pipeline.py
+++ b/src/stpipe/pipeline.py
@@ -95,7 +95,7 @@ class Pipeline(Step):
                     cfg2 = config_parser.load_config_file(
                         join(dirname(config_file or ''), cfg.get('config_file')))
                     del cfg['config_file']
-                    config_parser.merge_config(cfg2, cfg)
+                    config_parser.merge_config(cfg, cfg2)
                     steps[key] = cfg2
 
         return config

--- a/src/stpipe/pipeline.py
+++ b/src/stpipe/pipeline.py
@@ -102,12 +102,15 @@ class Pipeline(Step):
             if cfg is not None:
                 # If a config_file is specified, load those values and
                 # then override them with our values.
+                cfg3 = cfg.copy()
                 if cfg.get('config_file'):
                     cfg2 = config_parser.load_config_file(
                         join(dirname(config_file or ''), cfg.get('config_file')))
                     del cfg['config_file']
+                    del cfg3['config_file']
                     config_parser.merge_config(cfg, cfg2)
-                    steps[key] = cfg2
+                    config_parser.merge_config(cfg, cfg3)
+                    steps[key] = cfg
 
         return config
 

--- a/src/stpipe/pipeline.py
+++ b/src/stpipe/pipeline.py
@@ -95,7 +95,7 @@ class Pipeline(Step):
                     cfg2 = config_parser.load_config_file(
                         join(dirname(config_file or ''), cfg.get('config_file')))
                     del cfg['config_file']
-                    config_parser.merge_config(cfg, cfg2)
+                    config_parser.merge_config(cfg2, cfg)
                     steps[key] = cfg2
 
         return config

--- a/src/stpipe/pipeline.py
+++ b/src/stpipe/pipeline.py
@@ -3,7 +3,7 @@ Pipeline
 """
 from collections.abc import Sequence
 from os.path import dirname, join
-
+from argparse import Namespace
 from .extern.configobj.configobj import Section, ConfigObj
 
 from . import config_parser
@@ -37,8 +37,17 @@ class Pipeline(Step):
         # Configure all of the steps
         for key, val in self.step_defs.items():
             cfg = self.steps.get(key)
-            if self.cmd_args is not None:
-                self._override_stepconfig_from_cmd_args(key, cfg, self.cmd_args)
+            if self.param_args is not None:
+                if isinstance(self.param_args, Namespace):
+                    self._override_stepconfig_from_param_args(key, cfg, self.param_args)
+                elif isinstance(self.param_args, dict):
+                    allsteps_dict = self.param_args.get('steps', {})
+                    step_dict = allsteps_dict.get(key, {})
+                    for item in step_dict:
+                        cfg[item] = step_dict[item]
+                else:
+                    # Can this ever be reached?
+                    raise ValueError(f"Cannot parse arguments to Pipeline: {self.param_args}")
             if cfg is not None:
                 new_step = val.from_config_section(
                     cfg, parent=self, name=key,
@@ -229,7 +238,7 @@ class Pipeline(Step):
 
     @classmethod
     def from_config_section(cls, config, parent=None, name=None,
-                            config_file=None, cmd_args=None):
+                            config_file=None, param_args=None):
         """
         Create a step from a configuration file fragment.
 
@@ -266,7 +275,7 @@ class Pipeline(Step):
             parent=parent,
             config_file=config_file,
             _validate_kwds=False,
-            cmd_args=cmd_args,
+            param_args=param_args,
             **config)
 
         return step
@@ -348,7 +357,7 @@ class Pipeline(Step):
             self.log.info(f"{how} for {reftype.upper()} reference file is '{refpath}'.")
             crds_client.check_reference_open(refpath)
 
-    def _override_stepconfig_from_cmd_args(self, stepname, stepcfg, cmd_args):
+    def _override_stepconfig_from_param_args(self, stepname, stepcfg, param_args):
         """After step config is built from any CRDS or user provided pars files,
         overwrite cfg with command line specified parameter values
 
@@ -356,19 +365,19 @@ class Pipeline(Step):
         ----------
         stepname : str
             Step name provided in step_defs, used to pull relevant pars
-            from cmd_args Namespace
+            from param_args Namespace
 
         stepcfg : ConfigObj
             The configobj built from step_pars files but not yet including
             possible command line values
 
-        cmd_args : argparse.Namespace
+        param_args : argparse.Namespace
             The parsed set of command line arguments
         """
-        for arg in vars(cmd_args):
+        for arg in vars(param_args):
             if f'steps.{stepname}' in arg:
-                if vars(cmd_args)[arg] is not None:
-                    stepcfg.merge({arg.split('.')[-1]: vars(cmd_args)[arg]})
+                if vars(param_args)[arg] is not None:
+                    stepcfg.merge({arg.split('.')[-1]: vars(param_args)[arg]})
 
     def get_pars(self, full_spec=True):
         """Retrieve the configuration parameters of a pipeline

--- a/src/stpipe/pipeline.py
+++ b/src/stpipe/pipeline.py
@@ -37,7 +37,8 @@ class Pipeline(Step):
         # Configure all of the steps
         for key, val in self.step_defs.items():
             cfg = self.steps.get(key)
-            self._override_stepconfig_from_cmd_args(key, cfg, self.cmd_args)
+            if self.cmd_args is not None:
+                self._override_stepconfig_from_cmd_args(key, cfg, self.cmd_args)
             if cfg is not None:
                 new_step = val.from_config_section(
                     cfg, parent=self, name=key,

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -250,7 +250,7 @@ class Step:
         return step
 
     @classmethod
-    def finalize_config(cls, config, name=None, config_file=None):
+    def finalize_config(cls, config, name=None, config_file=None, validate=True):
         """Load default config, merge with config_file if present, then validate.
 
         Parameters
@@ -293,8 +293,9 @@ class Step:
 
         spec = cls.load_spec_file()
         config = cls.merge_config(config, config_file)
-        config_parser.validate(
-            config, spec, root_dir=dirname(config_file or ''))
+        if validate:
+            config_parser.validate(
+                config, spec, root_dir=dirname(config_file or ''))
 
         if 'config_file' in config:
             del config['config_file']

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -208,7 +208,7 @@ class Step:
 
     @classmethod
     def from_config_section(cls, config, parent=None, name=None,
-                            config_file=None):
+                            config_file=None, *args):
         """
         Create a step from a configuration file fragment.
 

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -237,6 +237,47 @@ class Step:
             Any parameters found in the config file fragment will be
             set as member variables on the returned `Step` instance.
         """
+
+        config = cls.finalize_config(config, name=None, config_file=None)
+
+        step = cls(
+            name=name,
+            parent=parent,
+            config_file=config_file,
+            _validate_kwds=False,
+            **config)
+
+        return step
+
+    @classmethod
+    def finalize_config(cls, config, name=None, config_file=None):
+        """Load default config, merge with config_file if present, then validate.
+
+        Parameters
+        ----------
+        config : configobj.Section instance
+            The config file fragment containing parameters for this
+            step only.
+        parent : Step instance, optional
+            The parent step of this step.  Used to determine a
+            fully-qualified name for this step, and to determine
+            the mode in which to run this step.
+        name : str, optional
+            If provided, use that name for the returned instance.
+            If not provided, try the following (in order):
+            - The ``name`` parameter in the config file fragment
+            - The name of returned class
+        config_file : str, optional
+            The path to the config file that created this step, if
+            any.  This is used to resolve relative file name
+            parameters in the config file.
+
+        Returns
+        -------
+        config : configobj.Section instance
+            The product of merging the default spec with the config_file
+            present, if any.
+        """
         if not name:
             if config.get('name'):
                 name = config['name']
@@ -260,14 +301,7 @@ class Step:
         if 'name' in config:
             del config['name']
 
-        step = cls(
-            name=name,
-            parent=parent,
-            config_file=config_file,
-            _validate_kwds=False,
-            **config)
-
-        return step
+        return config
 
     def __init__(self, name=None, parent=None, config_file=None,
                  _validate_kwds=True, **kws):

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -208,7 +208,7 @@ class Step:
 
     @classmethod
     def from_config_section(cls, config, parent=None, name=None,
-                            config_file=None, *args):
+                            config_file=None, **kwargs):
         """
         Create a step from a configuration file fragment.
 
@@ -366,6 +366,9 @@ class Step:
         # Store the config file path so config filenames can be resolved
         # against it.
         self.config_file = config_file
+
+        # Create placeholder for any command line arguments.
+        self.cmd_args = kws.get('cmd_args', None)
 
         # Setup the hooks
         if len(self.pre_hooks) or len(self.post_hooks):

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -367,8 +367,9 @@ class Step:
         # against it.
         self.config_file = config_file
 
-        # Create placeholder for any command line arguments.
-        self.cmd_args = kws.get('cmd_args', None)
+        # Create placeholder for any parameter-setting arguments, either from
+        # the command line for strun, or in a steps dict for .call().
+        self.param_args = kws.get('param_args', None)
 
         # Setup the hooks
         if len(self.pre_hooks) or len(self.post_hooks):
@@ -647,7 +648,7 @@ class Step:
 
         name = config.get('name', None)
         instance = cls.from_config_section(config,
-            name=name, config_file=config_file)
+            name=name, config_file=config_file, param_args=kwargs)
 
         return instance.run(*args)
 

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -240,6 +240,8 @@ class Step:
 
         config = cls.finalize_config(config, name=None, config_file=None)
 
+        log.log.critical(f"config: {config}\n\n")
+
         step = cls(
             name=name,
             parent=parent,
@@ -250,7 +252,7 @@ class Step:
         return step
 
     @classmethod
-    def finalize_config(cls, config, name=None, config_file=None, validate=True):
+    def finalize_config(cls, config, name=None, config_file=None):
         """Load default config, merge with config_file if present, then validate.
 
         Parameters
@@ -293,9 +295,8 @@ class Step:
 
         spec = cls.load_spec_file()
         config = cls.merge_config(config, config_file)
-        if validate:
-            config_parser.validate(
-                config, spec, root_dir=dirname(config_file or ''))
+        config_parser.validate(
+            config, spec, root_dir=dirname(config_file or ''))
 
         if 'config_file' in config:
             del config['config_file']


### PR DESCRIPTION
Currently, running a pipeline while providing a pars-{step} file overwrites the user-supplied pars with the default pars. It appears as though a simple swap in a merge may be all that's required to get this functioning - the overwrite priority is now flipped for parameters which are specified in both the default spec and the user pars file.

Addresses [JP-2609](https://jira.stsci.edu/browse/JP-2609)