### PR TITLE
JP-2608: Remove misleading log of CRDS pars-ref pars

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@
 
 - Update CI workflows to cache test environments and depend upon style and security checks [#55]
 
+- Remove log dump of any CRDS-retrieved PARS-reference files [#60]
+
 0.3.3 (2022-04-07)
 ==================
 

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -813,7 +813,6 @@ class Step:
                 for par, value in ref.items()
                 if par not in ['class', 'name']
             }
-            logger.info(f'{reftype.upper()} parameters are {ref_pars}')
 
             return ref
         else:

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -813,7 +813,7 @@ class Step:
                 for par, value in ref.items()
                 if par not in ['class', 'name']
             }
-            logger.debug(f'{reftype.upper()} parameters are {ref_pars}')
+            logger.debug(f'{reftype.upper()} parameters retrieved from CRDS: {ref_pars}')
 
             return ref
         else:

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -813,6 +813,7 @@ class Step:
                 for par, value in ref.items()
                 if par not in ['class', 'name']
             }
+            logger.debug(f'{reftype.upper()} parameters are {ref_pars}')
 
             return ref
         else:


### PR DESCRIPTION
This PR removes a log statement that dumps parameter values from parameter reference files retrieved from CRDS. In the event of a local pars-ref file supplied by the user, this log statement would show values that are later overridden and unused. Parameters used by each step are still logged at the start of each step's run().

