### PR TITLE
Update get_crds_reference to not use JWST specific calls

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,10 @@
 0.4.2 (unreleased)
 ==================
 
--
+- Refactored ``Step.crds_get_config_from_reference`` and
+  ``Pipeline.get_config_from_reference`` to reduce memory when the input to
+  a pipeline is an association file, i.e. a ``ModelContainer``. In this case
+  the crds parameters are retrieved from the first model which is already opened. [#63]
 
 0.4.1 (2022-07-14)
 ==================

--- a/src/stpipe/pipeline.py
+++ b/src/stpipe/pipeline.py
@@ -181,7 +181,7 @@ class Pipeline(Step):
         # Iterate over the steps in the pipeline
         with cls._datamodels_open(dataset, asn_n_members=1) as model:
             if isinstance(model, Sequence):
-                crds_parameters = model._models.get_crds_parameters()
+                crds_parameters = model._models[0].get_crds_parameters()
                 crds_observatory = model.crds_observatory
             else:
                 crds_parameters = model.get_crds_parameters()

--- a/src/stpipe/pipeline.py
+++ b/src/stpipe/pipeline.py
@@ -182,24 +182,22 @@ class Pipeline(Step):
         with cls._datamodels_open(dataset, asn_n_members=1) as model:
             if isinstance(model, Sequence):
                 for contained_model in model:
-                    input_class = contained_model.__class__()
-                    metadata = input_class
-                    metadata.update(contained_model, only='PRIMARY')
+                    crds_parameters = model.get_crds_parameters()
+                    crds_observatory = model.crds_observatory
             else:
-                input_class = model.__class__()
-                metadata = input_class
-                metadata.update(model, only='PRIMARY')
+                crds_parameters = model.get_crds_parameters()
+                crds_observatory = model.crds_observatory
 
         for cal_step in cls.step_defs.keys():
             cal_step_class = cls.step_defs[cal_step]
-            refcfg['steps'][cal_step] = cal_step_class.get_config_from_reference(metadata)
+            refcfg['steps'][cal_step] = cal_step_class.get_config_from_reference(model)
         #
         # Now merge any config parameters from the step cfg file
         logger.debug(f'Retrieving pipeline {reftype.upper()} parameters from CRDS')
         try:
-            ref_file = crds_client.get_reference_file(metadata.get_crds_parameters(),
-                                                    reftype,
-                                                    metadata.crds_observatory)
+            ref_file = crds_client.get_reference_file(crds_parameters,
+                                                      reftype,
+                                                      crds_observatory)
         except (AttributeError, crds_client.CrdsError):
             logger.debug(f'{reftype.upper()}: No parameters found')
         else:

--- a/src/stpipe/pipeline.py
+++ b/src/stpipe/pipeline.py
@@ -141,7 +141,7 @@ class Pipeline(Step):
         return spec
 
     @classmethod
-    def get_config_from_reference(cls, dataset, disable=None):
+    def get_config_from_reference(cls, dataset, disable=None, crds_observatory=None):
         """Retrieve step parameters from reference database
 
         Parameters
@@ -157,6 +157,9 @@ class Pipeline(Step):
 
         disable: bool or None
             Do not retrieve parameters from CRDS. If None, check global settings.
+
+        crds_observatory : str
+            Observatory name ('jwst' or 'roman').
 
         Returns
         -------

--- a/src/stpipe/pipeline.py
+++ b/src/stpipe/pipeline.py
@@ -181,16 +181,16 @@ class Pipeline(Step):
         # Iterate over the steps in the pipeline
         with cls._datamodels_open(dataset, asn_n_members=1) as model:
             if isinstance(model, Sequence):
-                for contained_model in model:
-                    crds_parameters = model.get_crds_parameters()
-                    crds_observatory = model.crds_observatory
+                crds_parameters = model._models.get_crds_parameters()
+                crds_observatory = model.crds_observatory
             else:
                 crds_parameters = model.get_crds_parameters()
                 crds_observatory = model.crds_observatory
 
         for cal_step in cls.step_defs.keys():
             cal_step_class = cls.step_defs[cal_step]
-            refcfg['steps'][cal_step] = cal_step_class.get_config_from_reference(model)
+            refcfg['steps'][cal_step] = cal_step_class.get_config_from_reference(crds_parameters,
+                                                                                 crds_observatory=crds_observatory)
         #
         # Now merge any config parameters from the step cfg file
         logger.debug(f'Retrieving pipeline {reftype.upper()} parameters from CRDS')

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -818,6 +818,7 @@ class Step:
             Do not retrieve parameters from CRDS. If None, check global settings.
         crds_observatory : str
             Observatory name ('jwst' or 'roman').
+
         Returns
         -------
         step_parameters : configobj


### PR DESCRIPTION
The issue with the big memory increase was tracked down to how `ModelContainer.get_crds_parameters` was implemented. Every time it was called, it reopened the first model read in from the asn table, and called `get_crds_parameters` on it,  instead of calling `get_crds_parameters` directly on the already opened model. 

This means the fix should be in jwst.datamodels.container, however since the next jwst release is after the next romancal release I am implementing it here. I'll make the changes in jwst as well. After the next jwst release the code here can be simplified by just calling `model.get_crds_parameters` regardless of the model type.

Fixes AL-668