### PR TITLE
JP-3018: Restore support for step list arguments at command line

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@
 - Load and merge configuration files for each step they are provided when
   running pipeline in interactive mode using ``Step.call()``. [#74]
 
+- Restored support for step list arguments by removing code that was
+  overwriting processed and validated command line arguments with their
+  raw values. [#73]
+
 
 0.4.2 (2022-07-29)
 ==================

--- a/src/stpipe/cmdline.py
+++ b/src/stpipe/cmdline.py
@@ -245,7 +245,6 @@ def just_the_step_from_cmdline(args, cls=None):
 
     args = parser2.parse_args(args)
 
-
     if cls is None:
         del args.cfg_file_or_class
     else:
@@ -258,6 +257,9 @@ def just_the_step_from_cmdline(args, cls=None):
     positional = args.args
     del args.args
 
+    # This updates config (a ConfigObj) with the values from the command line arguments
+    # Config is empty if class specified, otherwise contains values from config file specified
+    # on command line
     _override_config_from_args(config, args)
 
     config = step_class.merge_config(config, config_file)
@@ -278,18 +280,11 @@ def just_the_step_from_cmdline(args, cls=None):
             config = parameter_cfg
     else:
         log.log.info("No input file specified, unable to retrieve parameters from CRDS")
-    #
-    # This updates config (a ConfigObj) with the values from the command line arguments
-    # Config is empty if class specified, otherwise contains values from config file specified
-    # on command line
-
 
     # This is where the step is instantiated
     try:
-        step_class.finalize_config(config, config_file=config_file, merge=False)
-
         step = step_class.from_config_section(
-            config, name=name, param_args=args)
+            config, name=name, config_file=config_file)
     except config_parser.ValidationError as e:
         # If the configobj validator failed, print usage information.
         _print_important_message("ERROR PARSING CONFIGURATION:", str(e))
@@ -336,7 +331,6 @@ def step_from_cmdline(args, cls=None):
         will be set as member variables on the returned `Step`
         instance.
     """
-
     step, step_class, positional, debug_on_exception = \
         just_the_step_from_cmdline(args, cls)
 

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -208,7 +208,7 @@ class Step:
 
     @classmethod
     def from_config_section(cls, config, parent=None, name=None,
-                            config_file=None, **kwargs):
+                            config_file=None):
         """
         Create a step from a configuration file fragment.
 
@@ -237,47 +237,6 @@ class Step:
             Any parameters found in the config file fragment will be
             set as member variables on the returned `Step` instance.
         """
-
-        config = cls.finalize_config(config, name=None, config_file=None)
-
-        step = cls(
-            name=name,
-            parent=parent,
-            config_file=config_file,
-            _validate_kwds=False,
-            **config)
-
-        return step
-
-    @classmethod
-    def finalize_config(cls, config, name=None, config_file=None, merge=True, validate=True):
-        """Load default config, merge with config_file if present, then validate.
-
-        Parameters
-        ----------
-        config : configobj.Section instance
-            The config file fragment containing parameters for this
-            step only.
-        parent : Step instance, optional
-            The parent step of this step.  Used to determine a
-            fully-qualified name for this step, and to determine
-            the mode in which to run this step.
-        name : str, optional
-            If provided, use that name for the returned instance.
-            If not provided, try the following (in order):
-            - The ``name`` parameter in the config file fragment
-            - The name of returned class
-        config_file : str, optional
-            The path to the config file that created this step, if
-            any.  This is used to resolve relative file name
-            parameters in the config file.
-
-        Returns
-        -------
-        config : configobj.Section instance
-            The product of merging the default spec with the config_file
-            present, if any.
-        """
         if not name:
             if config.get('name'):
                 name = config['name']
@@ -292,18 +251,23 @@ class Step:
             del config['config_file']
 
         spec = cls.load_spec_file()
-        if merge:
-            config = cls.merge_config(config, config_file)
-        if validate:
-            config_parser.validate(
-                config, spec, root_dir=dirname(config_file or ''))
+        config = cls.merge_config(config, config_file)
+        config_parser.validate(
+            config, spec, root_dir=dirname(config_file or ''))
 
         if 'config_file' in config:
             del config['config_file']
         if 'name' in config:
             del config['name']
 
-        return config
+        step = cls(
+            name=name,
+            parent=parent,
+            config_file=config_file,
+            _validate_kwds=False,
+            **config)
+
+        return step
 
     def __init__(self, name=None, parent=None, config_file=None,
                  _validate_kwds=True, **kws):
@@ -368,10 +332,6 @@ class Step:
         # Store the config file path so config filenames can be resolved
         # against it.
         self.config_file = config_file
-
-        # Create placeholder for any parameter-setting arguments, either from
-        # the command line for strun, or in a steps dict for .call().
-        self.param_args = kws.get('param_args', None)
 
         # Setup the hooks
         if len(self.pre_hooks) or len(self.post_hooks):
@@ -657,7 +617,7 @@ class Step:
 
         name = config.get('name', None)
         instance = cls.from_config_section(config,
-            name=name, config_file=config_file, param_args=kwargs)
+            name=name, config_file=config_file)
 
         return instance.run(*args)
 


### PR DESCRIPTION
Closes #69
Closes #71
Resolves [JP-3018](https://jira.stsci.edu/browse/JP-3018)

CC: @tapastro @hbushouse @stscieisenhamer @nden

This PR restores support for step's list arguments at the command line that was broken since #57 (or version `0.4.0`).

This PR essentially undoes most of the changes from #57 with exception of moving `_override_config_from_args()` in front of  `config = step_class.merge_config(config, config_file)` in `cmdline.just_the_step_from_cmdline()` - this was the only change compared to pre- #57 that was needed to fix the issue that #57 was addressing while not breaking support for list arguments.

-----

### Testing:

Here is my setup (use any MIRI imaging ASN as input data; non-MIRI might have different default values from CRDS):

For testing purposes, I created two step configuration files (for tweakreg and for the resample steps):

**tweakreg-custom.cfg**:
```INI
name = "tweakreg"
class = "jwst.tweakreg.TweakRegStep"

kernel_fwhm = 2.77
```

**resample-custom.cfg**:
```INI
name = "resample"
class = "jwst.resample.ResampleStep"

output_shape = 4900,4999
pixel_scale_ratio = 0.98765
```

I then run the pipeline like this:
```Shell
strun cfg/calwebb_image3.cfg miri_asn.json  --steps.resample.rotation=0 --steps.resample.output_shape=5000,5000
--steps.tweakreg.config_file=tweakreg-custom.cfg --steps.resample.config_file=resample-custom.cfg
```

Below I will reproduce only the relevant lines from the terminal output:
```
2022-12-04 11:18:56,323 - stpipe - INFO - PARS-TWEAKREGSTEP parameters found: /.../jwst/miri/jwst_miri_pars-tweakregstep_0019.asdf
2022-12-04 11:18:56,669 - stpipe.Image3Pipeline - INFO - Prefetch for DRIZPARS reference file is '/.../jwst/miri/jwst_miri_drizpars_0001.fits'.

2022-12-04 11:18:57,068 - stpipe.Image3Pipeline.tweakreg - INFO - Step tweakreg parameters are:
   {'pre_hooks': [], 'post_hooks': [], 'output_file': None, 'output_dir': None, 'output_ext': '.fits',
    'output_use_model': True, 'output_use_index': True, 'save_results': False, 'skip': False,
    'suffix': None, 'search_output_file': True, 'input_dir': '', 'save_catalogs': False,
    'use_custom_catalogs': False, 'catalog_format': 'ecsv', 'catfile': '', 'kernel_fwhm': 2.77,
    'snr_threshold': 10.0, 'sharplo': 0.2, 'sharphi': 1.0, 'roundlo': -1.0, 'roundhi': 1.0,
    'brightest': 134, 'peakmax': None, 'bkg_boxsize': 400, 'enforce_user_order': False,
    'expand_refcat': False, 'minobj': 15, 'searchrad': 1.0, 'use2dhist': True, 'separation': 1.0,
    'tolerance': 0.7, 'xoffset': 0.0, 'yoffset': 0.0, 'fitgeometry': 'rshift', 'nclip': 3, 'sigma': 3,
    'abs_refcat': '', 'save_abs_catalog': False, 'abs_minobj': 15, 'abs_searchrad': 6.0,
    'abs_use2dhist': True, 'abs_separation': 0.1, 'abs_tolerance': 0.7, 'abs_fitgeometry': 'rshift',
    'abs_nclip': 3, 'abs_sigma': 3.0}

2022-12-04 11:19:06,224 - stpipe.Image3Pipeline.resample - INFO - Step resample parameters are:
   {'pre_hooks': [], 'post_hooks': [], 'output_file': None, 'output_dir': None, 'output_ext': '.fits',
    'output_use_model': False, 'output_use_index': True, 'save_results': True, 'skip': False,
    'suffix': 'i2d', 'search_output_file': True, 'input_dir': '', 'pixfrac': 1.0, 'kernel': 'square',
    'fillval': 'INDEF', 'weight_type': 'ivm', 'output_shape': [5000, 5000], 'crpix': None, 'crval': None,
    'rotation': 0.0, 'pixel_scale_ratio': 0.98765, 'pixel_scale': None, 'single': False,
    'blendheaders': True, 'allowed_memory': None, 'in_memory': True}
2022-12-04 11:19:06,251 - stpipe.Image3Pipeline.resample - INFO - Using drizpars reference file: /.../jwst/miri/jwst_miri_drizpars_0001.fits
2022-12-04 11:19:06,291 - stpipe.Image3Pipeline.resample - INFO - Driz parameter kernel: square
2022-12-04 11:19:06,291 - stpipe.Image3Pipeline.resample - INFO - Driz parameter pixfrac: 1.0
2022-12-04 11:19:06,291 - stpipe.Image3Pipeline.resample - INFO - Driz parameter fillval: INDEF
2022-12-04 11:19:06,291 - stpipe.Image3Pipeline.resample - INFO - Driz parameter weight_type: ivm
2022-12-04 11:19:06,291 - stpipe.Image3Pipeline.resample - INFO - Output pixel scale ratio: 0.98765
2022-12-04 11:19:06,533 - stpipe.Image3Pipeline.resample - INFO - Blending metadata for F560W_comb_square_ivm.fits
2022-12-04 11:19:07,452 - stpipe.Image3Pipeline.resample - INFO - Resampling science data
2022-12-04 11:19:07,862 - stpipe.Image3Pipeline.resample - INFO - Drizzling (1024, 1032) --> (5000, 5000)
```

It is important to also show the content of two reference files loaded by the pipeline:

**jwst_miri_pars-tweakregstep_0019.asdf:**

```
parameters: {class: jwst.tweakreg.tweakreg_step.TweakRegStep, fitgeometry: rshift,
  kernel_fwhm: 1.63, minobj: 15, name: tweakreg, nclip: 3, searchrad: 1.0, separation: 1.0,
  sigma: 3, snr_threshold: 10.0, tolerance: 0.7, use2dhist: true}
```

**jwst_miri_drizpars_0001.fits:**
```
FITS_rec([(1, 'ANY', 1. , 'square', 'INDEF', 'exptime', 10),
          (2, 'ANY', 1. , 'square', 'INDEF', 'exptime', 10),
          (4, 'ANY', 0.8, 'square', 'INDEF', 'exptime', 10)],
         dtype=(numpy.record, [('numimages', '>i4'), ('filter', 'S40'), ('pixfrac', '>f4'), ('kernel', 'S10'), ('fillval', 'S10'), ('wht_type', 'S10'), ('stepsize', '>i4')]))
```

By comparing the parameter values used by the `tweakreg` and the `resample` steps for parameters:
```
--steps.tweakreg.kernel_fwhm = 2.77
--steps.resample.rotation=0
--steps.resample.output_shape=5000,5000
--steps.resample.rotation=pixel_scale_ratio = 0.98765
```
with values from CRDS reference files or Step's `spec` defaults, we can see that this PR fixes the https://jira.stsci.edu/browse/JP-2609 issue without breaking support for list arguments.