### PR TITLE
refactor toxenvs, use OpenAstronomy workflows, and move MacOS jobs to schedule

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,4 +7,7 @@ max-line-length = 130
 exclude =
     docs,
     src/stpipe/extern,
+    build,
+    .tox,
+    .eggs
 ignore = E203, W503, W504, W605

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,20 +26,16 @@ jobs:
       envs: |
         - linux: test-xdist
           python-version: '3.8'
-        - macos: test-xdist
-          python-version: '3.8'
         - linux: test-xdist
           python-version: '3.9'
-        - macos: test-xdist
-          python-version: '3.9'
         - linux: test-xdist
-          python-version: '3.10'
-        - macos: test-xdist
           python-version: '3.10'
         - linux: test-xdist
           python-version: '3.11'
         - macos: test-xdist
           python-version: '3.11'
+        - linux: test-cov
+          coverage: 'codecov'
   test_numpy:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
@@ -60,46 +56,13 @@ jobs:
           python-version: '3.8'
         - linux: test-numpy120
           python-version: '3.8'
-  test_coverage:
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
-    with:
-      envs: |
-        - linux: test-cov
-          coverage: 'codecov'
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   test_downstream:
-    name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    env:
-      CRDS_PATH: /tmp/crds_cache
-      CRDS_CLIENT_RETRY_COUNT: 3
-      CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - toxenv: test-jwst-xdist
-            os: ubuntu-latest
-            python-version: '3.x'
-          - toxenv: test-romancal-xdist
-            os: ubuntu-latest
-            python-version: '3.x'
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-          cache-dependency-path: 'pyproject.toml'
-      - run: pip install tox
-      - run: tox -e ${{ matrix.toxenv }}
-      - if: ${{ contains(matrix.toxenv,'-cov') }}
-        uses: codecov/codecov-action@v3
-        with:
-          file: ./coverage.xml
-          flags: unit
-          fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
+    with:
+      setenv: |
+        CRDS_PATH: ${{ needs.crds.outputs.path }}
+        CRDS_CLIENT_RETRY_COUNT: 3
+        CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
+      envs: |
+        - linux: test-jwst-xdist
+        - linux: test-romancal-xdist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,114 +18,83 @@ env:
   CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
 
 jobs:
