### PR TITLE
convert FromCommandLine to str before building Step

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 0.4.5 (unreleased)
 ==================
 
--
+- convert FromCommandLine instances to str before using as keyword arguments to Step [#78]
 
 0.4.4 (2022-12-16)
 ==================

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -260,12 +260,23 @@ class Step:
         if 'name' in config:
             del config['name']
 
+        # cmdline.FromCommandLine instances should not be passed to
+        # steps. Instead, convert them back to strings.
+        from . import cmdline
+
+        kwargs = {}
+        for k in config:
+            if isinstance(config[k], cmdline.FromCommandLine):
+                kwargs[k] = str(config[k])
+            else:
+                kwargs[k] = config[k]
+
         step = cls(
             name=name,
             parent=parent,
             config_file=config_file,
             _validate_kwds=False,
-            **config)
+            **kwargs)
 
         return step
 


### PR DESCRIPTION
When string arguments are passed in via the command line they are converted to FromCommandLine instances. Convert them back to strings before providing them as keyword arguments while building the step.

It appears this conversion is only needed to resolve the path of input and output files provided to the step
https://github.com/spacetelescope/stpipe/blob/454314bfd8cfd8764bfc55448bc7c1c2d0f6489f/src/stpipe/config_parser.py#L38-L46

This will hopefully fix the failing regression tests for https://github.com/spacetelescope/jwst/pull/7403 and other instances of similar failures.