### PR TITLE
JP-2675: Bug in setting SKIPPED for cal_step keywords, when input is ModelContainer

### DIFF
--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -466,10 +466,17 @@ class Step:
                     self.log.info('Step skipped.')
                     if isinstance(args[0], AbstractDataModel):
                         if self.class_alias is not None:
-                            try:
-                                args[0][f"meta.cal_step.{self.class_alias}"] = 'SKIPPED'
-                            except AttributeError as e:
-                                self.log.info(f"Could not record skip into DataModel header: {e}")
+                            if isinstance(args[0], Sequence):
+                                for model in args[0]:
+                                    try:
+                                        model[f"meta.cal_step.{self.class_alias}"] = 'SKIPPED'
+                                    except AttributeError as e:
+                                        self.log.info(f"Could not record skip into DataModel header: {e}")
+                            elif isinstance(args[0], AbstractDataModel):
+                                try:
+                                    args[0][f"meta.cal_step.{self.class_alias}"] = 'SKIPPED'
+                                except AttributeError as e:
+                                    self.log.info(f"Could not record skip into DataModel header: {e}")
                     step_result = args[0]
                 else:
                     if self.prefetch_references:


### PR DESCRIPTION
Addresses #61 
Addresses [JP-2675](https://jira.stsci.edu/browse/JP-2675)

Recent code added by yours truly tried to catch errors in meta keyword assignment of cal_step values to SKIPPED, but missed the possibliity of the first step in a pipeline being skipped, exposing this code to a ModelContainer. Code is added to "broadcast" behavior initially applied to a single input DataModel to all DataModel enclosed within the ModelContainer.

NB: This reinforces the need for an stdatamodels issue to add a parent class to ModelContainer that provides for a robust isinstance() check, e.g. @stscieisenhamer's suggested `ModelList`.