-  style:
-    name: Code style checks
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - uses: actions/cache@v3
-        with:
-          path: ${{ env.pythonLocation }}
-          key: style-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml', '**/setup.*') }}
-      - run: pip install ruff
-      - run: ruff src
-  audit:
-    name: Bandit security audit
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - uses: actions/cache@v3
-        with:
-          path: ${{ env.pythonLocation }}
-          key: audit-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml', '**/setup.*') }}
-      - run: pip install bandit
-      - run: bandit -r -ll src
-  test:
-    name: test
-    needs: [ style, audit ]
+  check:
+    name: ${{ matrix.toxenv }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python: [ 3.8, 3.9, '3.10' ]
+        toxenv: [ check-style, check-security, check-build ]
+        python-version: [ '3.x' ]
+        os: [ ubuntu-latest ]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: pyproject.toml
+      - run: pip install tox
+      - run: tox -e ${{ matrix.toxenv }}
+  test:
+    name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
+    needs: [ check ]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        toxenv: [ test-xdist ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
         os: [ ubuntu-latest, macos-latest ]
+        include:
+          - toxenv: test-cov
+            os: ubuntu-latest
+            python-version: '3.11'
+          - toxenv: test-numpy122
+            os: ubuntu-latest
+            python-version: '3.10'
+          - toxenv: test-numpy121
+            os: ubuntu-latest
+            python-version: '3.10'
+          - toxenv: test-numpy122
+            os: ubuntu-latest
+            python-version: '3.9'
+          - toxenv: test-numpy121
+            os: ubuntu-latest
+            python-version: '3.9'
+          - toxenv: test-numpy120
+            os: ubuntu-latest
+            python-version: '3.9'
+          - toxenv: test-numpy122
+            os: ubuntu-latest
+            python-version: '3.8'
+          - toxenv: test-numpy121
+            os: ubuntu-latest
+            python-version: '3.8'
+          - toxenv: test-numpy120
+            os: ubuntu-latest
+            python-version: '3.8'
+          - toxenv: test-jwst-xdist
+            os: ubuntu-latest
+            python-version: '3.x'
+          - toxenv: test-romancal-xdist
+            os: ubuntu-latest
+            python-version: '3.x'
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
         with:
-          python-version: ${{ matrix.python }}
-      - uses: actions/cache@v3
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
         with:
-          path: ${{ env.pythonLocation }}
-          key: test-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml', '**/setup.*') }}
-      - run: pip install ".[test]" pytest-xdist
-      - run: pip freeze
-      - run: pytest -n auto
-  test_with_coverage:
-    name: test base library with coverage
-    needs: [ style, audit ]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-      - uses: actions/cache@v3
-        with:
-          path: ${{ env.pythonLocation }}
-          key: test-coverage-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml', '**/setup.*') }}
-      - run: pip install -e ".[test]" pytest-xdist pytest-cov
-      - run: pip freeze
-      - run: pytest -n auto --cov-report=xml --cov=src/stpipe
-      - run: coverage report -m
-      - uses: codecov/codecov-action@v2
+          python-version: ${{ matrix.python-version }}
+      - run: pip install tox
+      - run: tox -e ${{ matrix.toxenv }}
+      - if: ${{ contains(matrix.toxenv,'-cov') }}
+        uses: codecov/codecov-action@v3
         with:
           file: ./coverage.xml
-  test_jwst_with_coverage:
-    name: test JWST pipeline with coverage
-    needs: [ style, audit ]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-      - uses: actions/cache@v3
-        with:
-          path: ${{ env.pythonLocation }}
-          key: test-coverage-jwst-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml', '**/setup.*') }}
-      - run: pip install -e ".[test]" pytest-xdist pytest-cov
-      - run: pip install "jwst[test] @ git+https://github.com/spacetelescope/jwst.git"
-      - run: pip freeze
-      - run: pytest -n auto --cov-report=xml --cov=src/stpipe --ignore-glob=timeconversion --ignore-glob=associations --ignore-glob=scripts --pyargs jwst
-        env:
-          CRDS_SERVER_URL: https://jwst-crds.stsci.edu
-      - run: coverage report -m
-      - uses: codecov/codecov-action@v2
-        with:
-          file: ./coverage.xml
-  test_roman_with_coverage:
-    name: test Roman pipeline with coverage
-    needs: [ style, audit ]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-      - uses: actions/cache@v3
-        with:
-          path: ${{ env.pythonLocation }}
-          key: test-coverage-roman-${{ runner.os }}-${{ env.pythonLocation }}-${{ hashFiles('**/pyproject.toml', '**/setup.*') }}
-      - run: pip install -e ".[test]" pytest-xdist pytest-cov
-      - run: pip install "romancal[test] @ git+https://github.com/spacetelescope/romancal.git"
-      - run: pip freeze
-      - run: pytest -n auto --cov-report=xml --cov=src/stpipe --pyargs romancal
-        env:
-          CRDS_SERVER_URL: https://roman-crds-test.stsci.edu
-      - run: coverage report -m
-      - uses: codecov/codecov-action@v2
-        with:
-          file: ./coverage.xml
+          flags: unit
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,6 @@ jobs:
       - run: tox -e ${{ matrix.toxenv }}
   test:
     name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
-    needs: [ check ]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,13 @@ jobs:
       envs: |
         - linux: check-style
         - linux: check-security
-        - linux: check-build
+        - linux: build-dist
   test:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
       envs: |
+        - linux: test-oldestdeps-cov-xdist
+          python-version: 3.8
         - linux: test-xdist
           python-version: '3.8'
         - linux: test-xdist
@@ -34,28 +36,8 @@ jobs:
           python-version: '3.11'
         - macos: test-xdist
           python-version: '3.11'
-        - linux: test-cov
+        - linux: test-cov-xdist
           coverage: 'codecov'
-  test_numpy:
-    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
-    with:
-      envs: |
-        - linux: test-numpy122
-          python-version: '3.10'
-        - linux: test-numpy121
-          python-version: '3.10'
-        - linux: test-numpy122
-          python-version: '3.9'
-        - linux: test-numpy121
-          python-version: '3.9'
-        - linux: test-numpy120
-          python-version: '3.9'
-        - linux: test-numpy122
-          python-version: '3.8'
-        - linux: test-numpy121
-          python-version: '3.8'
-        - linux: test-numpy120
-          python-version: '3.8'
   test_downstream:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@main
     with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,69 +12,61 @@ on:
     # * is a special character in YAML so you have to quote this string
     - cron: '0 9 * * 1'
 
-env:
-  CRDS_PATH: $HOME/crds_cache
-  CRDS_CLIENT_RETRY_COUNT: 3
-  CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
-
 jobs:
-  check:
-    name: ${{ matrix.toxenv }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        toxenv: [ check-style, check-security, check-build ]
-        python-version: [ '3.x' ]
-        os: [ ubuntu-latest ]
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-          cache-dependency-path: pyproject.toml
-      - run: pip install tox
-      - run: tox -e ${{ matrix.toxenv }}
   test:
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    with:
+      posargs: '-n 4'
+      envs: |
+        - linux: check-style
+        - linux: check-security
+        - linux: check-build
+        - linux: test-xdist
+          python-version: '3.8'
+        - macos: test-xdist
+          python-version: '3.8'
+        - linux: test-xdist
+          python-version: '3.9'
+        - macos: test-xdist
+          python-version: '3.9'
+        - linux: test-xdist
+          python-version: '3.10'
+        - macos: test-xdist
+          python-version: '3.10'
+        - linux: test-xdist
+          python-version: '3.11'
+        - macos: test-xdist
+          python-version: '3.11'
+        - linux: test-numpy122
+          python-version: '3.10'
+        - linux: test-numpy121
+          python-version: '3.10'
+        - linux: test-numpy122
+          python-version: '3.9'
+        - linux: test-numpy121
+          python-version: '3.9'
+        - linux: test-numpy120
+          python-version: '3.9'
+        - linux: test-numpy122
+          python-version: '3.8'
+        - linux: test-numpy121
+          python-version: '3.8'
+        - linux: test-numpy120
+          python-version: '3.8'
+        - linux: test-cov
+          coverage: 'codecov'
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+  downstream:
     name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    env:
+      CRDS_PATH: /tmp/crds_cache
+      CRDS_CLIENT_RETRY_COUNT: 3
+      CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
     strategy:
-      fail-fast: false
       matrix:
-        toxenv: [ test-xdist ]
-        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
-        os: [ ubuntu-latest, macos-latest ]
         include:
-          - toxenv: test-cov
-            os: ubuntu-latest
-            python-version: '3.11'
-          - toxenv: test-numpy122
-            os: ubuntu-latest
-            python-version: '3.10'
-          - toxenv: test-numpy121
-            os: ubuntu-latest
-            python-version: '3.10'
-          - toxenv: test-numpy122
-            os: ubuntu-latest
-            python-version: '3.9'
-          - toxenv: test-numpy121
-            os: ubuntu-latest
-            python-version: '3.9'
-          - toxenv: test-numpy120
-            os: ubuntu-latest
-            python-version: '3.9'
-          - toxenv: test-numpy122
-            os: ubuntu-latest
-            python-version: '3.8'
-          - toxenv: test-numpy121
-            os: ubuntu-latest
-            python-version: '3.8'
-          - toxenv: test-numpy120
-            os: ubuntu-latest
-            python-version: '3.8'
           - toxenv: test-jwst-xdist
             os: ubuntu-latest
             python-version: '3.x'
@@ -88,6 +80,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: 'pyproject.toml'
       - run: pip install tox
       - run: tox -e ${{ matrix.toxenv }}
       - if: ${{ contains(matrix.toxenv,'-cov') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,6 @@ jobs:
           python-version: '3.8'
   test_coverage:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
-    needs: [ test ]
     with:
       envs: |
         - linux: test-cov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
       CRDS_CLIENT_RETRY_COUNT: 3
       CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
     strategy:
+      fail-fast: false
       matrix:
         include:
           - toxenv: test-jwst-xdist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,17 @@ on:
     - cron: '0 9 * * 1'
 
 jobs:
-  test:
+  check:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
       envs: |
         - linux: check-style
         - linux: check-security
         - linux: check-build
+  test:
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    with:
+      envs: |
         - linux: test-xdist
           python-version: '3.8'
         - macos: test-xdist
@@ -36,6 +40,10 @@ jobs:
           python-version: '3.11'
         - macos: test-xdist
           python-version: '3.11'
+  test_numpy:
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    with:
+      envs: |
         - linux: test-numpy122
           python-version: '3.10'
         - linux: test-numpy121
@@ -52,11 +60,16 @@ jobs:
           python-version: '3.8'
         - linux: test-numpy120
           python-version: '3.8'
+  test_coverage:
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    needs: [ test ]
+    with:
+      envs: |
         - linux: test-cov
           coverage: 'codecov'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-  downstream:
+  test_downstream:
     name: ${{ matrix.toxenv }} (Python ${{ matrix.python-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
   test:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
-      posargs: '-n 4'
       envs: |
         - linux: check-style
         - linux: check-security

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -1,0 +1,20 @@
+
+name: Weekly cron
+
+on:
+  schedule:
+    # Weekly Monday 6AM build
+    - cron: "0 0 * * 1"
+  workflow_dispatch:
+
+jobs:
+  test:
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
+    with:
+      envs: |
+        - macos: test-xdist
+          python-version: 3.8
+        - macos: test-xdist
+          python-version: 3.9
+        - macos: test-xdist
+          python-version: 3.10

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@
   usage of pkg_resources [#84]
 - update minimum python to 3.8 and ASDF version to 2.8 [#87]
 - replace legacy AsdfExtension with resource_mapping [#82]
+- update minimum version of ``asdf`` to ``2.13`` and add minimum dependency testing to CI [#75]
 
 0.4.5 (2022-12-23)
 ==================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     'Programming Language :: Python :: 3',
 ]
 dependencies = [
-    'asdf>=2.8.0',
+    'asdf>=2.13',
     'crds>=7.4.1.3',
     'astropy>=5.0.4',
     'stdatamodels>=0.2.4',

--- a/tox.ini
+++ b/tox.ini
@@ -67,7 +67,7 @@ commands =
     pytest \
     warnings: -W error \
     xdist: -n auto \
-    jwst: --pyargs jwst --ignore-glob=timeconversion --ignore-glob=associations \
+    jwst: --pyargs jwst --ignore-glob=timeconversion --ignore-glob=associations --ignore-glob=*/scripts/* \
     romancal: --pyargs romancal \
     cov: --cov=src/stpipe --cov-config=pyproject.toml --cov-report=term-missing --cov-report=xml \
     {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -31,21 +31,12 @@ deps =
 commands =
     bandit -r -ll src
 
-[testenv:check-build]
-description = check build sdist/wheel and a strict twine check for metadata
-skip_install = true
-deps =
-    twine>=3.3
-    build
-commands =
-    python -m build .
-    twine check --strict dist/*
-
 [testenv]
 description =
     run tests
     jwst: of JWST pipeline
     romancal: of Romancal pipeline
+    oldestdeps: with the oldest supported version of key dependencies
     warnings: treating warnings as errors
     cov: with coverage
     xdist: using parallel processing
@@ -56,9 +47,7 @@ deps =
     cov: pytest-cov
     jwst: jwst[test] @ git+https://github.com/spacetelescope/jwst.git
     romancal: romancal[test] @ git+https://github.com/spacetelescope/romancal.git
-    numpy120: numpy==1.20.*
-    numpy121: numpy==1.21.*
-    numpy122: numpy==1.22.*
+    oldestdeps: minimum_dependencies
 pass_env =
     CRDS_*
     CI
@@ -71,9 +60,9 @@ package =
 allowlist_externals =
     echo
 commands_pre =
+    oldestdeps: minimum_dependencies stpipe --filename requirements-min.txt
+    oldestdeps: pip install --ignore-installed -r requirements-min.txt
     pip freeze
-    jwst,romancal: echo $CRDS_SERVER_URL
-    jwst,romancal: echo $CRDS_PATH
 commands =
     pytest \
     warnings: -W error \

--- a/tox.ini
+++ b/tox.ini
@@ -16,12 +16,12 @@ envlist =
 #
 
 [testenv:check-style]
-description = check code style, e.g. with flake8
+description = check code style, e.g. with ruff
 skip_install = true
 deps =
-    flake8
+    ruff
 commands =
-    flake8 . {posargs}
+    ruff . {posargs}
 
 [testenv:check-security]
 description = run bandit to check security compliance
@@ -57,7 +57,7 @@ deps =
     jwst: jwst[test] @ git+https://github.com/spacetelescope/jwst.git
     romancal: romancal[test] @ git+https://github.com/spacetelescope/romancal.git
     numpy120: numpy==1.20.*
-    numpy121: numpy==1.21.*
+    numpy121: numpy==1.21 .*
     numpy122: numpy==1.22.*
 pass_env =
     CRDS_*

--- a/tox.ini
+++ b/tox.ini
@@ -57,7 +57,7 @@ deps =
     jwst: jwst[test] @ git+https://github.com/spacetelescope/jwst.git
     romancal: romancal[test] @ git+https://github.com/spacetelescope/romancal.git
     numpy120: numpy==1.20.*
-    numpy121: numpy==1.21 .*
+    numpy121: numpy==1.21.*
     numpy122: numpy==1.22.*
 pass_env =
     CRDS_*

--- a/tox.ini
+++ b/tox.ini
@@ -59,11 +59,17 @@ deps =
     numpy120: numpy==1.20.*
     numpy121: numpy==1.21.*
     numpy122: numpy==1.22.*
+pass_env =
+    CRDS_*
 set_env =
     jwst: CRDS_SERVER_URL=https://jwst-crds.stsci.edu
     romancal: CRDS_SERVER_URL=https://roman-crds.stsci.edu
+allowlist_externals =
+    echo
 commands_pre =
     pip freeze
+    jwst,romancal: echo $CRDS_SERVER_URL
+    jwst,romancal: echo $CRDS_PATH
 commands =
     pytest \
     warnings: -W error \

--- a/tox.ini
+++ b/tox.ini
@@ -61,7 +61,7 @@ allowlist_externals =
     echo
 commands_pre =
     oldestdeps: minimum_dependencies stpipe --filename requirements-min.txt
-    oldestdeps: pip install --ignore-installed -r requirements-min.txt
+    oldestdeps: pip install -r requirements-min.txt
     pip freeze
 commands =
     pytest \

--- a/tox.ini
+++ b/tox.ini
@@ -64,6 +64,9 @@ pass_env =
 set_env =
     jwst: CRDS_SERVER_URL=https://jwst-crds.stsci.edu
     romancal: CRDS_SERVER_URL=https://roman-crds.stsci.edu
+package = 
+    !cov: wheel
+    cov: editable
 allowlist_externals =
     echo
 commands_pre =

--- a/tox.ini
+++ b/tox.ini
@@ -61,6 +61,7 @@ deps =
     numpy122: numpy==1.22.*
 pass_env =
     CRDS_*
+    CI
 set_env =
     jwst: CRDS_SERVER_URL=https://jwst-crds.stsci.edu
     romancal: CRDS_SERVER_URL=https://roman-crds.stsci.edu

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,88 @@
+[tox]
+envlist =
+    check-{style,security,build}
+    test{,-warnings,-cov}-xdist
+    test-numpy{120,121,122}
+    test-{jwst,romancal}-xdist
+    build-{docs,dist}
+
+# tox environments are constructed with so-called 'factors' (or terms)
+# separated by hyphens, e.g. test-devdeps-cov. Lines below starting with factor:
+# will only take effect if that factor is included in the environment name. To
+# see a list of example environments that can be run, along with a description,
+# run:
+#
+#     tox -l -v
+#
+
+[testenv:check-style]
+description = check code style, e.g. with ruff
+skip_install = true
+deps =
+    ruff
+commands =
+    ruff . {posargs}
+
+[testenv:check-security]
+description = run bandit to check security compliance
+skip_install = true
+deps =
+    bandit>=1.7
+commands =
+    bandit -r -ll src
+
+[testenv:check-build]
+description = check build sdist/wheel and a strict twine check for metadata
+skip_install = true
+deps =
+    twine>=3.3
+    build
+commands =
+    python -m build .
+    twine check --strict dist/*
+
+[testenv]
+description =
+    run tests
+    jwst: of JWST pipeline
+    romancal: of Romancal pipeline
+    warnings: treating warnings as errors
+    cov: with coverage
+    xdist: using parallel processing
+extras =
+    test
+deps =
+    xdist: pytest-xdist
+    jwst: jwst[test] @ git+https://github.com/spacetelescope/jwst.git
+    romancal: romancal[test] @ git+https://github.com/spacetelescope/romancal.git
+    numpy120: numpy==1.20.*
+    numpy121: numpy==1.21.*
+    numpy122: numpy==1.22.*
+set_env =
+    jwst: CRDS_SERVER_URL=https://jwst-crds.stsci.edu
+    romancal: CRDS_SERVER_URL=https://roman-crds.stsci.edu
+commands_pre =
+    pip freeze
+commands =
+    pytest \
+    warnings: -W error \
+    xdist: -n auto \
+    jwst: --pyargs jwst --ignore-glob=timeconversion --ignore-glob=associations \
+    romancal: --pyargs romancal \
+    cov: --cov=src/stpipe --cov-config=pyproject.toml --cov-report=term-missing --cov-report=xml \
+    {posargs}
+
+[testenv:build-docs]
+description = invoke sphinx-build to build the HTML docs
+extras =
+    docs
+commands =
+    sphinx-build -W docs docs/_build
+
+[testenv:build-dist]
+description = build wheel and sdist
+skip_install = true
+deps =
+    build
+commands =
+    python -m build .

--- a/tox.ini
+++ b/tox.ini
@@ -16,12 +16,12 @@ envlist =
 #
 
 [testenv:check-style]
-description = check code style, e.g. with ruff
+description = check code style, e.g. with flake8
 skip_install = true
 deps =
-    ruff
+    flake8
 commands =
-    ruff . {posargs}
+    flake8 . {posargs}
 
 [testenv:check-security]
 description = run bandit to check security compliance
@@ -53,6 +53,7 @@ extras =
     test
 deps =
     xdist: pytest-xdist
+    cov: pytest-cov
     jwst: jwst[test] @ git+https://github.com/spacetelescope/jwst.git
     romancal: romancal[test] @ git+https://github.com/spacetelescope/romancal.git
     numpy120: numpy==1.20.*


### PR DESCRIPTION
This PR abstracts CI workflows to the OpenAstronomy workflows; this should reduce maintenance for updating and maintaining actions. Additionally, these changes move the majority of MacOS jobs to the weekly scheduled workflow. This should alleviate the issue where the limited MacOS runners for the organization are not available for CI jobs.

- add `tox.ini` with `toxenv`s from Romancal
- test various Python versions on `ubuntu` and `macos`
- ~~use `ruff` instead of `flake8` to check lint rules~~ moved to #77

<img width="325" alt="image" src="https://user-images.githubusercontent.com/16024299/225340684-bb3ab58d-1626-426e-bfdc-ef1899563e39.png">

after merging, the Required Statuses should also be updated