### PR TITLE
Pull first model from ModelContainers before datamodel methods applied

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,10 @@
   a pipeline is an association file, i.e. a ``ModelContainer``. In this case
   the crds parameters are retrieved from the first model which is already opened. [#63]
 
+- Added a small edit to ``Step.get_config_from_reference`` to run datamodel
+  methods on the first contained model in a ModelContainer, rather than the
+  ModelContainer itself [#65]
+
 0.4.1 (2022-07-14)
 ==================
 

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -842,6 +842,9 @@ class Step:
             # log as such and return an empty config object
             try:
                 model = cls._datamodels_open(dataset)
+                if isinstance(dataset, Sequence):
+                    # Pull out first model in ModelContainer
+                    model = model[0]
                 crds_parameters = model.get_crds_parameters()
                 crds_observatory = model.crds_observatory
             except (IOError, TypeError, ValueError):


### PR DESCRIPTION
Recent changes to config creation and reference file gathering require a fix for ModelContainer input, so datamodel.crds_parameters() will be run on the contents of the ModelContainer and not the container itself.