### PR TITLE
Start using `isort` and `black` code formatters

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,8 +2,7 @@
 
 [flake8]
 select = F, W, E101, E111, E112, E113, E401, E402, E501, E711, E722
-# We should set max line length to 88 eventually
-max-line-length = 130
+max-line-length = 88
 exclude =
     docs,
     src/stpipe/extern,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,11 @@ repos:
       args: ["--fix", "--force-exclude"]
       exclude: "scripts/strun"
 
+- repo: https://github.com/pycqa/isort
+  rev: 5.12.0
+  hooks:
+    - id: isort
+
 - repo: https://github.com/PyCQA/bandit
   rev: 1.7.4
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,6 +44,11 @@ repos:
   hooks:
     - id: isort
 
+- repo: https://github.com/psf/black
+  rev: 23.3.0
+  hooks:
+    - id: black
+
 - repo: https://github.com/PyCQA/bandit
   rev: 1.7.4
   hooks:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
   catching ``ResourceWarning`` s. [#90]
 
 - Start using ``pre-commit`` to handle style checks. [#79]
+- Apply the ``isort`` and ``black`` code formatters and reduce the line length
+  maximum to 88 characters. [#80]
 
 0.4.6 (2023-03-27)
 ==================

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -29,12 +29,12 @@ sys.path.insert(0, str(REPO_ROOT / "src" / "stpipe"))
 # values here:
 with open(REPO_ROOT / "pyproject.toml", "rb") as configuration_file:
     conf = tomllib.load(configuration_file)
-setup_metadata = conf['project']
+setup_metadata = conf["project"]
 
 project = setup_metadata["name"]
 primary_author = setup_metadata["authors"][0]
 author = f'{primary_author["name"]} <{primary_author["email"]}>'
-copyright = f'{datetime.now().year}, {author}'
+copyright = f"{datetime.now().year}, {author}"
 
 package = importlib.import_module(project)
 version = package.__version__.split("-", 1)[0]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,10 +1,13 @@
 import importlib
-import stsci_rtd_theme
 import sys
+
+import stsci_rtd_theme
+
 if sys.version_info < (3, 11):
     import tomli as tomllib
 else:
     import tomllib
+
 from datetime import datetime
 from pathlib import Path
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -51,7 +51,7 @@ autoclass_content = "both"
 
 html_theme = "stsci_rtd_theme"
 html_theme_options = {
-    "collapse_navigation": True
+    "collapse_navigation": True,
 }
 html_theme_path = [stsci_rtd_theme.get_html_theme_path()]
 html_domain_indices = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ select = [
     'F', # flakes
     'W', # whitespace / deprecation
 ]
-line-length = 130
+line-length = 88
 extend-exclude = [
     'docs',
     'src/stpipe/extern',
@@ -99,11 +99,11 @@ extend-ignore = [
 [tool.isort]
 profile = "black"
 filter_files = true
-line_length = 130
+line_length = 88
 extend_skip_glob = ["src/stpipe/extern/*"]
 
 [tool.black]
-line-length = 130
+line-length = 88
 force-exclude = '''
 ^/(
   (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,3 +95,9 @@ extend-exclude = [
 extend-ignore = [
     'W605', # invalid escape sequence
 ]
+
+[tool.isort]
+profile = "black"
+filter_files = true
+line_length = 130
+extend_skip_glob = ["src/stpipe/extern/*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,3 +101,17 @@ profile = "black"
 filter_files = true
 line_length = 130
 extend_skip_glob = ["src/stpipe/extern/*"]
+
+[tool.black]
+line-length = 130
+force-exclude = '''
+^/(
+  (
+      \.eggs
+    | \.git
+    | \.pytest_cache
+    | \.tox
+    | src/stpipe/extern
+  )/
+)
+'''

--- a/scripts/strun
+++ b/scripts/strun
@@ -17,7 +17,6 @@ import stpipe
 from stpipe import Step
 from stpipe.exceptions import StpipeExitException
 
-
 if __name__ == '__main__':
 
     if '--version' in sys.argv:

--- a/scripts/strun
+++ b/scripts/strun
@@ -17,9 +17,8 @@ import stpipe
 from stpipe import Step
 from stpipe.exceptions import StpipeExitException
 
-if __name__ == '__main__':
-
-    if '--version' in sys.argv:
+if __name__ == "__main__":
+    if "--version" in sys.argv:
         sys.stdout.write(f"{stpipe.__version__}\n")
         sys.exit(0)
 
@@ -29,5 +28,6 @@ if __name__ == '__main__':
         sys.exit(e.exit_status)
     except Exception:
         import traceback
+
         traceback.print_exc()
         sys.exit(1)

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,6 @@ from pathlib import Path
 
 from setuptools import setup
 
-scripts = [str(filename) for filename in Path('./scripts').glob('**/*') if filename.is_file() and filename.name != '__pycache__']
+scripts = [str(filename) for filename in Path("./scripts").glob("**/*") if filename.is_file() and filename.name != "__pycache__"]
 
 setup(scripts=scripts)

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,10 @@ from pathlib import Path
 
 from setuptools import setup
 
-scripts = [str(filename) for filename in Path("./scripts").glob("**/*") if filename.is_file() and filename.name != "__pycache__"]
+scripts = [
+    str(filename)
+    for filename in Path("./scripts").glob("**/*")
+    if filename.is_file() and filename.name != "__pycache__"
+]
 
 setup(scripts=scripts)

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,6 @@ from pathlib import Path
 
 from setuptools import setup
 
-scripts = [
-    str(filename)
-    for filename in Path('./scripts').glob('**/*')
-    if filename.is_file() and filename.name != '__pycache__'
-]
+scripts = [str(filename) for filename in Path('./scripts').glob('**/*') if filename.is_file() and filename.name != '__pycache__']
 
 setup(scripts=scripts)

--- a/src/stpipe/__init__.py
+++ b/src/stpipe/__init__.py
@@ -1,7 +1,6 @@
+from . import _version
 from .pipeline import Pipeline
 from .step import Step
-from . import _version
-
 
 __version__ = _version.version
 

--- a/src/stpipe/__init__.py
+++ b/src/stpipe/__init__.py
@@ -5,4 +5,4 @@ from .step import Step
 __version__ = _version.version
 
 
-__all__ = ['Pipeline', 'Step', '__version__']
+__all__ = ["Pipeline", "Step", "__version__"]

--- a/src/stpipe/__main__.py
+++ b/src/stpipe/__main__.py
@@ -1,6 +1,5 @@
 from .cli.main import main
 
-
 # main() always raises SystemExit, so we don't need
 # to perform any exception handling here.
 main()

--- a/src/stpipe/cli/__init__.py
+++ b/src/stpipe/cli/__init__.py
@@ -4,5 +4,4 @@ implementation of 'strun').
 """
 from .main import handle_args
 
-
 __all__ = ["handle_args"]

--- a/src/stpipe/cli/command.py
+++ b/src/stpipe/cli/command.py
@@ -6,6 +6,7 @@ class Command(abc.ABC):
     Base class for stpipe CLI commands.  Every subclass should
     be added to the _COMMAND_CLASSES list in core.py.
     """
+
     @abc.abstractclassmethod
     def get_name(cls):
         """

--- a/src/stpipe/cli/list.py
+++ b/src/stpipe/cli/list.py
@@ -2,13 +2,12 @@
 Implements the 'stpipe list' command, which lists available
 Step subclasses.
 """
-import sys
-
 import argparse
 import re
+import sys
 
-from .command import Command
 from .. import entry_points
+from .command import Command
 
 
 class ListCommand(Command):

--- a/src/stpipe/cli/list.py
+++ b/src/stpipe/cli/list.py
@@ -33,7 +33,7 @@ examples:
             formatter_class=argparse.RawDescriptionHelpFormatter,
             description="list available classes",
             help="list available classes",
-    )
+        )
 
         parser.add_argument("pattern", metavar="<pattern>", help="restrict classes to glob pattern (case-insensitive)", nargs="?")
 
@@ -71,6 +71,7 @@ def _filter_pattern(pattern, steps):
     pattern = re.compile(re.escape(pattern.lower()).replace(r"\*", ".*"))
 
     return [
-        s for s in steps
+        s
+        for s in steps
         if pattern.fullmatch(s.class_name.lower()) or (s.class_alias is not None and pattern.fullmatch(s.class_alias.lower()))
     ]

--- a/src/stpipe/cli/list.py
+++ b/src/stpipe/cli/list.py
@@ -35,11 +35,26 @@ examples:
             help="list available classes",
         )
 
-        parser.add_argument("pattern", metavar="<pattern>", help="restrict classes to glob pattern (case-insensitive)", nargs="?")
+        parser.add_argument(
+            "pattern",
+            metavar="<pattern>",
+            help="restrict classes to glob pattern (case-insensitive)",
+            nargs="?",
+        )
 
         group = parser.add_mutually_exclusive_group()
-        group.add_argument("--pipelines-only", help="list only pipeline classes", action="store_true", default=False)
-        group.add_argument("--steps-only", help="list only step classes", action="store_true", default=False)
+        group.add_argument(
+            "--pipelines-only",
+            help="list only pipeline classes",
+            action="store_true",
+            default=False,
+        )
+        group.add_argument(
+            "--steps-only",
+            help="list only step classes",
+            action="store_true",
+            default=False,
+        )
 
     @classmethod
     def run(cls, args):
@@ -73,5 +88,6 @@ def _filter_pattern(pattern, steps):
     return [
         s
         for s in steps
-        if pattern.fullmatch(s.class_name.lower()) or (s.class_alias is not None and pattern.fullmatch(s.class_alias.lower()))
+        if pattern.fullmatch(s.class_name.lower())
+        or (s.class_alias is not None and pattern.fullmatch(s.class_alias.lower()))
     ]

--- a/src/stpipe/cli/main.py
+++ b/src/stpipe/cli/main.py
@@ -41,7 +41,9 @@ def handle_args(raw_args):
         parser.print_help()
         return 0
 
-    command_class = next(c for c in _COMMAND_CLASSES if c.get_name() == args.command_name)
+    command_class = next(
+        c for c in _COMMAND_CLASSES if c.get_name() == args.command_name
+    )
 
     return command_class.run(args)
 
@@ -67,7 +69,12 @@ def main():
 
 def _get_parser():
     parser = argparse.ArgumentParser("stpipe", description="stpipe CLI")
-    parser.add_argument("-v", "--version", help="print version information and exit", action="store_true")
+    parser.add_argument(
+        "-v",
+        "--version",
+        help="print version information and exit",
+        action="store_true",
+    )
 
     subparsers = parser.add_subparsers(dest="command_name", title="commands")
 
@@ -86,7 +93,10 @@ def _print_versions():
 
     from .. import entry_points
 
-    packages = sorted({(s.package_name, s.package_version) for s in entry_points.get_steps()}, key=lambda tup: tup[0])
+    packages = sorted(
+        {(s.package_name, s.package_version) for s in entry_points.get_steps()},
+        key=lambda tup: tup[0],
+    )
 
     print(f"stpipe: {stpipe.__version__}")
     for package_name, package_version in packages:

--- a/src/stpipe/cli/main.py
+++ b/src/stpipe/cli/main.py
@@ -5,9 +5,8 @@ import argparse
 import sys
 import traceback
 
-from .list import ListCommand
 from ..exceptions import StpipeExitException
-
+from .list import ListCommand
 
 # New subclasses of Command must be imported
 # and appended to this list before they'll
@@ -83,8 +82,9 @@ def _print_versions():
     Print stpipe version as well as versions of any packages
     that register an stpipe.steps entry point.
     """
-    from .. import entry_points
     import stpipe
+
+    from .. import entry_points
 
     packages = sorted({(s.package_name, s.package_version) for s in entry_points.get_steps()}, key=lambda tup: tup[0])
 

--- a/src/stpipe/cmdline.py
+++ b/src/stpipe/cmdline.py
@@ -42,9 +42,13 @@ def _get_config_and_class(identifier):
         step_class, name = Step._parse_class_and_name(config, config_file=config_file)
     else:
         try:
-            step_class = utilities.import_class(utilities.resolve_step_class_alias(identifier), Step)
+            step_class = utilities.import_class(
+                utilities.resolve_step_class_alias(identifier), Step
+            )
         except (ImportError, AttributeError, TypeError):
-            raise ValueError(f"{identifier!r} is not a path to a config file or a Python Step class")
+            raise ValueError(
+                f"{identifier!r} is not a path to a config file or a Python Step class"
+            )
         # Don't validate yet
         config = config_parser.config_from_dict({})
         name = None
@@ -87,7 +91,9 @@ def _build_arg_parser_from_spec(spec, step_class, parent=None):
                 comment = comment.lstrip("#").strip()
                 argument = "--" + ".".join(parts + [key])
                 if argument[2:] in built_in_configuration_parameters:
-                    raise ValueError(f"The Step's spec is trying to override a built-in parameter {argument!r}")
+                    raise ValueError(
+                        f"The Step's spec is trying to override a built-in parameter {argument!r}"
+                    )
                 parser.add_argument(
                     "--" + ".".join(parts + [key]),
                     type=str,
@@ -222,17 +228,23 @@ def just_the_step_from_cmdline(args, cls=None):
 
     try:
         if cls is None:
-            step_class, config, name, config_file = _get_config_and_class(known.cfg_file_or_class[0])
+            step_class, config, name, config_file = _get_config_and_class(
+                known.cfg_file_or_class[0]
+            )
         else:
             config_file = known.config_file
             config = config_parser.load_config_file(config_file)
-            step_class, name = Step._parse_class_and_name(config, config_file=config_file)
+            step_class, name = Step._parse_class_and_name(
+                config, config_file=config_file
+            )
             step_class = cls
 
         log_config = None
         if known.verbose:
             if known.logcfg is not None:
-                raise ValueError("If --verbose is set, a logging configuration file may not be provided")
+                raise ValueError(
+                    "If --verbose is set, a logging configuration file may not be provided"
+                )
             log_config = io.BytesIO(log.MAX_CONFIGURATION)
         elif known.logcfg is not None:
             if not os.path.exists(known.logcfg):
@@ -291,9 +303,13 @@ def just_the_step_from_cmdline(args, cls=None):
 
         # Attempt to retrieve Step parameters from CRDS
         try:
-            parameter_cfg = step_class.get_config_from_reference(input_file, disable=disable_crds_steppars)
+            parameter_cfg = step_class.get_config_from_reference(
+                input_file, disable=disable_crds_steppars
+            )
         except (FileNotFoundError, OSError):
-            log.log.warning("Unable to open input file, cannot get parameters from CRDS")
+            log.log.warning(
+                "Unable to open input file, cannot get parameters from CRDS"
+            )
         else:
             if config:
                 config_parser.merge_config(parameter_cfg, config)
@@ -354,7 +370,9 @@ def step_from_cmdline(args, cls=None):
         will be set as member variables on the returned `Step`
         instance.
     """
-    step, step_class, positional, debug_on_exception = just_the_step_from_cmdline(args, cls)
+    step, step_class, positional, debug_on_exception = just_the_step_from_cmdline(
+        args, cls
+    )
 
     try:
         profile_path = os.environ.pop("STPIPE_PROFILE", None)

--- a/src/stpipe/cmdline.py
+++ b/src/stpipe/cmdline.py
@@ -92,7 +92,8 @@ def _build_arg_parser_from_spec(spec, step_class, parent=None):
                 argument = "--" + ".".join(parts + [key])
                 if argument[2:] in built_in_configuration_parameters:
                     raise ValueError(
-                        f"The Step's spec is trying to override a built-in parameter {argument!r}"
+                        "The Step's spec is trying to override a built-in parameter"
+                        f" {argument!r}"
                     )
                 parser.add_argument(
                     "--" + ".".join(parts + [key]),
@@ -243,7 +244,8 @@ def just_the_step_from_cmdline(args, cls=None):
         if known.verbose:
             if known.logcfg is not None:
                 raise ValueError(
-                    "If --verbose is set, a logging configuration file may not be provided"
+                    "If --verbose is set, a logging configuration file may not be"
+                    " provided"
                 )
             log_config = io.BytesIO(log.MAX_CONFIGURATION)
         elif known.logcfg is not None:
@@ -290,8 +292,8 @@ def just_the_step_from_cmdline(args, cls=None):
     del args.args
 
     # This updates config (a ConfigObj) with the values from the command line arguments
-    # Config is empty if class specified, otherwise contains values from config file specified
-    # on command line
+    # Config is empty if class specified, otherwise contains values from config file
+    # specified on command line
     _override_config_from_args(config, args)
 
     config = step_class.merge_config(config, config_file)

--- a/src/stpipe/cmdline.py
+++ b/src/stpipe/cmdline.py
@@ -6,10 +6,8 @@ import os
 import os.path
 import textwrap
 
-from . import config_parser
-from . import log
-from . import utilities
-from .step import get_disable_crds_steppars, Step
+from . import config_parser, log, utilities
+from .step import Step, get_disable_crds_steppars
 
 built_in_configuration_parameters = [
     'debug', 'logcfg', 'verbose'

--- a/src/stpipe/cmdline.py
+++ b/src/stpipe/cmdline.py
@@ -44,7 +44,7 @@ def _get_config_and_class(identifier):
         try:
             step_class = utilities.import_class(utilities.resolve_step_class_alias(identifier), Step)
         except (ImportError, AttributeError, TypeError):
-            raise ValueError("{!r} is not a path to a config file or a Python Step " "class".format(identifier))
+            raise ValueError(f"{identifier!r} is not a path to a config file or a Python Step class")
         # Don't validate yet
         config = config_parser.config_from_dict({})
         name = None
@@ -87,7 +87,7 @@ def _build_arg_parser_from_spec(spec, step_class, parent=None):
                 comment = comment.lstrip("#").strip()
                 argument = "--" + ".".join(parts + [key])
                 if argument[2:] in built_in_configuration_parameters:
-                    raise ValueError("The Step's spec is trying to override a built-in " f"parameter {argument!r}")
+                    raise ValueError(f"The Step's spec is trying to override a built-in parameter {argument!r}")
                 parser.add_argument(
                     "--" + ".".join(parts + [key]),
                     type=str,
@@ -232,7 +232,7 @@ def just_the_step_from_cmdline(args, cls=None):
         log_config = None
         if known.verbose:
             if known.logcfg is not None:
-                raise ValueError("If --verbose is set, a logging configuration file may " "not be provided")
+                raise ValueError("If --verbose is set, a logging configuration file may not be provided")
             log_config = io.BytesIO(log.MAX_CONFIGURATION)
         elif known.logcfg is not None:
             if not os.path.exists(known.logcfg):

--- a/src/stpipe/cmdline.py
+++ b/src/stpipe/cmdline.py
@@ -10,25 +10,25 @@ from . import config_parser, log, utilities
 from .step import Step, get_disable_crds_steppars
 
 built_in_configuration_parameters = [
-    'debug',
-    'logcfg',
-    'verbose',
+    "debug",
+    "logcfg",
+    "verbose",
 ]
 
 
 def _print_important_message(header, message, no_wrap=None):
-    print('-' * 70)
+    print("-" * 70)
     print(textwrap.fill(header))
     print(
         textwrap.fill(
             message,
-            initial_indent='    ',
-            subsequent_indent='    ',
+            initial_indent="    ",
+            subsequent_indent="    ",
         )
     )
     if no_wrap:
         print(no_wrap)
-    print('-' * 70)
+    print("-" * 70)
 
 
 def _get_config_and_class(identifier):
@@ -44,7 +44,7 @@ def _get_config_and_class(identifier):
         try:
             step_class = utilities.import_class(utilities.resolve_step_class_alias(identifier), Step)
         except (ImportError, AttributeError, TypeError):
-            raise ValueError('{!r} is not a path to a config file or a Python Step ' 'class'.format(identifier))
+            raise ValueError("{!r} is not a path to a config file or a Python Step " "class".format(identifier))
         # Don't validate yet
         config = config_parser.config_from_dict({})
         name = None
@@ -83,8 +83,8 @@ def _build_arg_parser_from_spec(spec, step_class, parent=None):
             if isinstance(val, dict):
                 build_from_spec(val, parts + [key])
             else:
-                comment = subspec.inline_comments.get(key) or ''
-                comment = comment.lstrip('#').strip()
+                comment = subspec.inline_comments.get(key) or ""
+                comment = comment.lstrip("#").strip()
                 argument = "--" + ".".join(parts + [key])
                 if argument[2:] in built_in_configuration_parameters:
                     raise ValueError("The Step's spec is trying to override a built-in " f"parameter {argument!r}")
@@ -92,15 +92,15 @@ def _build_arg_parser_from_spec(spec, step_class, parent=None):
                     "--" + ".".join(parts + [key]),
                     type=str,
                     help=comment,
-                    metavar='',
+                    metavar="",
                 )
 
     build_from_spec(spec)
 
     parser.add_argument(
-        'args',
-        nargs='*',
-        help='arguments to pass to step',
+        "args",
+        nargs="*",
+        help="arguments to pass to step",
     )
 
     return parser
@@ -127,7 +127,7 @@ def _override_config_from_args(config, args):
     """
 
     def set_value(subconf, key, val):
-        root, sep, rest = key.partition('.')
+        root, sep, rest = key.partition(".")
         if rest:
             set_value(subconf.setdefault(root, {}), rest, val)
         else:
@@ -209,14 +209,14 @@ def just_the_step_from_cmdline(args, cls=None):
         help="When an exception occurs, invoke the Python debugger, pdb",
     )
     parser1.add_argument(
-        '--save-parameters',
+        "--save-parameters",
         type=str,
-        help='Save step parameters to specified file.',
+        help="Save step parameters to specified file.",
     )
     parser1.add_argument(
-        '--disable-crds-steppars',
-        action='store_true',
-        help='Disable retrieval of step parameter references files from CRDS',
+        "--disable-crds-steppars",
+        action="store_true",
+        help="Disable retrieval of step parameter references files from CRDS",
     )
     known, _ = parser1.parse_known_args(args)
 
@@ -287,7 +287,7 @@ def just_the_step_from_cmdline(args, cls=None):
     if len(positional):
         input_file = positional[0]
         if args.input_dir:
-            input_file = args.input_dir + '/' + input_file
+            input_file = args.input_dir + "/" + input_file
 
         # Attempt to retrieve Step parameters from CRDS
         try:

--- a/src/stpipe/cmdline.py
+++ b/src/stpipe/cmdline.py
@@ -10,14 +10,22 @@ from . import config_parser, log, utilities
 from .step import Step, get_disable_crds_steppars
 
 built_in_configuration_parameters = [
-    'debug', 'logcfg', 'verbose'
-    ]
+    'debug',
+    'logcfg',
+    'verbose',
+]
+
 
 def _print_important_message(header, message, no_wrap=None):
     print('-' * 70)
     print(textwrap.fill(header))
-    print(textwrap.fill(
-        message, initial_indent='    ', subsequent_indent='    '))
+    print(
+        textwrap.fill(
+            message,
+            initial_indent='    ',
+            subsequent_indent='    ',
+        )
+    )
     if no_wrap:
         print(no_wrap)
     print('-' * 70)
@@ -31,15 +39,12 @@ def _get_config_and_class(identifier):
     if os.path.exists(identifier):
         config_file = identifier
         config = config_parser.load_config_file(config_file)
-        step_class, name = Step._parse_class_and_name(
-            config, config_file=config_file)
+        step_class, name = Step._parse_class_and_name(config, config_file=config_file)
     else:
         try:
             step_class = utilities.import_class(utilities.resolve_step_class_alias(identifier), Step)
         except (ImportError, AttributeError, TypeError):
-            raise ValueError(
-                '{!r} is not a path to a config file or a Python Step '
-                'class'.format(identifier))
+            raise ValueError('{!r} is not a path to a config file or a Python Step ' 'class'.format(identifier))
         # Don't validate yet
         config = config_parser.config_from_dict({})
         name = None
@@ -70,7 +75,8 @@ def _build_arg_parser_from_spec(spec, step_class, parent=None):
     # later be verified by configobj itself.
     parser = argparse.ArgumentParser(
         parents=[parent],
-        description=step_class.__doc__)
+        description=step_class.__doc__,
+    )
 
     def build_from_spec(subspec, parts=[]):
         for key, val in subspec.items():
@@ -81,16 +87,21 @@ def _build_arg_parser_from_spec(spec, step_class, parent=None):
                 comment = comment.lstrip('#').strip()
                 argument = "--" + ".".join(parts + [key])
                 if argument[2:] in built_in_configuration_parameters:
-                    raise ValueError(
-                        "The Step's spec is trying to override a built-in "
-                        f"parameter {argument!r}")
+                    raise ValueError("The Step's spec is trying to override a built-in " f"parameter {argument!r}")
                 parser.add_argument(
                     "--" + ".".join(parts + [key]),
-                    type=str, help=comment, metavar='')
+                    type=str,
+                    help=comment,
+                    metavar='',
+                )
+
     build_from_spec(spec)
 
     parser.add_argument(
-        'args', nargs='*', help='arguments to pass to step')
+        'args',
+        nargs='*',
+        help='arguments to pass to step',
+    )
 
     return parser
 
@@ -105,13 +116,16 @@ class FromCommandLine(str):
     as instances of this class, we can later (in `config_parser.py`)
     use isinstance to see where the values came from.
     """
+
     pass
+
 
 def _override_config_from_args(config, args):
     """
     Overrides any configuration values in `config` with values from the
     parsed commandline arguments `args`.
     """
+
     def set_value(subconf, key, val):
         root, sep, rest = key.partition('.')
         if rest:
@@ -160,69 +174,78 @@ def just_the_step_from_cmdline(args, cls=None):
     DOES NOT RUN THE STEP
     """
     import argparse
+
     parser1 = argparse.ArgumentParser(
         description="Run an stpipe Step or Pipeline",
-        add_help=False)
+        add_help=False,
+    )
     if cls is None:
         parser1.add_argument(
-            "cfg_file_or_class", type=str, nargs=1,
-            help="The configuration file or Python class to run")
+            "cfg_file_or_class",
+            type=str,
+            nargs=1,
+            help="The configuration file or Python class to run",
+        )
     else:
         parser1.add_argument(
-            "--config-file", type=str,
-            help="A configuration file to load parameters from")
+            "--config-file",
+            type=str,
+            help="A configuration file to load parameters from",
+        )
     parser1.add_argument(
-        "--logcfg", type=str,
-        help="The logging configuration file to load")
-    parser1.add_argument(
-        "--verbose", "-v", action="store_true",
-        help="Turn on all logging messages")
-    parser1.add_argument(
-        "--debug", action="store_true",
-        help="When an exception occurs, invoke the Python debugger, pdb")
-    parser1.add_argument(
-        '--save-parameters', type=str,
-        help='Save step parameters to specified file.'
+        "--logcfg",
+        type=str,
+        help="The logging configuration file to load",
     )
     parser1.add_argument(
-        '--disable-crds-steppars', action='store_true',
-        help='Disable retrieval of step parameter references files from CRDS'
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Turn on all logging messages",
+    )
+    parser1.add_argument(
+        "--debug",
+        action="store_true",
+        help="When an exception occurs, invoke the Python debugger, pdb",
+    )
+    parser1.add_argument(
+        '--save-parameters',
+        type=str,
+        help='Save step parameters to specified file.',
+    )
+    parser1.add_argument(
+        '--disable-crds-steppars',
+        action='store_true',
+        help='Disable retrieval of step parameter references files from CRDS',
     )
     known, _ = parser1.parse_known_args(args)
 
     try:
         if cls is None:
-            step_class, config, name, config_file = \
-                _get_config_and_class(known.cfg_file_or_class[0])
+            step_class, config, name, config_file = _get_config_and_class(known.cfg_file_or_class[0])
         else:
             config_file = known.config_file
             config = config_parser.load_config_file(config_file)
-            step_class, name = Step._parse_class_and_name(
-                config, config_file=config_file)
+            step_class, name = Step._parse_class_and_name(config, config_file=config_file)
             step_class = cls
 
         log_config = None
         if known.verbose:
             if known.logcfg is not None:
-                raise ValueError(
-                    "If --verbose is set, a logging configuration file may "
-                    "not be provided")
+                raise ValueError("If --verbose is set, a logging configuration file may " "not be provided")
             log_config = io.BytesIO(log.MAX_CONFIGURATION)
         elif known.logcfg is not None:
             if not os.path.exists(known.logcfg):
-                raise OSError(
-                    f"Logging config {known.logcfg!r} not found")
+                raise OSError(f"Logging config {known.logcfg!r} not found")
             log_config = known.logcfg
 
         if log_config is not None:
             try:
                 log.load_configuration(log_config)
             except Exception as e:
-                raise ValueError(
-                    f"Error parsing logging config {log_config!r}:\n{e}")
+                raise ValueError(f"Error parsing logging config {log_config!r}:\n{e}")
     except Exception as e:
-        _print_important_message(
-            "ERROR PARSING CONFIGURATION:", str(e))
+        _print_important_message("ERROR PARSING CONFIGURATION:", str(e))
         parser1.print_help()
         raise
 
@@ -281,7 +304,10 @@ def just_the_step_from_cmdline(args, cls=None):
     # This is where the step is instantiated
     try:
         step = step_class.from_config_section(
-            config, name=name, config_file=config_file)
+            config,
+            name=name,
+            config_file=config_file,
+        )
     except config_parser.ValidationError as e:
         # If the configobj validator failed, print usage information.
         _print_important_message("ERROR PARSING CONFIGURATION:", str(e))
@@ -328,23 +354,22 @@ def step_from_cmdline(args, cls=None):
         will be set as member variables on the returned `Step`
         instance.
     """
-    step, step_class, positional, debug_on_exception = \
-        just_the_step_from_cmdline(args, cls)
+    step, step_class, positional, debug_on_exception = just_the_step_from_cmdline(args, cls)
 
     try:
         profile_path = os.environ.pop("STPIPE_PROFILE", None)
         if profile_path:
             import cProfile
+
             cProfile.runctx("step.run(*positional)", globals(), locals(), profile_path)
         else:
             step.run(*positional)
     except Exception as e:
-        _print_important_message(
-            f"ERROR RUNNING STEP {step_class.__name__!r}:", str(e)
-        )
+        _print_important_message(f"ERROR RUNNING STEP {step_class.__name__!r}:", str(e))
 
         if debug_on_exception:
             import pdb
+
             pdb.post_mortem()
         else:
             raise

--- a/src/stpipe/config.py
+++ b/src/stpipe/config.py
@@ -109,8 +109,13 @@ class StepConfig:
 
         if include_metadata:
             meta = deepcopy(_META_TEMPLATE)
-            meta["date"] = meta["date"].replace(_TEMPLATE_PLACEHOLDER, datetime.utcnow().replace(microsecond=0).isoformat())
-            meta["description"] = meta["description"].replace(_TEMPLATE_PLACEHOLDER, self.class_name)
+            meta["date"] = meta["date"].replace(
+                _TEMPLATE_PLACEHOLDER,
+                datetime.utcnow().replace(microsecond=0).isoformat(),
+            )
+            meta["description"] = meta["description"].replace(
+                _TEMPLATE_PLACEHOLDER, self.class_name
+            )
             result["meta"] = meta
 
         _validate_asdf(result, _CONFIG_SCHEMA_URI)
@@ -190,7 +195,10 @@ def export_config(step):
     # ahold of the name and class name.
     parameters.pop("steps", None)
 
-    steps = [export_config(getattr(step, step_name)) for step_name, _ in getattr(step, "step_defs", {}).items()]
+    steps = [
+        export_config(getattr(step, step_name))
+        for step_name, _ in getattr(step, "step_defs", {}).items()
+    ]
 
     return StepConfig(class_name, name, parameters, steps)
 

--- a/src/stpipe/config.py
+++ b/src/stpipe/config.py
@@ -6,10 +6,9 @@ both until we replace configobj with traitlets.
 from copy import deepcopy
 from datetime import datetime
 
-from .utilities import get_fully_qualified_class_name
-
 import asdf
 
+from .utilities import get_fully_qualified_class_name
 
 _CONFIG_SCHEMA_URI = "http://stsci.edu/schemas/stpipe/step_config-1.0.0"
 _LEGACY_CONFIG_SCHEMA_URI = "http://stsci.edu/schemas/stpipe/step_config-0.1.0"

--- a/src/stpipe/config.py
+++ b/src/stpipe/config.py
@@ -46,6 +46,7 @@ class StepConfig:
     steps : list of StepConfig
         List of sub-step configs.
     """
+
     def __init__(self, class_name, name, parameters, steps):
         self._class_name = class_name
         self._name = name
@@ -73,10 +74,10 @@ class StepConfig:
             return False
 
         return (
-            self.class_name == other.class_name and
-            self.name == other.name and
-            self.parameters == other.parameters and
-            self.steps == other.steps
+            self.class_name == other.class_name
+            and self.name == other.name
+            and self.parameters == other.parameters
+            and self.steps == other.steps
         )
 
     def _to_tree(self):
@@ -189,10 +190,7 @@ def export_config(step):
     # ahold of the name and class name.
     parameters.pop("steps", None)
 
-    steps = [
-        export_config(getattr(step, step_name))
-        for step_name, _ in getattr(step, "step_defs", {}).items()
-    ]
+    steps = [export_config(getattr(step, step_name)) for step_name, _ in getattr(step, "step_defs", {}).items()]
 
     return StepConfig(class_name, name, parameters, steps)
 

--- a/src/stpipe/config_parser.py
+++ b/src/stpipe/config_parser.py
@@ -14,7 +14,12 @@ from stdatamodels import s3_utils
 from . import utilities
 from .config import StepConfig
 from .datamodel import AbstractDataModel
-from .extern.configobj.configobj import ConfigObj, Section, flatten_errors, get_extra_values
+from .extern.configobj.configobj import (
+    ConfigObj,
+    Section,
+    flatten_errors,
+    get_extra_values,
+)
 from .extern.configobj.validate import ValidateError, Validator, VdtTypeError
 
 # Configure logger
@@ -110,7 +115,9 @@ def _load_config_file_filesystem(config_file):
         with asdf_open(config_file) as asdf_file:
             return _config_obj_from_asdf(asdf_file)
     except (AsdfValidationError, ValueError):
-        logger.debug("Config file did not parse as ASDF. Trying as ConfigObj: %s", config_file)
+        logger.debug(
+            "Config file did not parse as ASDF. Trying as ConfigObj: %s", config_file
+        )
         return ConfigObj(config_file, raise_errors=True)
 
 
@@ -123,7 +130,9 @@ def _load_config_file_s3(config_file):
         with asdf_open(content) as asdf_file:
             return _config_obj_from_asdf(asdf_file)
     except (AsdfValidationError, ValueError):
-        logger.debug("Config file did not parse as ASDF. Trying as ConfigObj: %s", config_file)
+        logger.debug(
+            "Config file did not parse as ASDF. Trying as ConfigObj: %s", config_file
+        )
         content.seek(0)
         return ConfigObj(content, raise_errors=True)
 
@@ -138,7 +147,10 @@ def _config_obj_from_step_config(config):
     merge_config(configobj, config.parameters)
     merge_config(configobj, {"class": config.class_name, "name": config.name})
     if len(config.steps) > 0:
-        merge_config(configobj, {"steps": {s.name: _config_obj_from_step_config(s) for s in config.steps}})
+        merge_config(
+            configobj,
+            {"steps": {s.name: _config_obj_from_step_config(s) for s in config.steps}},
+        )
     return configobj
 
 
@@ -296,7 +308,9 @@ def config_from_dict(d, spec=None, root_dir=None, allow_missing=False):
     return config
 
 
-def validate(config, spec, section=None, validator=None, root_dir=None, allow_missing=False):
+def validate(
+    config, spec, section=None, validator=None, root_dir=None, allow_missing=False
+):
     """
     Parse config_file, in INI format, and do validation with the
     provided specfile.

--- a/src/stpipe/config_parser.py
+++ b/src/stpipe/config_parser.py
@@ -42,8 +42,7 @@ def _get_input_file_check(root_dir):
 
         path = os.path.abspath(path)
         if not os.path.exists(path):
-            raise ValidateError(
-                f"Path {path!r} does not exist")
+            raise ValidateError(f"Path {path!r} does not exist")
 
         return path
 
@@ -139,7 +138,7 @@ def _config_obj_from_step_config(config):
     merge_config(configobj, config.parameters)
     merge_config(configobj, {"class": config.class_name, "name": config.name})
     if len(config.steps) > 0:
-        merge_config(configobj, {"steps": { s.name: _config_obj_from_step_config(s) for s in config.steps }})
+        merge_config(configobj, {"steps": {s.name: _config_obj_from_step_config(s) for s in config.steps}})
     return configobj
 
 
@@ -210,8 +209,12 @@ def load_spec_file(cls, preserve_comments=False):
     else:
         spec_file = utilities.find_spec_file(cls)
     if spec_file:
-        return ConfigObj(spec_file, _inspec=not preserve_comments,
-                         raise_errors=True, list_values=False)
+        return ConfigObj(
+            spec_file,
+            _inspec=not preserve_comments,
+            raise_errors=True,
+            list_values=False,
+        )
     return
 
 
@@ -244,7 +247,11 @@ def merge_config(into, new):
         if isinstance(val, Section):
             if key not in into:
                 section = Section(
-                    into, into.depth + 1, into.main, name=key)
+                    into,
+                    into.depth + 1,
+                    into.main,
+                    name=key,
+                )
                 into[key] = section
             merge_config(into[key], val)
         elif key not in defaults:
@@ -337,8 +344,10 @@ def validate(config, spec, section=None, validator=None, root_dir=None, allow_mi
             section = None
 
         errors = config.main.validate(
-            validator, preserve_errors=True,
-            section=section)
+            validator,
+            preserve_errors=True,
+            section=section,
+        )
 
         messages = []
         if errors is not True:
@@ -355,8 +364,7 @@ def validate(config, spec, section=None, validator=None, root_dir=None, allow_mi
                     else:
                         err = 'missing'
 
-                messages.append(
-                    f"Config parameter {section_string!r}: {err}")
+                messages.append(f"Config parameter {section_string!r}: {err}")
 
         extra_values = get_extra_values(config)
         if extra_values:
@@ -365,8 +373,7 @@ def validate(config, spec, section=None, validator=None, root_dir=None, allow_mi
                 sections = 'root'
             else:
                 sections = '/'.join(sections)
-            messages.append(
-                f"Extra value {name!r} in {sections}")
+            messages.append(f"Extra value {name!r} in {sections}")
 
         if len(messages):
             raise ValidationError('\n'.join(messages))

--- a/src/stpipe/config_parser.py
+++ b/src/stpipe/config_parser.py
@@ -1,24 +1,21 @@
 """
 Our configuration files are ConfigObj/INI files.
 """
-from inspect import isclass
 import logging
 import os
 import os.path
 import textwrap
+from inspect import isclass
 
-from asdf import open as asdf_open
 from asdf import ValidationError as AsdfValidationError
+from asdf import open as asdf_open
 from stdatamodels import s3_utils
-
-from .extern.configobj.configobj import (
-    ConfigObj, Section, flatten_errors, get_extra_values)
-from .extern.configobj.validate import Validator, ValidateError, VdtTypeError
 
 from . import utilities
 from .config import StepConfig
 from .datamodel import AbstractDataModel
-
+from .extern.configobj.configobj import ConfigObj, Section, flatten_errors, get_extra_values
+from .extern.configobj.validate import ValidateError, Validator, VdtTypeError
 
 # Configure logger
 logger = logging.getLogger(__name__)

--- a/src/stpipe/config_parser.py
+++ b/src/stpipe/config_parser.py
@@ -29,7 +29,7 @@ class ValidationError(Exception):
 def _get_input_file_check(root_dir):
     from . import cmdline
 
-    root_dir = root_dir or ''
+    root_dir = root_dir or ""
 
     def _input_file_check(path):
         if not isinstance(path, cmdline.FromCommandLine):
@@ -52,7 +52,7 @@ def _get_input_file_check(root_dir):
 def _get_output_file_check(root_dir):
     from . import cmdline
 
-    root_dir = root_dir or ''
+    root_dir = root_dir or ""
 
     def _output_file_check(path):
         if not isinstance(path, cmdline.FromCommandLine):
@@ -110,7 +110,7 @@ def _load_config_file_filesystem(config_file):
         with asdf_open(config_file) as asdf_file:
             return _config_obj_from_asdf(asdf_file)
     except (AsdfValidationError, ValueError):
-        logger.debug('Config file did not parse as ASDF. Trying as ConfigObj: %s', config_file)
+        logger.debug("Config file did not parse as ASDF. Trying as ConfigObj: %s", config_file)
         return ConfigObj(config_file, raise_errors=True)
 
 
@@ -123,7 +123,7 @@ def _load_config_file_s3(config_file):
         with asdf_open(content) as asdf_file:
             return _config_obj_from_asdf(asdf_file)
     except (AsdfValidationError, ValueError):
-        logger.debug('Config file did not parse as ASDF. Trying as ConfigObj: %s', config_file)
+        logger.debug("Config file did not parse as ASDF. Trying as ConfigObj: %s", config_file)
         content.seek(0)
         return ConfigObj(content, raise_errors=True)
 
@@ -195,14 +195,14 @@ def load_spec_file(cls, preserve_comments=False):
     # from the base class.
     if not isclass(cls):
         cls = cls.__class__
-    if 'spec' in cls.__dict__:
+    if "spec" in cls.__dict__:
         spec = cls.spec.strip()
         spec_file = textwrap.dedent(spec)
-        spec_file = spec_file.split('\n')
+        spec_file = spec_file.split("\n")
         encoded = []
         for line in spec_file:
             if isinstance(line, str):
-                encoded.append(line.encode('utf8'))
+                encoded.append(line.encode("utf8"))
             else:
                 encoded.append(line)
         spec_file = encoded
@@ -329,10 +329,10 @@ def validate(config, spec, section=None, validator=None, root_dir=None, allow_mi
 
     if validator is None:
         validator = Validator()
-        validator.functions['input_file'] = _get_input_file_check(root_dir)
-        validator.functions['output_file'] = _get_output_file_check(root_dir)
-        validator.functions['is_datamodel'] = _is_datamodel
-        validator.functions['is_string_or_datamodel'] = _is_string_or_datamodel
+        validator.functions["input_file"] = _get_input_file_check(root_dir)
+        validator.functions["output_file"] = _get_output_file_check(root_dir)
+        validator.functions["is_datamodel"] = _is_datamodel
+        validator.functions["is_string_or_datamodel"] = _is_string_or_datamodel
 
     orig_configspec = config.main.configspec
     config.main.configspec = spec
@@ -355,14 +355,14 @@ def validate(config, spec, section=None, validator=None, root_dir=None, allow_mi
                 if key is not None:
                     section_list.append(key)
                 else:
-                    section_list.append('[missing section]')
-                section_string = '/'.join(section_list)
+                    section_list.append("[missing section]")
+                section_string = "/".join(section_list)
                 if err == False:
                     if allow_missing:
                         config[key] = spec[key]
                         continue
                     else:
-                        err = 'missing'
+                        err = "missing"
 
                 messages.append(f"Config parameter {section_string!r}: {err}")
 
@@ -370,13 +370,13 @@ def validate(config, spec, section=None, validator=None, root_dir=None, allow_mi
         if extra_values:
             sections, name = extra_values[0]
             if len(sections) == 0:
-                sections = 'root'
+                sections = "root"
             else:
-                sections = '/'.join(sections)
+                sections = "/".join(sections)
             messages.append(f"Extra value {name!r} in {sections}")
 
         if len(messages):
-            raise ValidationError('\n'.join(messages))
+            raise ValidationError("\n".join(messages))
     finally:
         config.main.configspec = orig_configspec
 
@@ -401,9 +401,9 @@ def _parse(val):
     """
     Parse scalar strings into scalar python types.
     """
-    if val.lower() == 'true':
+    if val.lower() == "true":
         return True
-    elif val.lower() == 'false':
+    elif val.lower() == "false":
         return False
     try:
         return int(val)

--- a/src/stpipe/crds_client.py
+++ b/src/stpipe/crds_client.py
@@ -68,7 +68,10 @@ def _get_refpaths(data_dict, reference_file_types, observatory):
             reftypes=reference_file_types,
             observatory=observatory,
         )
-    refpaths = {filetype: filepath if "N/A" not in filepath.upper() else "N/A" for (filetype, filepath) in bestrefs.items()}
+    refpaths = {
+        filetype: filepath if "N/A" not in filepath.upper() else "N/A"
+        for (filetype, filepath) in bestrefs.items()
+    }
     return refpaths
 
 
@@ -113,7 +116,9 @@ def get_reference_file(parameters, reference_file_type, observatory):
 
     See also get_multiple_reference_paths().
     """
-    return get_multiple_reference_paths(parameters, [reference_file_type], observatory)[reference_file_type]
+    return get_multiple_reference_paths(parameters, [reference_file_type], observatory)[
+        reference_file_type
+    ]
 
 
 def get_override_name(reference_file_type):
@@ -133,7 +138,9 @@ def get_override_name(reference_file_type):
         reference file type.
     """
     if not re.match("^[_A-Za-z][_A-Za-z0-9]*$", reference_file_type):
-        raise ValueError(f"{reference_file_type!r} is not a valid reference file type name. It must be an identifier")
+        raise ValueError(
+            f"{reference_file_type!r} is not a valid reference file type name. It must be an identifier"
+        )
     return f"override_{reference_file_type}"
 
 
@@ -167,7 +174,10 @@ def reference_uri_to_cache_path(reference_uri, observatory):
     The default CRDS_PATH value is /grp/crds/cache, currently on the Central Store.
     """
     if not reference_uri.startswith("crds://"):
-        raise CrdsError("CRDS reference URI's should start with 'crds://' but got", repr(reference_uri))
+        raise CrdsError(
+            "CRDS reference URI's should start with 'crds://' but got",
+            repr(reference_uri),
+        )
     basename = config.pop_crds_uri(reference_uri)
     return crds.locate_file(basename, observatory)
 

--- a/src/stpipe/crds_client.py
+++ b/src/stpipe/crds_client.py
@@ -132,7 +132,7 @@ def get_override_name(reference_file_type):
         The configuration parameter name to use to override the given
         reference file type.
     """
-    if not re.match('^[_A-Za-z][_A-Za-z0-9]*$', reference_file_type):
+    if not re.match("^[_A-Za-z][_A-Za-z0-9]*$", reference_file_type):
         raise ValueError(f"{reference_file_type!r} is not a valid reference file type name. It must be an identifier")
     return f"override_{reference_file_type}"
 

--- a/src/stpipe/crds_client.py
+++ b/src/stpipe/crds_client.py
@@ -10,11 +10,9 @@ general integration can be managed here.
 import re
 
 import crds
-from crds.core import config, heavy_client, log
+from crds.core import config, crds_cache_locking, heavy_client, log
 from crds.core.exceptions import CrdsError
-from crds.core import crds_cache_locking
 from stdatamodels import s3_utils
-
 
 __all__ = [
     "check_reference_open",

--- a/src/stpipe/crds_client.py
+++ b/src/stpipe/crds_client.py
@@ -56,8 +56,8 @@ def get_multiple_reference_paths(parameters, reference_file_types, observatory):
 
 def _get_refpaths(data_dict, reference_file_types, observatory):
     """Tailor the CRDS core library getreferences() call to the stpipe code by
-    adding locking and truncating expected exceptions.   Also simplify 'NOT FOUND n/a' to
-    'N/A'.  Re-interpret empty reference_file_types as "no types" instead of core
+    adding locking and truncating expected exceptions.   Also simplify 'NOT FOUND n/a'
+    to 'N/A'.  Re-interpret empty reference_file_types as "no types" instead of core
     library default of "all types."
     """
     if not reference_file_types:  # [] interpreted as *all types*.
@@ -139,7 +139,8 @@ def get_override_name(reference_file_type):
     """
     if not re.match("^[_A-Za-z][_A-Za-z0-9]*$", reference_file_type):
         raise ValueError(
-            f"{reference_file_type!r} is not a valid reference file type name. It must be an identifier"
+            f"{reference_file_type!r} is not a valid reference file type name. It must"
+            " be an identifier"
         )
     return f"override_{reference_file_type}"
 

--- a/src/stpipe/crds_client.py
+++ b/src/stpipe/crds_client.py
@@ -60,13 +60,15 @@ def _get_refpaths(data_dict, reference_file_types, observatory):
     'N/A'.  Re-interpret empty reference_file_types as "no types" instead of core
     library default of "all types."
     """
-    if not reference_file_types:   # [] interpreted as *all types*.
+    if not reference_file_types:  # [] interpreted as *all types*.
         return {}
     with crds_cache_locking.get_cache_lock():
         bestrefs = crds.getreferences(
-            data_dict, reftypes=reference_file_types, observatory=observatory)
-    refpaths = {filetype: filepath if "N/A" not in filepath.upper() else "N/A"
-                for (filetype, filepath) in bestrefs.items()}
+            data_dict,
+            reftypes=reference_file_types,
+            observatory=observatory,
+        )
+    refpaths = {filetype: filepath if "N/A" not in filepath.upper() else "N/A" for (filetype, filepath) in bestrefs.items()}
     return refpaths
 
 
@@ -111,8 +113,7 @@ def get_reference_file(parameters, reference_file_type, observatory):
 
     See also get_multiple_reference_paths().
     """
-    return get_multiple_reference_paths(
-        parameters, [reference_file_type], observatory)[reference_file_type]
+    return get_multiple_reference_paths(parameters, [reference_file_type], observatory)[reference_file_type]
 
 
 def get_override_name(reference_file_type):
@@ -132,9 +133,7 @@ def get_override_name(reference_file_type):
         reference file type.
     """
     if not re.match('^[_A-Za-z][_A-Za-z0-9]*$', reference_file_type):
-        raise ValueError(
-            f"{reference_file_type!r} is not a valid reference file type name. "
-            "It must be an identifier")
+        raise ValueError(f"{reference_file_type!r} is not a valid reference file type name. It must be an identifier")
     return f"override_{reference_file_type}"
 
 
@@ -168,8 +167,7 @@ def reference_uri_to_cache_path(reference_uri, observatory):
     The default CRDS_PATH value is /grp/crds/cache, currently on the Central Store.
     """
     if not reference_uri.startswith("crds://"):
-        raise CrdsError(
-            "CRDS reference URI's should start with 'crds://' but got", repr(reference_uri))
+        raise CrdsError("CRDS reference URI's should start with 'crds://' but got", repr(reference_uri))
     basename = config.pop_crds_uri(reference_uri)
     return crds.locate_file(basename, observatory)
 

--- a/src/stpipe/datamodel.py
+++ b/src/stpipe/datamodel.py
@@ -22,9 +22,11 @@ class AbstractDataModel(abc.ABC):
         """
         if cls is AbstractDataModel:
             mro = C.__mro__
-            if (any([hasattr(CC, "crds_observatory") for CC in mro]) and
-                any([hasattr(CC, "get_crds_parameters") for CC in mro]) and
-                any([hasattr(CC, "save") for CC in mro])):
+            if (
+                any([hasattr(CC, "crds_observatory") for CC in mro])
+                and any([hasattr(CC, "get_crds_parameters") for CC in mro])
+                and any([hasattr(CC, "save") for CC in mro])
+            ):
                 return True
         return False
 
@@ -33,7 +35,6 @@ class AbstractDataModel(abc.ABC):
     def crds_observatory(self):
         """This should return a string identifying the observatory as CRDS expects it"""
         pass
-
 
     @abc.abstractmethod
     def get_crds_parameters(self):

--- a/src/stpipe/datamodel.py
+++ b/src/stpipe/datamodel.py
@@ -1,5 +1,6 @@
 import abc
 
+
 class AbstractDataModel(abc.ABC):
     """
     This Abstract Base Class is intended to cover multiple implementations of

--- a/src/stpipe/entry_points.py
+++ b/src/stpipe/entry_points.py
@@ -1,8 +1,7 @@
-from collections import namedtuple
 import warnings
+from collections import namedtuple
 
 from importlib_metadata import entry_points
-
 
 STEPS_GROUP = "stpipe.steps"
 

--- a/src/stpipe/entry_points.py
+++ b/src/stpipe/entry_points.py
@@ -36,7 +36,7 @@ def get_steps():
         except Exception as e:
             warnings.warn(
                 f"{STEPS_GROUP} plugin from package {package_name}=={package_version} "
-                f"failed to load:\n\n"
+                "failed to load:\n\n"
                 f"{e.__class__.__name__}: {e}"
             )
 

--- a/src/stpipe/entry_points.py
+++ b/src/stpipe/entry_points.py
@@ -6,7 +6,10 @@ from importlib_metadata import entry_points
 STEPS_GROUP = "stpipe.steps"
 
 
-StepInfo = namedtuple("StepInfo", ["class_name", "class_alias", "is_pipeline", "package_name", "package_version"])
+StepInfo = namedtuple(
+    "StepInfo",
+    ["class_name", "class_alias", "is_pipeline", "package_name", "package_version"],
+)
 
 
 def get_steps():

--- a/src/stpipe/exceptions.py
+++ b/src/stpipe/exceptions.py
@@ -2,6 +2,7 @@ class StpipeException(Exception):
     """
     Base class for exceptions from the stpipe package.
     """
+
     pass
 
 
@@ -10,6 +11,7 @@ class StpipeExitException(StpipeException):
     An exception that carries an exit status that is
     returned by stpipe CLI tools.
     """
+
     def __init__(self, exit_status, *args):
         super().__init__(exit_status, *args)
         self._exit_status = exit_status

--- a/src/stpipe/format_template.py
+++ b/src/stpipe/format_template.py
@@ -175,7 +175,11 @@ class FormatTemplate(Formatter):
 
         # Get any unused arguments and simply do the appending
         unused_keys = set(formatted_kwargs).difference(self._used_keys)
-        unused_values = [formatted_kwargs[unused] for unused in unused_keys if formatted_kwargs[unused] is not None]
+        unused_values = [
+            formatted_kwargs[unused]
+            for unused in unused_keys
+            if formatted_kwargs[unused] is not None
+        ]
         result_parts = [result] + unused_values
         result = self.separator.join(result_parts)
 

--- a/src/stpipe/format_template.py
+++ b/src/stpipe/format_template.py
@@ -103,6 +103,7 @@ class FormatTemplate(Formatter):
     >>> fmt_preformat(template, name='fred', value='great')
     'name="fred" value="pre_great_format"'
     """
+
     def __init__(self, separator='_', key_formats=None, remove_unused=False):
         """Inialize class
 
@@ -149,7 +150,6 @@ class FormatTemplate(Formatter):
         for key, value in kwargs.items():
             if value is not None:
                 for key_format in self.key_formats[key]:
-
                     # Get the formatting type character. Indices are:
                     #  0: The first replacement field. There should only be one.
                     #  2: Get the format spec.
@@ -166,21 +166,17 @@ class FormatTemplate(Formatter):
                     raise RuntimeError(
                         'No suitable formatting for {key}: {value} found. Given formatting options:'
                         '\n\t{formats}'.format(
-                            key=key, value=value, formats=self.key_formats[key]
+                            key=key,
+                            value=value,
+                            formats=self.key_formats[key],
                         )
                     )
             formatted_kwargs[key] = value
-        result = super().format(
-            format_string, **formatted_kwargs
-        )
+        result = super().format(format_string, **formatted_kwargs)
 
         # Get any unused arguments and simply do the appending
         unused_keys = set(formatted_kwargs).difference(self._used_keys)
-        unused_values = [
-            formatted_kwargs[unused]
-            for unused in unused_keys
-            if formatted_kwargs[unused] is not None
-        ]
+        unused_values = [formatted_kwargs[unused] for unused in unused_keys if formatted_kwargs[unused] is not None]
         result_parts = [result] + unused_values
         result = self.separator.join(result_parts)
 

--- a/src/stpipe/format_template.py
+++ b/src/stpipe/format_template.py
@@ -164,8 +164,7 @@ class FormatTemplate(Formatter):
                         break
                 else:
                     raise RuntimeError(
-                        "No suitable formatting for {key}: {value} found. Given formatting options:"
-                        "\n\t{formats}".format(
+                        "No suitable formatting for {key}: {value} found. Given formatting options:\n\t{formats}".format(
                             key=key,
                             value=value,
                             formats=self.key_formats[key],

--- a/src/stpipe/format_template.py
+++ b/src/stpipe/format_template.py
@@ -164,7 +164,8 @@ class FormatTemplate(Formatter):
                         break
                 else:
                     raise RuntimeError(
-                        "No suitable formatting for {key}: {value} found. Given formatting options:\n\t{formats}".format(
+                        "No suitable formatting for {key}: {value} found. Given"
+                        " formatting options:\n\t{formats}".format(
                             key=key,
                             value=value,
                             formats=self.key_formats[key],

--- a/src/stpipe/format_template.py
+++ b/src/stpipe/format_template.py
@@ -5,26 +5,26 @@ Format template string allowing partial formatting.
 from collections import defaultdict
 from string import Formatter
 
-__all__ = ['FormatTemplate']
+__all__ = ["FormatTemplate"]
 
 
 # Define conversion based on format type
 CONVERSION = {
-    '%': float,
-    'b': int,
-    'c': int,
-    'd': int,
-    'e': float,
-    'E': float,
-    'f': float,
-    'F': float,
-    'g': float,
-    'G': float,
-    'n': int,
-    'o': int,
-    's': str,
-    'x': int,
-    'X': int,
+    "%": float,
+    "b": int,
+    "c": int,
+    "d": int,
+    "e": float,
+    "E": float,
+    "f": float,
+    "F": float,
+    "g": float,
+    "G": float,
+    "n": int,
+    "o": int,
+    "s": str,
+    "x": int,
+    "X": int,
 }
 
 
@@ -104,7 +104,7 @@ class FormatTemplate(Formatter):
     'name="fred" value="pre_great_format"'
     """
 
-    def __init__(self, separator='_', key_formats=None, remove_unused=False):
+    def __init__(self, separator="_", key_formats=None, remove_unused=False):
         """Inialize class
 
         Parameters
@@ -123,7 +123,7 @@ class FormatTemplate(Formatter):
         self.remove_unused = remove_unused
         self._used_keys = []
 
-        self.key_formats = defaultdict(lambda: ['{:s}'])
+        self.key_formats = defaultdict(lambda: ["{:s}"])
         if key_formats:
             self.key_formats.update(key_formats)
 
@@ -164,8 +164,8 @@ class FormatTemplate(Formatter):
                         break
                 else:
                     raise RuntimeError(
-                        'No suitable formatting for {key}: {value} found. Given formatting options:'
-                        '\n\t{formats}'.format(
+                        "No suitable formatting for {key}: {value} found. Given formatting options:"
+                        "\n\t{formats}".format(
                             key=key,
                             value=value,
                             formats=self.key_formats[key],
@@ -207,12 +207,12 @@ class FormatTemplate(Formatter):
             If not found, the string '{key}' is returned.
         """
         if self.remove_unused:
-            default = ''
+            default = ""
         else:
-            default = '{' + key + '}'
+            default = "{" + key + "}"
         value = kwargs.get(key, default)
         self._used_keys.append(key)
         if value is None:
-            value = ''
+            value = ""
 
         return value

--- a/src/stpipe/function_wrapper.py
+++ b/src/stpipe/function_wrapper.py
@@ -8,6 +8,7 @@ class FunctionWrapper(Step):
     """
     This Step wraps an ordinary Python function.
     """
+
     def __init__(self, func, *args):
         Step.__init__(self, func.__name__, *args)
 

--- a/src/stpipe/hooks.py
+++ b/src/stpipe/hooks.py
@@ -12,26 +12,23 @@ def hook_from_string(step, type, num, command):
 
     step_class = None
     try:
-        step_class = utilities.import_class(
-            command, Step, step.config_file)
+        step_class = utilities.import_class(command, Step, step.config_file)
     except Exception:
         pass
 
     if step_class is not None:
-        return step_class(
-            name, parent=step, config_file=step.config_file)
+        return step_class(name, parent=step, config_file=step.config_file)
 
     step_func = None
     try:
-        step_func = utilities.import_class(
-            command, types.FunctionType, step.config_file)
+        step_func = utilities.import_class(command, types.FunctionType, step.config_file)
     except Exception:
         pass
 
     if step_func is not None:
         from . import function_wrapper
-        return function_wrapper.FunctionWrapper(
-            step_func, parent=step, config_file=step.config_file)
+
+        return function_wrapper.FunctionWrapper(step_func, parent=step, config_file=step.config_file)
 
     from .subproc import SystemCall
 
@@ -39,5 +36,4 @@ def hook_from_string(step, type, num, command):
 
 
 def get_hook_objects(step, type, hooks):
-    return [hook_from_string(step, type, i, hook)
-            for i, hook in enumerate(hooks)]
+    return [hook_from_string(step, type, i, hook) for i, hook in enumerate(hooks)]

--- a/src/stpipe/hooks.py
+++ b/src/stpipe/hooks.py
@@ -21,14 +21,18 @@ def hook_from_string(step, type, num, command):
 
     step_func = None
     try:
-        step_func = utilities.import_class(command, types.FunctionType, step.config_file)
+        step_func = utilities.import_class(
+            command, types.FunctionType, step.config_file
+        )
     except Exception:
         pass
 
     if step_func is not None:
         from . import function_wrapper
 
-        return function_wrapper.FunctionWrapper(step_func, parent=step, config_file=step.config_file)
+        return function_wrapper.FunctionWrapper(
+            step_func, parent=step, config_file=step.config_file
+        )
 
     from .subproc import SystemCall
 

--- a/src/stpipe/hooks.py
+++ b/src/stpipe/hooks.py
@@ -8,7 +8,7 @@ from .step import Step
 
 
 def hook_from_string(step, type, num, command):
-    name = f'{type}_hook{num:d}'
+    name = f"{type}_hook{num:d}"
 
     step_class = None
     try:

--- a/src/stpipe/hooks.py
+++ b/src/stpipe/hooks.py
@@ -3,8 +3,9 @@ Pre- and post-hooks
 """
 import types
 
-from .step import Step
 from . import utilities
+from .step import Step
+
 
 def hook_from_string(step, type, num, command):
     name = f'{type}_hook{num:d}'

--- a/src/stpipe/integration.py
+++ b/src/stpipe/integration.py
@@ -5,10 +5,14 @@ import os
 
 from asdf.resource import DirectoryResourceMapping
 
-SCHEMAS_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "resources", "schemas"))
+SCHEMAS_PATH = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "resources", "schemas")
+)
 
 
 def get_resource_mappings():
     return [
-        DirectoryResourceMapping(SCHEMAS_PATH, "http://stsci.edu/schemas/stpipe/", recursive=True),
+        DirectoryResourceMapping(
+            SCHEMAS_PATH, "http://stsci.edu/schemas/stpipe/", recursive=True
+        ),
     ]

--- a/src/stpipe/integration.py
+++ b/src/stpipe/integration.py
@@ -5,9 +5,7 @@ import os
 
 from asdf.resource import DirectoryResourceMapping
 
-SCHEMAS_PATH = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), "resources", "schemas")
-)
+SCHEMAS_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "resources", "schemas"))
 
 
 def get_resource_mappings():

--- a/src/stpipe/integration.py
+++ b/src/stpipe/integration.py
@@ -5,7 +5,6 @@ import os
 
 from asdf.resource import DirectoryResourceMapping
 
-
 SCHEMAS_PATH = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "resources", "schemas")
 )

--- a/src/stpipe/log.py
+++ b/src/stpipe/log.py
@@ -151,7 +151,9 @@ class LogConfig:
 
         formatter = logging.Formatter(self.format)
         for handler in log.handlers:
-            if isinstance(handler, logging.Handler) and hasattr(handler, "_from_config"):
+            if isinstance(handler, logging.Handler) and hasattr(
+                handler, "_from_config"
+            ):
                 handler.setFormatter(formatter)
 
     def match_and_apply(self, log):
@@ -250,7 +252,9 @@ class DelegationHandler(logging.Handler):
 
     @log.setter
     def log(self, log):
-        assert log is None or (isinstance(log, logging.Logger) and log.name.startswith(STPIPE_ROOT_LOGGER))
+        assert log is None or (
+            isinstance(log, logging.Logger) and log.name.startswith(STPIPE_ROOT_LOGGER)
+        )
         self._logs[threading.current_thread()] = log
 
 

--- a/src/stpipe/log.py
+++ b/src/stpipe/log.py
@@ -1,18 +1,17 @@
 """
 Logging setup etc.
 """
-from contextlib import contextmanager
 import fnmatch
 import io
 import logging
 import os
 import sys
 import threading
-
-from .extern.configobj.configobj import ConfigObj
-from .extern.configobj import validate
+from contextlib import contextmanager
 
 from . import config_parser
+from .extern.configobj import validate
+from .extern.configobj.configobj import ConfigObj
 
 STPIPE_ROOT_LOGGER = 'stpipe'
 DEFAULT_FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'

--- a/src/stpipe/log.py
+++ b/src/stpipe/log.py
@@ -13,8 +13,8 @@ from . import config_parser
 from .extern.configobj import validate
 from .extern.configobj.configobj import ConfigObj
 
-STPIPE_ROOT_LOGGER = 'stpipe'
-DEFAULT_FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+STPIPE_ROOT_LOGGER = "stpipe"
+DEFAULT_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 DEFAULT_CONFIGURATION = b"""
 [*]
 handler = stderr
@@ -85,15 +85,15 @@ class LogConfig:
         break_level=logging.NOTSET,
         format=None,
     ):
-        if name in ('', '.', 'root'):
-            name = '*'
+        if name in ("", ".", "root"):
+            name = "*"
         self.name = name
         self.handler = handler
         if not isinstance(self.handler, list):
-            if self.handler.strip() == '':
+            if self.handler.strip() == "":
                 self.handler = []
             else:
-                self.handler = [x.strip() for x in self.handler.split(',')]
+                self.handler = [x.strip() for x in self.handler.split(",")]
         self.level = level
         self.break_level = break_level
         if format is None:
@@ -116,12 +116,12 @@ class LogConfig:
         Given a handler string, returns a `logging.Handler` object.
         """
         if handler_str.startswith("file:"):
-            return logging.FileHandler(handler_str[5:], 'w', 'utf-8', True)
+            return logging.FileHandler(handler_str[5:], "w", "utf-8", True)
         elif handler_str.startswith("append:"):
-            return logging.FileHandler(handler_str[7:], 'a', 'utf-8', True)
-        elif handler_str == 'stdout':
+            return logging.FileHandler(handler_str[7:], "a", "utf-8", True)
+        elif handler_str == "stdout":
             return logging.StreamHandler(sys.stdout)
-        elif handler_str == 'stderr':
+        elif handler_str == "stderr":
             return logging.StreamHandler(sys.stderr)
         else:
             raise ValueError(f"Can't parse handler {handler_str!r}")
@@ -132,7 +132,7 @@ class LogConfig:
         object.
         """
         for handler in log.handlers[:]:
-            if hasattr(handler, '_from_config'):
+            if hasattr(handler, "_from_config"):
                 log.handlers.remove(handler)
 
         # Set a handler
@@ -151,7 +151,7 @@ class LogConfig:
 
         formatter = logging.Formatter(self.format)
         for handler in log.handlers:
-            if isinstance(handler, logging.Handler) and hasattr(handler, '_from_config'):
+            if isinstance(handler, logging.Handler) and hasattr(handler, "_from_config"):
                 handler.setFormatter(formatter)
 
     def match_and_apply(self, log):
@@ -187,7 +187,7 @@ def load_configuration(config_file):
     spec = config_parser.load_spec_file(LogConfig)
     config = ConfigObj(config_file, raise_errors=True, interpolation=False)
     val = validate.Validator()
-    val.functions['level'] = _level_check
+    val.functions["level"] = _level_check
     config_parser.validate(config, spec, validator=val)
 
     log_config.clear()

--- a/src/stpipe/log.py
+++ b/src/stpipe/log.py
@@ -31,6 +31,7 @@ level = DEBUG
 ###########################################################################
 # LOGS AS EXCEPTIONS
 
+
 class LoggedException(Exception):
     """
     This is an exception used when a log record is converted into an
@@ -38,6 +39,7 @@ class LoggedException(Exception):
 
     Use its `record` member to get the original `logging.LogRecord`.
     """
+
     def __init__(self, record):
         self.record = record
         Exception.__init__(self, record.getMessage())
@@ -48,6 +50,7 @@ class BreakHandler(logging.Handler):
     A handler that turns logs of a certain severity or higher into
     exceptions.
     """
+
     _from_config = True
 
     def emit(self, record):
@@ -61,7 +64,7 @@ class BreakHandler(logging.Handler):
 log_config = {}
 
 
-class LogConfig():
+class LogConfig:
     """
     Stores a single logging configuration.
 
@@ -73,8 +76,15 @@ class LogConfig():
     handler, level, break_level, format : str
         See LogConfig.spec for a description of these values.
     """
-    def __init__(self, name, handler=None, level=logging.NOTSET,
-                 break_level=logging.NOTSET, format=None):
+
+    def __init__(
+        self,
+        name,
+        handler=None,
+        level=logging.NOTSET,
+        break_level=logging.NOTSET,
+        format=None,
+    ):
         if name in ('', '.', 'root'):
             name = '*'
         self.name = name
@@ -96,7 +106,7 @@ class LogConfig():
         configuration.
         """
         if log_name.startswith(STPIPE_ROOT_LOGGER):
-            log_name = log_name[len(STPIPE_ROOT_LOGGER) + 1:]
+            log_name = log_name[len(STPIPE_ROOT_LOGGER) + 1 :]
             if fnmatch.fnmatchcase(log_name, self.name):
                 return True
         return False
@@ -141,8 +151,7 @@ class LogConfig():
 
         formatter = logging.Formatter(self.format)
         for handler in log.handlers:
-            if (isinstance(handler, logging.Handler) and
-                hasattr(handler, '_from_config')):
+            if isinstance(handler, logging.Handler) and hasattr(handler, '_from_config'):
                 handler.setFormatter(formatter)
 
     def match_and_apply(self, log):
@@ -163,6 +172,7 @@ def load_configuration(config_file):
     ----------
     config_file : str or readable file-like object
     """
+
     def _level_check(value):
         try:
             value = int(value)
@@ -198,11 +208,7 @@ def getLogger(name=None):
 
 
 def _find_logging_config_file():
-    files = [
-        "stpipe-log.cfg",
-        "~/.stpipe-log.cfg",
-        "/etc/stpipe-log.cfg"
-        ]
+    files = ["stpipe-log.cfg", "~/.stpipe-log.cfg", "/etc/stpipe-log.cfg"]
 
     for file in files:
         file = os.path.expanduser(file)
@@ -227,14 +233,14 @@ class DelegationHandler(logging.Handler):
     different thread, we need to manage a dictionary mapping the
     current thread to the Step's logger on that thread.
     """
+
     def __init__(self, *args, **kwargs):
         self._logs = {}
         logging.Handler.__init__(self, *args, **kwargs)
 
     def emit(self, record):
         log = self.log
-        if (log is not None and
-            not record.name.startswith(STPIPE_ROOT_LOGGER)):
+        if log is not None and not record.name.startswith(STPIPE_ROOT_LOGGER):
             record.name = log.name
             log.handle(record)
 
@@ -244,9 +250,7 @@ class DelegationHandler(logging.Handler):
 
     @log.setter
     def log(self, log):
-        assert (log is None or
-                (isinstance(log, logging.Logger) and
-                 log.name.startswith(STPIPE_ROOT_LOGGER)))
+        assert log is None or (isinstance(log, logging.Logger) and log.name.startswith(STPIPE_ROOT_LOGGER))
         self._logs[threading.current_thread()] = log
 
 
@@ -254,6 +258,7 @@ class RecordingHandler(logging.Handler):
     """
     A handler that simply accumulates LogRecord instances.
     """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._log_records = []

--- a/src/stpipe/pipeline.py
+++ b/src/stpipe/pipeline.py
@@ -251,7 +251,7 @@ class Pipeline(Step):
             with self.open_model(input_file, asn_n_members=1, asn_exptypes=["science"]) as model:
                 self._precache_references_opened(model)
         except (ValueError, TypeError, OSError):
-            self.log.info(f"First argument {input_file} does not appear to be a " "model")
+            self.log.info(f"First argument {input_file} does not appear to be a model")
 
     def _precache_references_opened(self, model_or_container):
         """Pre-fetches references for `model_or_container`.

--- a/src/stpipe/pipeline.py
+++ b/src/stpipe/pipeline.py
@@ -3,13 +3,10 @@ Pipeline
 """
 from collections.abc import Sequence
 from os.path import dirname, join
-from .extern.configobj.configobj import Section, ConfigObj
 
-from . import config_parser
-from . import crds_client
-from . import log
-from .step import get_disable_crds_steppars, Step
-
+from . import config_parser, crds_client, log
+from .extern.configobj.configobj import ConfigObj, Section
+from .step import Step, get_disable_crds_steppars
 
 # For classmethods, the logger to use is the
 # delegator, since the pipeline has not yet been instantiated.

--- a/src/stpipe/pipeline.py
+++ b/src/stpipe/pipeline.py
@@ -88,7 +88,7 @@ class Pipeline(Step):
 
     @classmethod
     def merge_config(cls, config, config_file):
-        steps = config.get('steps', {})
+        steps = config.get("steps", {})
 
         # Configure all of the steps
         for key in cls.step_defs:
@@ -96,9 +96,9 @@ class Pipeline(Step):
             if cfg is not None:
                 # If a config_file is specified, load those values and
                 # then override them with our values.
-                if cfg.get('config_file'):
-                    cfg2 = config_parser.load_config_file(join(dirname(config_file or ''), cfg.get('config_file')))
-                    del cfg['config_file']
+                if cfg.get("config_file"):
+                    cfg2 = config_parser.load_config_file(join(dirname(config_file or ""), cfg.get("config_file")))
+                    del cfg["config_file"]
                     config_parser.merge_config(cfg2, cfg)
                     steps[key] = cfg2
         return config
@@ -107,8 +107,8 @@ class Pipeline(Step):
     def load_spec_file(cls, preserve_comments=False):
         spec = config_parser.get_merged_spec_file(cls, preserve_comments=preserve_comments)
 
-        spec['steps'] = Section(spec, spec.depth + 1, spec.main, name="steps")
-        steps = spec['steps']
+        spec["steps"] = Section(spec, spec.depth + 1, spec.main, name="steps")
+        steps = spec["steps"]
         for key, val in cls.step_defs.items():
             if not issubclass(val, Step):
                 raise TypeError(f"Entry {key!r} in step_defs is not a Step subclass")
@@ -119,10 +119,10 @@ class Pipeline(Step):
 
             # Also add a key that can be used to specify an external
             # config_file
-            step = spec['steps'][key]
-            step['config_file'] = 'string(default=None)'
-            step['name'] = "string(default='')"
-            step['class'] = "string(default='')"
+            step = spec["steps"][key]
+            step["config_file"] = "string(default=None)"
+            step["name"] = "string(default='')"
+            step["class"] = "string(default='')"
 
         return spec
 
@@ -155,16 +155,16 @@ class Pipeline(Step):
         """
         reftype = cls.get_config_reftype()
         refcfg = ConfigObj()
-        refcfg['steps'] = Section(refcfg, refcfg.depth + 1, refcfg.main, name="steps")
+        refcfg["steps"] = Section(refcfg, refcfg.depth + 1, refcfg.main, name="steps")
 
         # Check if retrieval should be attempted.
         if disable is None:
             disable = get_disable_crds_steppars()
         if disable:
-            logger.debug(f'{reftype.upper()}: CRDS parameter reference retrieval disabled.')
+            logger.debug(f"{reftype.upper()}: CRDS parameter reference retrieval disabled.")
             return refcfg
 
-        logger.debug('Retrieving all substep parameters from CRDS')
+        logger.debug("Retrieving all substep parameters from CRDS")
         #
         # Iterate over the steps in the pipeline
         with cls._datamodels_open(dataset, asn_n_members=1) as model:
@@ -177,13 +177,13 @@ class Pipeline(Step):
 
         for cal_step in cls.step_defs.keys():
             cal_step_class = cls.step_defs[cal_step]
-            refcfg['steps'][cal_step] = cal_step_class.get_config_from_reference(
+            refcfg["steps"][cal_step] = cal_step_class.get_config_from_reference(
                 crds_parameters,
                 crds_observatory=crds_observatory,
             )
         #
         # Now merge any config parameters from the step cfg file
-        logger.debug(f'Retrieving pipeline {reftype.upper()} parameters from CRDS')
+        logger.debug(f"Retrieving pipeline {reftype.upper()} parameters from CRDS")
         try:
             ref_file = crds_client.get_reference_file(
                 crds_parameters,
@@ -191,13 +191,13 @@ class Pipeline(Step):
                 crds_observatory,
             )
         except (AttributeError, crds_client.CrdsError):
-            logger.debug(f'{reftype.upper()}: No parameters found')
+            logger.debug(f"{reftype.upper()}: No parameters found")
         else:
-            if ref_file != 'N/A':
-                logger.info(f'{reftype.upper()} parameters found: {ref_file}')
+            if ref_file != "N/A":
+                logger.info(f"{reftype.upper()} parameters found: {ref_file}")
                 refcfg = cls.merge_pipeline_config(refcfg, ref_file)
             else:
-                logger.debug(f'No {reftype.upper()} reference files found.')
+                logger.debug(f"No {reftype.upper()} reference files found.")
 
         return refcfg
 
@@ -251,7 +251,7 @@ class Pipeline(Step):
             with self.open_model(input_file, asn_n_members=1, asn_exptypes=["science"]) as model:
                 self._precache_references_opened(model)
         except (ValueError, TypeError, OSError):
-            self.log.info(f'First argument {input_file} does not appear to be a ' 'model')
+            self.log.info(f"First argument {input_file} does not appear to be a " "model")
 
     def _precache_references_opened(self, model_or_container):
         """Pre-fetches references for `model_or_container`.
@@ -323,7 +323,7 @@ class Pipeline(Step):
             Keys are the parameters and values are the values.
         """
         pars = super().get_pars(full_spec=full_spec)
-        pars['steps'] = {}
+        pars["steps"] = {}
         for step_name, step_class in self.step_defs.items():
-            pars['steps'][step_name] = getattr(self, step_name).get_pars(full_spec=full_spec)
+            pars["steps"][step_name] = getattr(self, step_name).get_pars(full_spec=full_spec)
         return pars

--- a/src/stpipe/pipeline.py
+++ b/src/stpipe/pipeline.py
@@ -57,7 +57,11 @@ class Pipeline(Step):
         Overridden reftypes are included but handled normally later by the
         Pipeline version of the get_ref_override() method defined below.
         """
-        return [reftype for step in self._unskipped_steps for reftype in step.reference_file_types]
+        return [
+            reftype
+            for step in self._unskipped_steps
+            for reftype in step.reference_file_types
+        ]
 
     @property
     def _unskipped_steps(self):
@@ -68,7 +72,9 @@ class Pipeline(Step):
         return [
             getattr(self, name)
             for name in self.step_defs
-            if (not getattr(self, name).skip and getattr(self, name).prefetch_references)
+            if (
+                not getattr(self, name).skip and getattr(self, name).prefetch_references
+            )
         ]
 
     def get_ref_override(self, reference_file_type):
@@ -97,7 +103,9 @@ class Pipeline(Step):
                 # If a config_file is specified, load those values and
                 # then override them with our values.
                 if cfg.get("config_file"):
-                    cfg2 = config_parser.load_config_file(join(dirname(config_file or ""), cfg.get("config_file")))
+                    cfg2 = config_parser.load_config_file(
+                        join(dirname(config_file or ""), cfg.get("config_file"))
+                    )
                     del cfg["config_file"]
                     config_parser.merge_config(cfg2, cfg)
                     steps[key] = cfg2
@@ -105,7 +113,9 @@ class Pipeline(Step):
 
     @classmethod
     def load_spec_file(cls, preserve_comments=False):
-        spec = config_parser.get_merged_spec_file(cls, preserve_comments=preserve_comments)
+        spec = config_parser.get_merged_spec_file(
+            cls, preserve_comments=preserve_comments
+        )
 
         spec["steps"] = Section(spec, spec.depth + 1, spec.main, name="steps")
         steps = spec["steps"]
@@ -161,7 +171,9 @@ class Pipeline(Step):
         if disable is None:
             disable = get_disable_crds_steppars()
         if disable:
-            logger.debug(f"{reftype.upper()}: CRDS parameter reference retrieval disabled.")
+            logger.debug(
+                f"{reftype.upper()}: CRDS parameter reference retrieval disabled."
+            )
             return refcfg
 
         logger.debug("Retrieving all substep parameters from CRDS")
@@ -248,7 +260,9 @@ class Pipeline(Step):
         None
         """
         try:
-            with self.open_model(input_file, asn_n_members=1, asn_exptypes=["science"]) as model:
+            with self.open_model(
+                input_file, asn_n_members=1, asn_exptypes=["science"]
+            ) as model:
                 self._precache_references_opened(model)
         except (ValueError, TypeError, OSError):
             self.log.info(f"First argument {input_file} does not appear to be a model")
@@ -293,9 +307,14 @@ class Pipeline(Step):
         fetch_types = sorted(set(self.reference_file_types) - set(ovr_refs.keys()))
 
         self.log.info(
-            "Prefetching reference files for dataset: " + repr(model.meta.filename) + " reftypes = " + repr(fetch_types)
+            "Prefetching reference files for dataset: "
+            + repr(model.meta.filename)
+            + " reftypes = "
+            + repr(fetch_types)
         )
-        crds_refs = crds_client.get_multiple_reference_paths(model.get_crds_parameters(), fetch_types, model.crds_observatory)
+        crds_refs = crds_client.get_multiple_reference_paths(
+            model.get_crds_parameters(), fetch_types, model.crds_observatory
+        )
 
         ref_path_map = dict(list(crds_refs.items()) + list(ovr_refs.items()))
 
@@ -325,5 +344,7 @@ class Pipeline(Step):
         pars = super().get_pars(full_spec=full_spec)
         pars["steps"] = {}
         for step_name, step_class in self.step_defs.items():
-            pars["steps"][step_name] = getattr(self, step_name).get_pars(full_spec=full_spec)
+            pars["steps"][step_name] = getattr(self, step_name).get_pars(
+                full_spec=full_spec
+            )
         return pars

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -11,6 +11,7 @@ from os.path import abspath, basename, dirname, expanduser, expandvars, isfile, 
 
 try:
     from astropy.io import fits
+
     DISCOURAGED_TYPES = (fits.HDUList,)
 except ImportError:
     DISCOURAGED_TYPES = None
@@ -24,6 +25,7 @@ class Step:
     """
     Step
     """
+
     spec = """
     pre_hooks          = string_list(default=list())
     post_hooks         = string_list(default=list())
@@ -79,14 +81,12 @@ class Step:
 
     @classmethod
     def load_spec_file(cls, preserve_comments=False):
-        spec = config_parser.get_merged_spec_file(
-            cls, preserve_comments=preserve_comments)
+        spec = config_parser.get_merged_spec_file(cls, preserve_comments=preserve_comments)
         # Add arguments for all of the expected reference files
         for reference_file_type in cls.reference_file_types:
             override_name = crds_client.get_override_name(reference_file_type)
             spec[override_name] = 'is_string_or_datamodel(default=None)'
-            spec.inline_comments[override_name] = (
-                f'# Override the {reference_file_type} reference file')
+            spec.inline_comments[override_name] = f'# Override the {reference_file_type} reference file'
         return spec
 
     @classmethod
@@ -135,10 +135,18 @@ class Step:
             config_file = config_file.name
 
         step_class, name = cls._parse_class_and_name(
-            config, parent, name, config_file)
+            config,
+            parent,
+            name,
+            config_file,
+        )
 
         return step_class.from_config_section(
-            config, parent=parent, name=name, config_file=config_file)
+            config,
+            parent=parent,
+            name=name,
+            config_file=config_file,
+        )
 
     @staticmethod
     def from_cmdline(args):
@@ -166,13 +174,16 @@ class Step:
     @classmethod
     def _parse_class_and_name(cls, config, parent=None, name=None, config_file=None):
         if 'class' in config:
-            step_class = utilities.import_class(utilities.resolve_step_class_alias(config['class']),
-                                                config_file=config_file)
+            step_class = utilities.import_class(
+                utilities.resolve_step_class_alias(config['class']),
+                config_file=config_file,
+            )
             if not issubclass(step_class, cls):
                 raise TypeError(
                     "Configuration file does not match the "
                     "expected step class.  Expected {}, "
-                    "got {}".format(cls, step_class))
+                    "got {}".format(cls, step_class)
+                )
         else:
             step_class = cls
 
@@ -192,8 +203,13 @@ class Step:
         return step_class, name
 
     @classmethod
-    def from_config_section(cls, config, parent=None, name=None,
-                            config_file=None):
+    def from_config_section(
+        cls,
+        config,
+        parent=None,
+        name=None,
+        config_file=None,
+    ):
         """
         Create a step from a configuration file fragment.
 
@@ -237,8 +253,7 @@ class Step:
 
         spec = cls.load_spec_file()
         config = cls.merge_config(config, config_file)
-        config_parser.validate(
-            config, spec, root_dir=dirname(config_file or ''))
+        config_parser.validate(config, spec, root_dir=dirname(config_file or ''))
 
         if 'config_file' in config:
             del config['config_file']
@@ -261,12 +276,19 @@ class Step:
             parent=parent,
             config_file=config_file,
             _validate_kwds=False,
-            **kwargs)
+            **kwargs,
+        )
 
         return step
 
-    def __init__(self, name=None, parent=None, config_file=None,
-                 _validate_kwds=True, **kws):
+    def __init__(
+        self,
+        name=None,
+        parent=None,
+        config_file=None,
+        _validate_kwds=True,
+        **kws,
+    ):
         """
         Create a `Step` instance.
 
@@ -300,21 +322,22 @@ class Step:
         if _validate_kwds:
             spec = self.load_spec_file()
             kws = config_parser.config_from_dict(
-                kws, spec, root_dir=dirname(config_file or ''))
+                kws,
+                spec,
+                root_dir=dirname(config_file or ''),
+            )
 
         if name is None:
             name = self.__class__.__name__
         self.name = name
         if parent is None:
-            self.qualified_name = '.'.join([
-                log.STPIPE_ROOT_LOGGER, self.name])
+            self.qualified_name = '.'.join([log.STPIPE_ROOT_LOGGER, self.name])
         else:
-            self.qualified_name = '.'.join([
-                parent.qualified_name, self.name])
+            self.qualified_name = '.'.join([parent.qualified_name, self.name])
         self.parent = parent
 
         # Set the parameters as member variables
-        for (key, val) in kws.items():
+        for key, val in kws.items():
             setattr(self, key, val)
 
         # Create a new logger for this step
@@ -332,12 +355,9 @@ class Step:
         # Setup the hooks
         if len(self.pre_hooks) or len(self.post_hooks):
             from . import hooks
-            self._pre_hooks = hooks.get_hook_objects(
-                self, 'pre', self.pre_hooks
-            )
-            self._post_hooks = hooks.get_hook_objects(
-                self, 'post', self.post_hooks
-            )
+
+            self._pre_hooks = hooks.get_hook_objects(self, 'pre', self.pre_hooks)
+            self._post_hooks = hooks.get_hook_objects(self, 'post', self.post_hooks)
         else:
             self._pre_hooks = []
             self._post_hooks = []
@@ -351,9 +371,7 @@ class Step:
 
         for i, arg in enumerate(args):
             if isinstance(arg, discouraged_types):
-                self.log.error(
-                    "{} {} object.  Use an instance of AbstractDataModel instead.".format(
-                        msg, i))
+                self.log.error("{} {} object.  Use an instance of AbstractDataModel instead.".format(msg, i))
 
     @property
     def log_records(self):
@@ -383,13 +401,9 @@ class Step:
 
             step_result = None
 
-            self.log.info(
-                f'Step {self.name} running with args {args}.'
-            )
+            self.log.info(f'Step {self.name} running with args {args}.')
 
-            self.log.info(
-                f'Step {self.name} parameters are: {self.get_pars()}'
-            )
+            self.log.info(f'Step {self.name} parameters are: {self.get_pars()}')
 
             if len(args):
                 self.set_primary_input(args[0])
@@ -439,9 +453,7 @@ class Step:
                         step_result = self.process(*args)
                     except TypeError as e:
                         if "process() takes exactly" in str(e):
-                            raise TypeError(
-                                "Incorrect number of arguments to step"
-                            )
+                            raise TypeError("Incorrect number of arguments to step")
                         raise
 
                 # Warn if returning a discouraged object
@@ -469,7 +481,6 @@ class Step:
 
                 # Save the output file if one was specified
                 if not self.skip and self.save_results:
-
                     # Setup the save list.
                     if not isinstance(step_result, (list, tuple)):
                         results_to_save = [step_result]
@@ -485,22 +496,13 @@ class Step:
                             try:
                                 output_path = self.make_output_path(idx=idx, name_format=self.name_format)
                             except AttributeError:
-                                self.log.warning(
-                                    '`save_results` has been requested,'
-                                    ' but cannot determine filename.'
-                                )
-                                self.log.warning(
-                                    'Specify an output file with `--output_file`'
-                                    ' or set `--save_results=false`'
-                                )
+                                self.log.warning('`save_results` has been requested,' ' but cannot determine filename.')
+                                self.log.warning('Specify an output file with `--output_file`' ' or set `--save_results=false`')
                             else:
-                                self.log.info(
-                                    f'Saving file {output_path}'
-                                )
+                                self.log.info(f'Saving file {output_path}')
                                 result.save(output_path, overwrite=True)
 
-                self.log.info(
-                    f'Step {self.name} done')
+                self.log.info(f'Step {self.name} done')
             finally:
                 log.delegator.log = orig_log
 
@@ -606,14 +608,11 @@ class Step:
             try:
                 log.load_configuration(config['logcfg'])
             except Exception as e:
-                raise RuntimeError(
-                    f"Error parsing logging config {config['logcfg']}"
-                ) from e
+                raise RuntimeError(f"Error parsing logging config {config['logcfg']}") from e
             del config['logcfg']
 
         name = config.get('name', None)
-        instance = cls.from_config_section(config,
-            name=name, config_file=config_file)
+        instance = cls.from_config_section(config, name=name, config_file=config_file)
 
         return instance.run(*args)
 
@@ -629,12 +628,9 @@ class Step:
         """Create a default filename based on the input name"""
         output_file = input_file
         if output_file is None or not isinstance(output_file, str):
-                output_file = self.search_attr('_input_filename')
+            output_file = self.search_attr('_input_filename')
         if output_file is None:
-            output_file = 'step_{}{}'.format(
-                self.name,
-                self.output_ext
-            )
+            output_file = 'step_{}{}'.format(self.name, self.output_ext)
         return output_file
 
     def default_suffix(self):
@@ -662,9 +658,7 @@ class Step:
         """
         if parent_first:
             try:
-                value = self.parent.search_attr(
-                    attribute, parent_first=parent_first
-                )
+                value = self.parent.search_attr(attribute, parent_first=parent_first)
             except AttributeError:
                 value = None
             if value is None:
@@ -731,12 +725,10 @@ class Step:
         override = self.get_ref_override(reference_file_type)
         if override is not None:
             if isinstance(override, AbstractDataModel):
-                self._reference_files_used.append(
-                    (reference_file_type, override.override_handle))
+                self._reference_files_used.append((reference_file_type, override.override_handle))
                 return override
             elif override.strip() != "":
-                self._reference_files_used.append(
-                    (reference_file_type, basename(override)))
+                self._reference_files_used.append((reference_file_type, basename(override)))
                 reference_name = override
             else:
                 return ""
@@ -751,14 +743,11 @@ class Step:
                 hdr_name = "crds://" + basename(reference_name)
             else:
                 hdr_name = "N/A"
-            self._reference_files_used.append(
-                (reference_file_type, hdr_name))
+            self._reference_files_used.append((reference_file_type, hdr_name))
         return crds_client.check_reference_open(reference_name)
 
     @classmethod
-    def get_config_from_reference(cls, dataset,
-                                  disable=None,
-                                  crds_observatory=None):
+    def get_config_from_reference(cls, dataset, disable=None, crds_observatory=None):
         """Retrieve step parameters from reference database
 
         Parameters
@@ -817,9 +806,11 @@ class Step:
         # Retrieve step parameters from CRDS
         logger.debug(f'Retrieving step {reftype.upper()} parameters from CRDS')
         try:
-            ref_file = crds_client.get_reference_file(crds_parameters,
-                                                      reftype,
-                                                      crds_observatory)
+            ref_file = crds_client.get_reference_file(
+                crds_parameters,
+                reftype,
+                crds_observatory,
+            )
         except (AttributeError, crds_client.CrdsError):
             logger.debug(f'{reftype.upper()}: No parameters found')
             return config_parser.ConfigObj()
@@ -827,11 +818,7 @@ class Step:
             logger.info(f'{reftype.upper()} parameters found: {ref_file}')
             ref = config_parser.load_config_file(ref_file)
 
-            ref_pars = {
-                par: value
-                for par, value in ref.items()
-                if par not in ['class', 'name']
-            }
+            ref_pars = {par: value for par, value in ref.items() if par not in ['class', 'name']}
             logger.debug(f'{reftype.upper()} parameters retrieved from CRDS: {ref_pars}')
 
             return ref
@@ -870,10 +857,7 @@ class Step:
         """
         self._set_input_dir(obj, exclusive=exclusive)
 
-        err_message = (
-            'Cannot set master input file name from object'
-            ' {}'.format(obj)
-        )
+        err_message = 'Cannot set master input file name from object' ' {}'.format(obj)
         parent_input_filename = self.search_attr('_input_filename')
         if not exclusive or parent_input_filename is None:
             if isinstance(obj, str):
@@ -886,14 +870,16 @@ class Step:
             else:
                 self.log.debug(err_message)
 
-    def save_model(self,
-                   model,
-                   suffix=None,
-                   idx=None,
-                   output_file=None,
-                   force=False,
-                   format=None,
-                   **components):
+    def save_model(
+        self,
+        model,
+        suffix=None,
+        idx=None,
+        output_file=None,
+        force=False,
+        format=None,
+        **components,
+    ):
         """
         Saves the given model using the step/pipeline's naming scheme
 
@@ -935,9 +921,7 @@ class Step:
             output_file = self.output_file
 
         # Check if saving is even specified.
-        if not force and \
-           not self.save_results and \
-           not output_file:
+        if not force and not self.save_results and not output_file:
             return
 
         if isinstance(model, Sequence):
@@ -946,18 +930,15 @@ class Step:
                 suffix=suffix,
                 force=force,
                 format=format,
-                **components
+                **components,
             )
             output_path = model.save(
                 path=output_file,
-                save_model_func=save_model_func)
+                save_model_func=save_model_func,
+            )
         else:
-
             # Search for an output file name.
-            if (
-                    self.output_use_model or
-                    (output_file is None and not self.search_output_file)
-            ):
+            if self.output_use_model or (output_file is None and not self.search_output_file):
                 output_file = model.meta.filename
                 idx = None
             output_path = model.save(
@@ -966,7 +947,7 @@ class Step:
                     suffix=suffix,
                     idx=idx,
                     name_format=format,
-                    **components
+                    **components,
                 )
             )
             self.log.info(f'Saved model in {output_path}')
@@ -976,21 +957,19 @@ class Step:
     @property
     def make_output_path(self):
         """Return function that creates the output path"""
-        make_output_path = self.search_attr(
-            '_make_output_path'
-        )
+        make_output_path = self.search_attr('_make_output_path')
         return partial(make_output_path, self)
 
     @staticmethod
     def _make_output_path(
-            step,
-            basepath=None,
-            ext=None,
-            suffix=None,
-            name_format=None,
-            component_format='',
-            separator='_',
-            **components
+        step,
+        basepath=None,
+        ext=None,
+        suffix=None,
+        name_format=None,
+        component_format='',
+        separator='_',
+        **components,
     ):
         """Create the output path
 
@@ -1076,7 +1055,7 @@ class Step:
             separator = ''
         formatter = FormatTemplate(
             separator=separator,
-            remove_unused=True
+            remove_unused=True,
         )
 
         if len(components):
@@ -1090,7 +1069,7 @@ class Step:
             suffix=suffix,
             suffix_sep=suffix_sep,
             ext=ext,
-            components=component_str
+            components=component_str,
         )
 
         output_dir = step.search_attr('output_dir', default='')
@@ -1126,10 +1105,7 @@ class Step:
                 if hasattr(item, 'close'):
                     item.close()
             except Exception as exception:
-                self.log.debug(
-                    'Could not close "{}"'
-                    'Reason:\n{}'.format(item, exception)
-                )
+                self.log.debug('Could not close "{}"' 'Reason:\n{}'.format(item, exception))
         for item in to_del:
             try:
                 del item
@@ -1195,7 +1171,6 @@ class Step:
                 full_path = join(self.input_dir, file_name)
 
         return full_path
-
 
     def _set_input_dir(self, input, exclusive=True):
         """Set the input directory
@@ -1370,7 +1345,7 @@ class Step:
                 else:
                     steps[step] = pars
 
-            kwargs = {k : v for k, v in kwargs.items() if k != 'steps'}
+            kwargs = {k: v for k, v in kwargs.items() if k != 'steps'}
             if steps:
                 kwargs['steps'] = steps
 
@@ -1383,6 +1358,7 @@ class Step:
 # #########
 # Utilities
 # #########
+
 
 def _get_suffix(suffix, step=None, default_suffix=None):
     """Retrieve either specified or pipeline-supplied suffix
@@ -1429,7 +1405,7 @@ def get_disable_crds_steppars(default=None):
     flag: bool
         True to disable CRDS STEPPARS retrieval.
     """
-    truths =  ('true', 'True', 't', 'yes', 'y')
+    truths = ('true', 'True', 't', 'yes', 'y')
     if default:
         if isinstance(default, bool):
             return default

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -179,11 +179,7 @@ class Step:
                 config_file=config_file,
             )
             if not issubclass(step_class, cls):
-                raise TypeError(
-                    "Configuration file does not match the "
-                    "expected step class.  Expected {}, "
-                    "got {}".format(cls, step_class)
-                )
+                raise TypeError(f"Configuration file does not match the expected step class.  Expected {cls}, got {step_class}")
         else:
             step_class = cls
 
@@ -496,8 +492,8 @@ class Step:
                             try:
                                 output_path = self.make_output_path(idx=idx, name_format=self.name_format)
                             except AttributeError:
-                                self.log.warning("`save_results` has been requested," " but cannot determine filename.")
-                                self.log.warning("Specify an output file with `--output_file`" " or set `--save_results=false`")
+                                self.log.warning("`save_results` has been requested, but cannot determine filename.")
+                                self.log.warning("Specify an output file with `--output_file` or set `--save_results=false`")
                             else:
                                 self.log.info(f"Saving file {output_path}")
                                 result.save(output_path, overwrite=True)
@@ -857,7 +853,7 @@ class Step:
         """
         self._set_input_dir(obj, exclusive=exclusive)
 
-        err_message = "Cannot set master input file name from object" " {}".format(obj)
+        err_message = f"Cannot set master input file name from object {obj}"
         parent_input_filename = self.search_attr("_input_filename")
         if not exclusive or parent_input_filename is None:
             if isinstance(obj, str):
@@ -1105,7 +1101,7 @@ class Step:
                 if hasattr(item, "close"):
                     item.close()
             except Exception as exception:
-                self.log.debug('Could not close "{}"' "Reason:\n{}".format(item, exception))
+                self.log.debug(f'Could not close "{item}"Reason:\n{exception}')
         for item in to_del:
             try:
                 del item

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -1,23 +1,13 @@
 """
 Step
 """
+import gc
+import os
+import sys
 from collections.abc import Sequence
 from contextlib import contextmanager
 from functools import partial
-import gc
-import os
-from os.path import (
-    abspath,
-    basename,
-    dirname,
-    expanduser,
-    expandvars,
-    isfile,
-    join,
-    split,
-    splitext,
-)
-import sys
+from os.path import abspath, basename, dirname, expanduser, expandvars, isfile, join, split, splitext
 
 try:
     from astropy.io import fits
@@ -25,11 +15,7 @@ try:
 except ImportError:
     DISCOURAGED_TYPES = None
 
-from . import config
-from . import config_parser
-from . import crds_client
-from . import log
-from . import utilities
+from . import config, config_parser, crds_client, log, utilities
 from .datamodel import AbstractDataModel
 from .format_template import FormatTemplate
 

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -49,7 +49,7 @@ class Step:
     suffix             = string(default=None)        # Default suffix for output files
     search_output_file = boolean(default=True)       # Use outputfile define in parent step
     input_dir          = string(default=None)        # Input directory
-    """
+    """  # noqa: E501
     # Nickname used to refer to this class in lieu of the fully-qualified class
     # name.  Must be globally unique!
     class_alias = None
@@ -194,7 +194,8 @@ class Step:
             )
             if not issubclass(step_class, cls):
                 raise TypeError(
-                    f"Configuration file does not match the expected step class.  Expected {cls}, got {step_class}"
+                    "Configuration file does not match the expected step class. "
+                    f" Expected {cls}, got {step_class}"
                 )
         else:
             step_class = cls
@@ -456,7 +457,8 @@ class Step:
                                         ] = "SKIPPED"
                                     except AttributeError as e:
                                         self.log.info(
-                                            f"Could not record skip into DataModel header: {e}"
+                                            "Could not record skip into DataModel"
+                                            f" header: {e}"
                                         )
                             elif isinstance(args[0], AbstractDataModel):
                                 try:
@@ -465,7 +467,8 @@ class Step:
                                     ] = "SKIPPED"
                                 except AttributeError as e:
                                     self.log.info(
-                                        f"Could not record skip into DataModel header: {e}"
+                                        "Could not record skip into DataModel"
+                                        f" header: {e}"
                                     )
                     step_result = args[0]
                 else:
@@ -521,10 +524,12 @@ class Step:
                                 )
                             except AttributeError:
                                 self.log.warning(
-                                    "`save_results` has been requested, but cannot determine filename."
+                                    "`save_results` has been requested, but cannot"
+                                    " determine filename."
                                 )
                                 self.log.warning(
-                                    "Specify an output file with `--output_file` or set `--save_results=false`"
+                                    "Specify an output file with `--output_file` or set"
+                                    " `--save_results=false`"
                                 )
                             else:
                                 self.log.info(f"Saving file {output_path}")

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -85,8 +85,8 @@ class Step:
         # Add arguments for all of the expected reference files
         for reference_file_type in cls.reference_file_types:
             override_name = crds_client.get_override_name(reference_file_type)
-            spec[override_name] = 'is_string_or_datamodel(default=None)'
-            spec.inline_comments[override_name] = f'# Override the {reference_file_type} reference file'
+            spec[override_name] = "is_string_or_datamodel(default=None)"
+            spec.inline_comments[override_name] = f"# Override the {reference_file_type} reference file"
         return spec
 
     @classmethod
@@ -131,7 +131,7 @@ class Step:
         config = config_parser.load_config_file(config_file)
 
         # If a file object was passed in, pass the file name along
-        if hasattr(config_file, 'name'):
+        if hasattr(config_file, "name"):
             config_file = config_file.name
 
         step_class, name = cls._parse_class_and_name(
@@ -173,9 +173,9 @@ class Step:
 
     @classmethod
     def _parse_class_and_name(cls, config, parent=None, name=None, config_file=None):
-        if 'class' in config:
+        if "class" in config:
             step_class = utilities.import_class(
-                utilities.resolve_step_class_alias(config['class']),
+                utilities.resolve_step_class_alias(config["class"]),
                 config_file=config_file,
             )
             if not issubclass(step_class, cls):
@@ -188,17 +188,17 @@ class Step:
             step_class = cls
 
         if not name:
-            name = config.get('name')
+            name = config.get("name")
             if not name:
                 if isinstance(config_file, str):
                     name = splitext(basename(config_file))[0]
                 else:
                     name = step_class.__name__
 
-        if 'name' in config:
-            del config['name']
-        if 'class' in config:
-            del config['class']
+        if "name" in config:
+            del config["name"]
+        if "class" in config:
+            del config["class"]
 
         return step_class, name
 
@@ -239,26 +239,26 @@ class Step:
             set as member variables on the returned `Step` instance.
         """
         if not name:
-            if config.get('name'):
-                name = config['name']
+            if config.get("name"):
+                name = config["name"]
             else:
                 name = cls.__name__
 
-        if 'name' in config:
-            del config['name']
-        if 'class' in config:
-            del config['class']
-        if 'config_file' in config:
-            del config['config_file']
+        if "name" in config:
+            del config["name"]
+        if "class" in config:
+            del config["class"]
+        if "config_file" in config:
+            del config["config_file"]
 
         spec = cls.load_spec_file()
         config = cls.merge_config(config, config_file)
-        config_parser.validate(config, spec, root_dir=dirname(config_file or ''))
+        config_parser.validate(config, spec, root_dir=dirname(config_file or ""))
 
-        if 'config_file' in config:
-            del config['config_file']
-        if 'name' in config:
-            del config['name']
+        if "config_file" in config:
+            del config["config_file"]
+        if "name" in config:
+            del config["name"]
 
         # cmdline.FromCommandLine instances should not be passed to
         # steps. Instead, convert them back to strings.
@@ -324,16 +324,16 @@ class Step:
             kws = config_parser.config_from_dict(
                 kws,
                 spec,
-                root_dir=dirname(config_file or ''),
+                root_dir=dirname(config_file or ""),
             )
 
         if name is None:
             name = self.__class__.__name__
         self.name = name
         if parent is None:
-            self.qualified_name = '.'.join([log.STPIPE_ROOT_LOGGER, self.name])
+            self.qualified_name = ".".join([log.STPIPE_ROOT_LOGGER, self.name])
         else:
-            self.qualified_name = '.'.join([parent.qualified_name, self.name])
+            self.qualified_name = ".".join([parent.qualified_name, self.name])
         self.parent = parent
 
         # Set the parameters as member variables
@@ -346,7 +346,7 @@ class Step:
         self.log.setLevel(log.logging.DEBUG)
 
         # Log the fact that we have been init-ed.
-        self.log.info(f'{self.__class__.__name__} instance created.')
+        self.log.info(f"{self.__class__.__name__} instance created.")
 
         # Store the config file path so config filenames can be resolved
         # against it.
@@ -356,8 +356,8 @@ class Step:
         if len(self.pre_hooks) or len(self.post_hooks):
             from . import hooks
 
-            self._pre_hooks = hooks.get_hook_objects(self, 'pre', self.pre_hooks)
-            self._post_hooks = hooks.get_hook_objects(self, 'post', self.post_hooks)
+            self._pre_hooks = hooks.get_hook_objects(self, "pre", self.pre_hooks)
+            self._post_hooks = hooks.get_hook_objects(self, "post", self.post_hooks)
         else:
             self._pre_hooks = []
             self._post_hooks = []
@@ -371,7 +371,7 @@ class Step:
 
         for i, arg in enumerate(args):
             if isinstance(arg, discouraged_types):
-                self.log.error("{} {} object.  Use an instance of AbstractDataModel instead.".format(msg, i))
+                self.log.error(f"{msg} {i} object.  Use an instance of AbstractDataModel instead.")
 
     @property
     def log_records(self):
@@ -401,9 +401,9 @@ class Step:
 
             step_result = None
 
-            self.log.info(f'Step {self.name} running with args {args}.')
+            self.log.info(f"Step {self.name} running with args {args}.")
 
-            self.log.info(f'Step {self.name} parameters are: {self.get_pars()}')
+            self.log.info(f"Step {self.name} parameters are: {self.get_pars()}")
 
             if len(args):
                 self.set_primary_input(args[0])
@@ -431,18 +431,18 @@ class Step:
 
                 # Run the Step-specific code.
                 if self.skip:
-                    self.log.info('Step skipped.')
+                    self.log.info("Step skipped.")
                     if isinstance(args[0], AbstractDataModel):
                         if self.class_alias is not None:
                             if isinstance(args[0], Sequence):
                                 for model in args[0]:
                                     try:
-                                        model[f"meta.cal_step.{self.class_alias}"] = 'SKIPPED'
+                                        model[f"meta.cal_step.{self.class_alias}"] = "SKIPPED"
                                     except AttributeError as e:
                                         self.log.info(f"Could not record skip into DataModel header: {e}")
                             elif isinstance(args[0], AbstractDataModel):
                                 try:
-                                    args[0][f"meta.cal_step.{self.class_alias}"] = 'SKIPPED'
+                                    args[0][f"meta.cal_step.{self.class_alias}"] = "SKIPPED"
                                 except AttributeError as e:
                                     self.log.info(f"Could not record skip into DataModel header: {e}")
                     step_result = args[0]
@@ -492,17 +492,17 @@ class Step:
                             idx = None
                         if isinstance(result, AbstractDataModel):
                             self.save_model(result, idx=idx, format=self.name_format)
-                        elif hasattr(result, 'save'):
+                        elif hasattr(result, "save"):
                             try:
                                 output_path = self.make_output_path(idx=idx, name_format=self.name_format)
                             except AttributeError:
-                                self.log.warning('`save_results` has been requested,' ' but cannot determine filename.')
-                                self.log.warning('Specify an output file with `--output_file`' ' or set `--save_results=false`')
+                                self.log.warning("`save_results` has been requested," " but cannot determine filename.")
+                                self.log.warning("Specify an output file with `--output_file`" " or set `--save_results=false`")
                             else:
-                                self.log.info(f'Saving file {output_path}')
+                                self.log.info(f"Saving file {output_path}")
                                 result.save(output_path, overwrite=True)
 
-                self.log.info(f'Step {self.name} done')
+                self.log.info(f"Step {self.name} done")
             finally:
                 log.delegator.log = orig_log
 
@@ -561,14 +561,14 @@ class Step:
         override this method. The default behaviour is to raise a
         NotImplementedError exception.
         """
-        raise NotImplementedError('Steps have to override process().')
+        raise NotImplementedError("Steps have to override process().")
 
     def resolve_file_name(self, file_name):
         """
         Resolve a file name expressed relative to this Step's
         configuration file.
         """
-        return join(dirname(self.config_file or ''), file_name)
+        return join(dirname(self.config_file or ""), file_name)
 
     @classmethod
     def call(cls, *args, **kwargs):
@@ -601,24 +601,24 @@ class Step:
             filename = args[0]
         config, config_file = cls.build_config(filename, **kwargs)
 
-        if 'class' in config:
-            del config['class']
+        if "class" in config:
+            del config["class"]
 
-        if 'logcfg' in config:
+        if "logcfg" in config:
             try:
-                log.load_configuration(config['logcfg'])
+                log.load_configuration(config["logcfg"])
             except Exception as e:
                 raise RuntimeError(f"Error parsing logging config {config['logcfg']}") from e
-            del config['logcfg']
+            del config["logcfg"]
 
-        name = config.get('name', None)
+        name = config.get("name", None)
         instance = cls.from_config_section(config, name=name, config_file=config_file)
 
         return instance.run(*args)
 
     @property
     def input_dir(self):
-        return self.search_attr('_input_dir', '')
+        return self.search_attr("_input_dir", "")
 
     @input_dir.setter
     def input_dir(self, input_dir):
@@ -628,9 +628,9 @@ class Step:
         """Create a default filename based on the input name"""
         output_file = input_file
         if output_file is None or not isinstance(output_file, str):
-            output_file = self.search_attr('_input_filename')
+            output_file = self.search_attr("_input_filename")
         if output_file is None:
-            output_file = 'step_{}{}'.format(self.name, self.output_ext)
+            output_file = f"step_{self.name}{self.output_ext}"
         return output_file
 
     def default_suffix(self):
@@ -697,7 +697,7 @@ class Step:
         if isinstance(path, AbstractDataModel):
             return path
         else:
-            return abspath(path) if path and path != 'N/A' else path
+            return abspath(path) if path and path != "N/A" else path
 
     def get_reference_file(self, input_file, reference_file_type):
         """
@@ -793,18 +793,18 @@ class Step:
                 crds_parameters = model.get_crds_parameters()
                 crds_observatory = model.crds_observatory
             except (OSError, TypeError, ValueError):
-                logger.warning('Input dataset is not an instance of AbstractDataModel.')
+                logger.warning("Input dataset is not an instance of AbstractDataModel.")
                 disable = True
 
         # Check if retrieval should be attempted.
         if disable is None:
             disable = get_disable_crds_steppars()
         if disable:
-            logger.info(f'{reftype.upper()}: CRDS parameter reference retrieval disabled.')
+            logger.info(f"{reftype.upper()}: CRDS parameter reference retrieval disabled.")
             return config_parser.ConfigObj()
 
         # Retrieve step parameters from CRDS
-        logger.debug(f'Retrieving step {reftype.upper()} parameters from CRDS')
+        logger.debug(f"Retrieving step {reftype.upper()} parameters from CRDS")
         try:
             ref_file = crds_client.get_reference_file(
                 crds_parameters,
@@ -812,18 +812,18 @@ class Step:
                 crds_observatory,
             )
         except (AttributeError, crds_client.CrdsError):
-            logger.debug(f'{reftype.upper()}: No parameters found')
+            logger.debug(f"{reftype.upper()}: No parameters found")
             return config_parser.ConfigObj()
-        if ref_file != 'N/A':
-            logger.info(f'{reftype.upper()} parameters found: {ref_file}')
+        if ref_file != "N/A":
+            logger.info(f"{reftype.upper()} parameters found: {ref_file}")
             ref = config_parser.load_config_file(ref_file)
 
-            ref_pars = {par: value for par, value in ref.items() if par not in ['class', 'name']}
-            logger.debug(f'{reftype.upper()} parameters retrieved from CRDS: {ref_pars}')
+            ref_pars = {par: value for par, value in ref.items() if par not in ["class", "name"]}
+            logger.debug(f"{reftype.upper()} parameters retrieved from CRDS: {ref_pars}")
 
             return ref
         else:
-            logger.debug(f'No {reftype.upper()} reference files found.')
+            logger.debug(f"No {reftype.upper()} reference files found.")
             return config_parser.ConfigObj()
 
     @classmethod
@@ -857,8 +857,8 @@ class Step:
         """
         self._set_input_dir(obj, exclusive=exclusive)
 
-        err_message = 'Cannot set master input file name from object' ' {}'.format(obj)
-        parent_input_filename = self.search_attr('_input_filename')
+        err_message = "Cannot set master input file name from object" " {}".format(obj)
+        parent_input_filename = self.search_attr("_input_filename")
         if not exclusive or parent_input_filename is None:
             if isinstance(obj, str):
                 self._input_filename = obj
@@ -917,7 +917,7 @@ class Step:
         output_paths : [str[, ...]]
             List of output file paths the model(s) were saved in.
         """
-        if output_file is None or output_file == '':
+        if output_file is None or output_file == "":
             output_file = self.output_file
 
         # Check if saving is even specified.
@@ -950,14 +950,14 @@ class Step:
                     **components,
                 )
             )
-            self.log.info(f'Saved model in {output_path}')
+            self.log.info(f"Saved model in {output_path}")
 
         return output_path
 
     @property
     def make_output_path(self):
         """Return function that creates the output path"""
-        make_output_path = self.search_attr('_make_output_path')
+        make_output_path = self.search_attr("_make_output_path")
         return partial(make_output_path, self)
 
     @staticmethod
@@ -967,8 +967,8 @@ class Step:
         ext=None,
         suffix=None,
         name_format=None,
-        component_format='',
-        separator='_',
+        component_format="",
+        separator="_",
         **components,
     ):
         """Create the output path
@@ -1018,7 +1018,7 @@ class Step:
         string.
         """
         if basepath is None and step.search_output_file:
-            basepath = step.search_attr('output_file')
+            basepath = step.search_attr("output_file")
         if basepath is None:
             basepath = step.default_output_file()
 
@@ -1027,21 +1027,21 @@ class Step:
             ext = step.output_ext
         if ext is None and len(basepath_ext):
             ext = basepath_ext
-        if ext.startswith('.'):
+        if ext.startswith("."):
             ext = ext[1:]
 
         # Suffix check. An explicit check on `False` is necessary
         # because `None` is also allowed.
         suffix = _get_suffix(suffix, step=step)
         if suffix is not False:
-            default_name_format = '{basename}{components}{suffix_sep}{suffix}.{ext}'
+            default_name_format = "{basename}{components}{suffix_sep}{suffix}.{ext}"
             suffix_sep = None
             if suffix is not None:
                 basename, suffix_sep = step.remove_suffix(basename)
             if suffix_sep is None:
                 suffix_sep = separator
         else:
-            default_name_format = '{basename}{components}.{ext}'
+            default_name_format = "{basename}{components}.{ext}"
             suffix = None
             suffix_sep = None
 
@@ -1049,10 +1049,10 @@ class Step:
         if name_format is None:
             name_format = default_name_format
         elif not name_format:
-            name_format = basename + '.{ext}'
-            basename = ''
-            suffix_sep = ''
-            separator = ''
+            name_format = basename + ".{ext}"
+            basename = ""
+            suffix_sep = ""
+            separator = ""
         formatter = FormatTemplate(
             separator=separator,
             remove_unused=True,
@@ -1061,7 +1061,7 @@ class Step:
         if len(components):
             component_str = formatter(component_format, **components)
         else:
-            component_str = ''
+            component_str = ""
 
         basename = formatter(
             name_format,
@@ -1072,7 +1072,7 @@ class Step:
             components=component_str,
         )
 
-        output_dir = step.search_attr('output_dir', default='')
+        output_dir = step.search_attr("output_dir", default="")
         output_dir = expandvars(expanduser(output_dir))
         full_output_path = join(output_dir, basename)
 
@@ -1102,10 +1102,10 @@ class Step:
         to_del += to_close
         for item in to_close:
             try:
-                if hasattr(item, 'close'):
+                if hasattr(item, "close"):
                     item.close()
             except Exception as exception:
-                self.log.debug('Could not close "{}"' 'Reason:\n{}'.format(item, exception))
+                self.log.debug('Could not close "{}"' "Reason:\n{}".format(item, exception))
         for item in to_del:
             try:
                 del item
@@ -1188,7 +1188,7 @@ class Step:
             defined by a parent Step. Otherwise, always set.
 
         """
-        if not exclusive or self.search_attr('_input_dir') is None:
+        if not exclusive or self.search_attr("_input_dir") is None:
             try:
                 if isfile(input):
                     self.input_dir = split(input)[0]
@@ -1273,13 +1273,13 @@ class Step:
         existing = self.get_pars().keys()
         for parameter, value in parameters.items():
             if parameter in existing:
-                if parameter != 'steps':
+                if parameter != "steps":
                     setattr(self, parameter, value)
                 else:
                     for step_name, step_parameters in value.items():
                         getattr(self, step_name).update_pars(step_parameters)
             else:
-                self.log.debug(f'Parameter {parameter} is not valid for step {self}. Ignoring.')
+                self.log.debug(f"Parameter {parameter} is not valid for step {self}. Ignoring.")
 
     @classmethod
     def build_config(cls, input, **kwargs):
@@ -1312,42 +1312,42 @@ class Step:
             log_cls.info("No filename given, cannot retrieve config from CRDS")
             config = config_parser.ConfigObj()
 
-        if 'config_file' in kwargs:
-            config_file = kwargs['config_file']
-            del kwargs['config_file']
+        if "config_file" in kwargs:
+            config_file = kwargs["config_file"]
+            del kwargs["config_file"]
             config_from_file = config_parser.load_config_file(config_file)
             config_parser.merge_config(config, config_from_file)
             config_dir = os.path.dirname(config_file)
         else:
             config_file = None
-            config_dir = ''
+            config_dir = ""
 
         config_kwargs = config_parser.ConfigObj()
 
         # load and merge configuration files for each step they are provided:
         steps = {}
-        if 'steps' in kwargs:
-            for step, pars in kwargs['steps'].items():
-                if 'config_file' in pars:
-                    step_config_file = os.path.join(config_dir, pars['config_file'])
+        if "steps" in kwargs:
+            for step, pars in kwargs["steps"].items():
+                if "config_file" in pars:
+                    step_config_file = os.path.join(config_dir, pars["config_file"])
                     cfgd = config_parser.load_config_file(step_config_file)
-                    if 'name' in cfgd:
-                        if cfgd['name'] != step:
+                    if "name" in cfgd:
+                        if cfgd["name"] != step:
                             raise ValueError(
                                 "Step name from configuration file "
                                 f"'{step_config_file}' does not match step "
                                 "name in the 'steps' argument."
                             )
-                        del cfgd['name']
-                    cfgd.pop('class', None)
+                        del cfgd["name"]
+                    cfgd.pop("class", None)
                     cfgd.update(pars)
                     steps[step] = cfgd
                 else:
                     steps[step] = pars
 
-            kwargs = {k: v for k, v in kwargs.items() if k != 'steps'}
+            kwargs = {k: v for k, v in kwargs.items() if k != "steps"}
             if steps:
-                kwargs['steps'] = steps
+                kwargs["steps"] = steps
 
         config_parser.merge_config(config_kwargs, kwargs)
         config_parser.merge_config(config, config_kwargs)
@@ -1381,7 +1381,7 @@ def _get_suffix(suffix, step=None, default_suffix=None):
         Suffix to use
     """
     if suffix is None and step is not None:
-        suffix = step.search_attr('suffix')
+        suffix = step.search_attr("suffix")
     if suffix is None:
         suffix = default_suffix
     if suffix is None and step is not None:
@@ -1405,15 +1405,15 @@ def get_disable_crds_steppars(default=None):
     flag: bool
         True to disable CRDS STEPPARS retrieval.
     """
-    truths = ('true', 'True', 't', 'yes', 'y')
+    truths = ("true", "True", "t", "yes", "y")
     if default:
         if isinstance(default, bool):
             return default
         elif isinstance(default, str):
             return default in truths
-        raise ValueError(f'default must be string or boolean: {default}')
+        raise ValueError(f"default must be string or boolean: {default}")
 
-    flag = os.environ.get('STPIPE_DISABLE_CRDS_STEPPARS', '')
+    flag = os.environ.get("STPIPE_DISABLE_CRDS_STEPPARS", "")
     return flag in truths
 
 

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -7,7 +7,17 @@ import sys
 from collections.abc import Sequence
 from contextlib import contextmanager
 from functools import partial
-from os.path import abspath, basename, dirname, expanduser, expandvars, isfile, join, split, splitext
+from os.path import (
+    abspath,
+    basename,
+    dirname,
+    expanduser,
+    expandvars,
+    isfile,
+    join,
+    split,
+    splitext,
+)
 
 try:
     from astropy.io import fits
@@ -81,12 +91,16 @@ class Step:
 
     @classmethod
     def load_spec_file(cls, preserve_comments=False):
-        spec = config_parser.get_merged_spec_file(cls, preserve_comments=preserve_comments)
+        spec = config_parser.get_merged_spec_file(
+            cls, preserve_comments=preserve_comments
+        )
         # Add arguments for all of the expected reference files
         for reference_file_type in cls.reference_file_types:
             override_name = crds_client.get_override_name(reference_file_type)
             spec[override_name] = "is_string_or_datamodel(default=None)"
-            spec.inline_comments[override_name] = f"# Override the {reference_file_type} reference file"
+            spec.inline_comments[
+                override_name
+            ] = f"# Override the {reference_file_type} reference file"
         return spec
 
     @classmethod
@@ -179,7 +193,9 @@ class Step:
                 config_file=config_file,
             )
             if not issubclass(step_class, cls):
-                raise TypeError(f"Configuration file does not match the expected step class.  Expected {cls}, got {step_class}")
+                raise TypeError(
+                    f"Configuration file does not match the expected step class.  Expected {cls}, got {step_class}"
+                )
         else:
             step_class = cls
 
@@ -367,7 +383,9 @@ class Step:
 
         for i, arg in enumerate(args):
             if isinstance(arg, discouraged_types):
-                self.log.error(f"{msg} {i} object.  Use an instance of AbstractDataModel instead.")
+                self.log.error(
+                    f"{msg} {i} object.  Use an instance of AbstractDataModel instead."
+                )
 
     @property
     def log_records(self):
@@ -433,14 +451,22 @@ class Step:
                             if isinstance(args[0], Sequence):
                                 for model in args[0]:
                                     try:
-                                        model[f"meta.cal_step.{self.class_alias}"] = "SKIPPED"
+                                        model[
+                                            f"meta.cal_step.{self.class_alias}"
+                                        ] = "SKIPPED"
                                     except AttributeError as e:
-                                        self.log.info(f"Could not record skip into DataModel header: {e}")
+                                        self.log.info(
+                                            f"Could not record skip into DataModel header: {e}"
+                                        )
                             elif isinstance(args[0], AbstractDataModel):
                                 try:
-                                    args[0][f"meta.cal_step.{self.class_alias}"] = "SKIPPED"
+                                    args[0][
+                                        f"meta.cal_step.{self.class_alias}"
+                                    ] = "SKIPPED"
                                 except AttributeError as e:
-                                    self.log.info(f"Could not record skip into DataModel header: {e}")
+                                    self.log.info(
+                                        f"Could not record skip into DataModel header: {e}"
+                                    )
                     step_result = args[0]
                 else:
                     if self.prefetch_references:
@@ -490,10 +516,16 @@ class Step:
                             self.save_model(result, idx=idx, format=self.name_format)
                         elif hasattr(result, "save"):
                             try:
-                                output_path = self.make_output_path(idx=idx, name_format=self.name_format)
+                                output_path = self.make_output_path(
+                                    idx=idx, name_format=self.name_format
+                                )
                             except AttributeError:
-                                self.log.warning("`save_results` has been requested, but cannot determine filename.")
-                                self.log.warning("Specify an output file with `--output_file` or set `--save_results=false`")
+                                self.log.warning(
+                                    "`save_results` has been requested, but cannot determine filename."
+                                )
+                                self.log.warning(
+                                    "Specify an output file with `--output_file` or set `--save_results=false`"
+                                )
                             else:
                                 self.log.info(f"Saving file {output_path}")
                                 result.save(output_path, overwrite=True)
@@ -604,7 +636,9 @@ class Step:
             try:
                 log.load_configuration(config["logcfg"])
             except Exception as e:
-                raise RuntimeError(f"Error parsing logging config {config['logcfg']}") from e
+                raise RuntimeError(
+                    f"Error parsing logging config {config['logcfg']}"
+                ) from e
             del config["logcfg"]
 
         name = config.get("name", None)
@@ -721,10 +755,14 @@ class Step:
         override = self.get_ref_override(reference_file_type)
         if override is not None:
             if isinstance(override, AbstractDataModel):
-                self._reference_files_used.append((reference_file_type, override.override_handle))
+                self._reference_files_used.append(
+                    (reference_file_type, override.override_handle)
+                )
                 return override
             elif override.strip() != "":
-                self._reference_files_used.append((reference_file_type, basename(override)))
+                self._reference_files_used.append(
+                    (reference_file_type, basename(override))
+                )
                 reference_name = override
             else:
                 return ""
@@ -796,7 +834,9 @@ class Step:
         if disable is None:
             disable = get_disable_crds_steppars()
         if disable:
-            logger.info(f"{reftype.upper()}: CRDS parameter reference retrieval disabled.")
+            logger.info(
+                f"{reftype.upper()}: CRDS parameter reference retrieval disabled."
+            )
             return config_parser.ConfigObj()
 
         # Retrieve step parameters from CRDS
@@ -814,8 +854,12 @@ class Step:
             logger.info(f"{reftype.upper()} parameters found: {ref_file}")
             ref = config_parser.load_config_file(ref_file)
 
-            ref_pars = {par: value for par, value in ref.items() if par not in ["class", "name"]}
-            logger.debug(f"{reftype.upper()} parameters retrieved from CRDS: {ref_pars}")
+            ref_pars = {
+                par: value for par, value in ref.items() if par not in ["class", "name"]
+            }
+            logger.debug(
+                f"{reftype.upper()} parameters retrieved from CRDS: {ref_pars}"
+            )
 
             return ref
         else:
@@ -934,7 +978,9 @@ class Step:
             )
         else:
             # Search for an output file name.
-            if self.output_use_model or (output_file is None and not self.search_output_file):
+            if self.output_use_model or (
+                output_file is None and not self.search_output_file
+            ):
                 output_file = model.meta.filename
                 idx = None
             output_path = model.save(
@@ -1244,7 +1290,9 @@ class Step:
             Set to True to include metadata that is required
             for submission to CRDS.
         """
-        with config.export_config(self).to_asdf(include_metadata=include_metadata) as af:
+        with config.export_config(self).to_asdf(
+            include_metadata=include_metadata
+        ) as af:
             af.write_to(filename)
 
     def update_pars(self, parameters):
@@ -1275,7 +1323,9 @@ class Step:
                     for step_name, step_parameters in value.items():
                         getattr(self, step_name).update_pars(step_parameters)
             else:
-                self.log.debug(f"Parameter {parameter} is not valid for step {self}. Ignoring.")
+                self.log.debug(
+                    f"Parameter {parameter} is not valid for step {self}. Ignoring."
+                )
 
     @classmethod
     def build_config(cls, input, **kwargs):

--- a/src/stpipe/subproc.py
+++ b/src/stpipe/subproc.py
@@ -44,11 +44,11 @@ class SystemCall(Step):
 
         env = dict(os.environ)
         for item in self.env:
-            var, sep, val = item.partition('=')
+            var, sep, val = item.partition("=")
             env[var] = val or None
 
         # Start the process and wait for it to finish.
-        self.log.info(f'Spawning {cmd_str!r}')
+        self.log.info(f"Spawning {cmd_str!r}")
         try:
             p = subprocess.Popen(
                 args=[cmd_str],
@@ -60,19 +60,19 @@ class SystemCall(Step):
             )
             err = p.wait()
         except Exception as e:
-            msg = f'Failed with an exception: \n{e}'
+            msg = f"Failed with an exception: \n{e}"
             self.log.info(msg)
 
             if self.failure_as_exception:
                 raise
         else:
-            self.log.info(f'Done with errorcode {err}')
+            self.log.info(f"Done with errorcode {err}")
 
             # Log STDOUT/ERR if we are asked to do so.
             if self.log_stdout:
-                self.log.info(f'STDOUT: {p.stdout.read()}')
+                self.log.info(f"STDOUT: {p.stdout.read()}")
             if self.log_stderr:
-                self.log.info(f'STDERR: {p.stderr.read()}')
+                self.log.info(f"STDERR: {p.stderr.read()}")
 
             if self.exitcode_as_exception and err != 0:
-                raise OSError(f'{cmd_str!r} returned error code {err}')
+                raise OSError(f"{cmd_str!r} returned error code {err}")

--- a/src/stpipe/subproc.py
+++ b/src/stpipe/subproc.py
@@ -8,6 +8,7 @@ class SystemCall(Step):
     """
     Execute a system call in the shell.
     """
+
     spec = """
     # SystemCall is a step to run external processes as Steps.
 
@@ -49,15 +50,17 @@ class SystemCall(Step):
         # Start the process and wait for it to finish.
         self.log.info(f'Spawning {cmd_str!r}')
         try:
-            p = subprocess.Popen(args=[cmd_str],
-                                 stdin=None,
-                                 stdout=subprocess.PIPE,
-                                 stderr=subprocess.PIPE,
-                                 shell=True,
-                                 env=env)
+            p = subprocess.Popen(
+                args=[cmd_str],
+                stdin=None,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                shell=True,
+                env=env,
+            )
             err = p.wait()
         except Exception as e:
-            msg = (f'Failed with an exception: \n{e}')
+            msg = f'Failed with an exception: \n{e}'
             self.log.info(msg)
 
             if self.failure_as_exception:

--- a/src/stpipe/subproc.py
+++ b/src/stpipe/subproc.py
@@ -26,7 +26,7 @@ class SystemCall(Step):
     exitcode_as_exception = boolean(default=True) # Should a non-zero exit code be converted into an exception?
 
     failure_as_exception = boolean(default=True) # If subprocess fails to run at all, should that be an exception?
-    """
+    """  # noqa: E501
 
     def process(self, *args):
         from .. import datamodels

--- a/src/stpipe/tests/test_abstract_datamodel.py
+++ b/src/stpipe/tests/test_abstract_datamodel.py
@@ -10,29 +10,39 @@ from ..step import AbstractDataModel
 def test_roman_datamodel():
     roman_datamodels = pytest.importorskip("roman_datamodels.datamodels")
     import roman_datamodels.tests.util as rutil
+
     roman_image_tree = rutil.mk_level2_image()
     image_model = roman_datamodels.ImageModel(roman_image_tree)
     assert isinstance(image_model, AbstractDataModel)
+
 
 def test_jwst_datamodel():
     jwst_datamodel = pytest.importorskip("jwst.datamodels")
     image_model = jwst_datamodel.ImageModel()
     assert isinstance(image_model, AbstractDataModel)
 
+
 class GoodDataModel:
     def __init__(self):
         pass
+
     def crds_observatory(self):
         pass
+
     def get_crds_parameters(self):
         pass
+
     def save(self):
         pass
+
+
 class BadDataModel:
     def __init__(self):
         pass
+
     def crds_observatory(self):
         pass
+
     def get_crds_parameters(self):
         pass
 
@@ -40,6 +50,7 @@ class BadDataModel:
 def test_good_datamodel():
     gdm = GoodDataModel()
     assert isinstance(gdm, AbstractDataModel)
+
 
 def test_bad_datamodel():
     gdm = BadDataModel()

--- a/src/stpipe/tests/test_abstract_datamodel.py
+++ b/src/stpipe/tests/test_abstract_datamodel.py
@@ -3,7 +3,9 @@ Test that the AbstractDataModel interface works properly
 """
 
 import pytest
+
 from ..step import AbstractDataModel
+
 
 def test_roman_datamodel():
     roman_datamodels = pytest.importorskip("roman_datamodels.datamodels")

--- a/src/stpipe/utilities.py
+++ b/src/stpipe/utilities.py
@@ -72,7 +72,7 @@ def import_class(full_name, subclassof=object, config_file=None):
         if not isinstance(step_class, type):
             raise TypeError(f"Object {class_name} from package {package_name} is not a class")
         elif not issubclass(step_class, subclassof):
-            raise TypeError(f"Class {class_name} from package {package_name} is not a " f"subclass of {subclassof.__name__}")
+            raise TypeError(f"Class {class_name} from package {package_name} is not a subclass of {subclassof.__name__}")
     finally:
         if config_file is not None:
             del sys.path[0]

--- a/src/stpipe/utilities.py
+++ b/src/stpipe/utilities.py
@@ -75,7 +75,8 @@ def import_class(full_name, subclassof=object, config_file=None):
             )
         elif not issubclass(step_class, subclassof):
             raise TypeError(
-                f"Class {class_name} from package {package_name} is not a subclass of {subclassof.__name__}"
+                f"Class {class_name} from package {package_name} is not a subclass of"
+                f" {subclassof.__name__}"
             )
     finally:
         if config_file is not None:

--- a/src/stpipe/utilities.py
+++ b/src/stpipe/utilities.py
@@ -58,17 +58,21 @@ def import_class(full_name, subclassof=object, config_file=None):
         if not package_name:
             raise ImportError(f"{full_name} is not a Python class")
         imported = __import__(
-            package_name, globals(), locals(), [class_name, ], level=0)
+            package_name,
+            globals(),
+            locals(),
+            [
+                class_name,
+            ],
+            level=0,
+        )
 
         step_class = getattr(imported, class_name)
 
         if not isinstance(step_class, type):
-            raise TypeError(
-                f'Object {class_name} from package {package_name} is not a class')
+            raise TypeError(f'Object {class_name} from package {package_name} is not a class')
         elif not issubclass(step_class, subclassof):
-            raise TypeError(
-                f'Class {class_name} from package {package_name} is not a '
-                f'subclass of {subclassof.__name__}')
+            raise TypeError(f'Class {class_name} from package {package_name} is not a ' f'subclass of {subclassof.__name__}')
     finally:
         if config_file is not None:
             del sys.path[0]

--- a/src/stpipe/utilities.py
+++ b/src/stpipe/utilities.py
@@ -70,9 +70,13 @@ def import_class(full_name, subclassof=object, config_file=None):
         step_class = getattr(imported, class_name)
 
         if not isinstance(step_class, type):
-            raise TypeError(f"Object {class_name} from package {package_name} is not a class")
+            raise TypeError(
+                f"Object {class_name} from package {package_name} is not a class"
+            )
         elif not issubclass(step_class, subclassof):
-            raise TypeError(f"Class {class_name} from package {package_name} is not a subclass of {subclassof.__name__}")
+            raise TypeError(
+                f"Class {class_name} from package {package_name} is not a subclass of {subclassof.__name__}"
+            )
     finally:
         if config_file is not None:
             del sys.path[0]

--- a/src/stpipe/utilities.py
+++ b/src/stpipe/utilities.py
@@ -54,7 +54,7 @@ def import_class(full_name, subclassof=object, config_file=None):
 
     try:
         full_name = full_name.strip()
-        package_name, sep, class_name = full_name.rpartition('.')
+        package_name, sep, class_name = full_name.rpartition(".")
         if not package_name:
             raise ImportError(f"{full_name} is not a Python class")
         imported = __import__(
@@ -70,9 +70,9 @@ def import_class(full_name, subclassof=object, config_file=None):
         step_class = getattr(imported, class_name)
 
         if not isinstance(step_class, type):
-            raise TypeError(f'Object {class_name} from package {package_name} is not a class')
+            raise TypeError(f"Object {class_name} from package {package_name} is not a class")
         elif not issubclass(step_class, subclassof):
-            raise TypeError(f'Class {class_name} from package {package_name} is not a ' f'subclass of {subclassof.__name__}')
+            raise TypeError(f"Class {class_name} from package {package_name} is not a " f"subclass of {subclassof.__name__}")
     finally:
         if config_file is not None:
             del sys.path[0]
@@ -96,7 +96,7 @@ def get_spec_file_path(step_class):
     # Since `step_class` could be defined in a file called whatever,
     # we need the source file basedir and the class name.
     dir = os.path.dirname(step_source_file)
-    return os.path.join(dir, step_class.__name__ + '.spec')
+    return os.path.join(dir, step_class.__name__ + ".spec")
 
 
 def find_spec_file(step_class):
@@ -129,4 +129,4 @@ def get_fully_qualified_class_name(cls_or_obj):
     if module is None or module == str.__class__.__module__:
         return cls.__name__  # Avoid reporting __builtin__
     else:
-        return module + '.' + cls.__name__
+        return module + "." + cls.__name__

--- a/tests/cli/test_list.py
+++ b/tests/cli/test_list.py
@@ -9,14 +9,62 @@ from stpipe.entry_points import StepInfo
 def monkey_patch_get_steps(monkeypatch):
     def _get_steps():
         return [
-            StepInfo("jwst.pipeline.Ami3Pipeline", "calwebb_ami3", True, "jwst", "0.18.4"),
-            StepInfo("jwst.pipeline.Coron3Pipeline", "calwebb_coron3", True, "jwst", "0.18.4"),
-            StepInfo("jwst.pipeline.DarkPipeline", "calwebb_dark", True, "jwst", "0.18.4"),
-            StepInfo("jwst.step.AlignRefsStep", None, False, "jwst", "0.18.4"),
-            StepInfo("jwst.step.AmiAnalyzeStep", None, False, "jwst", "0.18.4"),
-            StepInfo("jwst.step.AmiAverageStep", None, False, "jwst", "0.18.4"),
-            StepInfo("romancal.pipeline.SomeRomanPipeline", None, True, "romancal", "0.1.1"),
-            StepInfo("romancal.step.FlatFieldStep", None, False, "romancal", "0.1.1"),
+            StepInfo(
+                "jwst.pipeline.Ami3Pipeline",
+                "calwebb_ami3",
+                True,
+                "jwst",
+                "0.18.4",
+            ),
+            StepInfo(
+                "jwst.pipeline.Coron3Pipeline",
+                "calwebb_coron3",
+                True,
+                "jwst",
+                "0.18.4",
+            ),
+            StepInfo(
+                "jwst.pipeline.DarkPipeline",
+                "calwebb_dark",
+                True,
+                "jwst",
+                "0.18.4",
+            ),
+            StepInfo(
+                "jwst.step.AlignRefsStep",
+                None,
+                False,
+                "jwst",
+                "0.18.4",
+            ),
+            StepInfo(
+                "jwst.step.AmiAnalyzeStep",
+                None,
+                False,
+                "jwst",
+                "0.18.4",
+            ),
+            StepInfo(
+                "jwst.step.AmiAverageStep",
+                None,
+                False,
+                "jwst",
+                "0.18.4",
+            ),
+            StepInfo(
+                "romancal.pipeline.SomeRomanPipeline",
+                None,
+                True,
+                "romancal",
+                "0.1.1",
+            ),
+            StepInfo(
+                "romancal.step.FlatFieldStep",
+                None,
+                False,
+                "romancal",
+                "0.1.1",
+            ),
         ]
 
     monkeypatch.setattr(entry_points, "get_steps", _get_steps)
@@ -27,7 +75,9 @@ def assert_captured_steps(captured, class_names):
 
     content = captured.out.strip()
     if content != "":
-        captured_class_names.extend([line.split(" ")[0] for line in content.split("\n")])
+        captured_class_names.extend(
+            [line.split(" ")[0] for line in content.split("\n")]
+        )
 
     assert captured_class_names == class_names
 

--- a/tests/cli/test_list.py
+++ b/tests/cli/test_list.py
@@ -1,7 +1,7 @@
 import pytest
 
-from stpipe.cli import handle_args
 from stpipe import entry_points
+from stpipe.cli import handle_args
 from stpipe.entry_points import StepInfo
 
 

--- a/tests/cli/test_list.py
+++ b/tests/cli/test_list.py
@@ -35,63 +35,81 @@ def assert_captured_steps(captured, class_names):
 def test_no_arguments(capsys):
     assert handle_args(["list"]) == 0
 
-    assert_captured_steps(capsys.readouterr(), [
-        "jwst.pipeline.Ami3Pipeline",
-        "jwst.pipeline.Coron3Pipeline",
-        "jwst.pipeline.DarkPipeline",
-        "jwst.step.AlignRefsStep",
-        "jwst.step.AmiAnalyzeStep",
-        "jwst.step.AmiAverageStep",
-        "romancal.pipeline.SomeRomanPipeline",
-        "romancal.step.FlatFieldStep",
-    ])
+    assert_captured_steps(
+        capsys.readouterr(),
+        [
+            "jwst.pipeline.Ami3Pipeline",
+            "jwst.pipeline.Coron3Pipeline",
+            "jwst.pipeline.DarkPipeline",
+            "jwst.step.AlignRefsStep",
+            "jwst.step.AmiAnalyzeStep",
+            "jwst.step.AmiAverageStep",
+            "romancal.pipeline.SomeRomanPipeline",
+            "romancal.step.FlatFieldStep",
+        ],
+    )
 
 
 def test_pipelines_only(capsys):
     assert handle_args(["list", "--pipelines-only"]) == 0
 
-    assert_captured_steps(capsys.readouterr(), [
-        "jwst.pipeline.Ami3Pipeline",
-        "jwst.pipeline.Coron3Pipeline",
-        "jwst.pipeline.DarkPipeline",
-        "romancal.pipeline.SomeRomanPipeline",
-    ])
+    assert_captured_steps(
+        capsys.readouterr(),
+        [
+            "jwst.pipeline.Ami3Pipeline",
+            "jwst.pipeline.Coron3Pipeline",
+            "jwst.pipeline.DarkPipeline",
+            "romancal.pipeline.SomeRomanPipeline",
+        ],
+    )
 
 
 def test_steps_only(capsys):
     assert handle_args(["list", "--steps-only"]) == 0
 
-    assert_captured_steps(capsys.readouterr(), [
-        "jwst.step.AlignRefsStep",
-        "jwst.step.AmiAnalyzeStep",
-        "jwst.step.AmiAverageStep",
-        "romancal.step.FlatFieldStep",
-    ])
+    assert_captured_steps(
+        capsys.readouterr(),
+        [
+            "jwst.step.AlignRefsStep",
+            "jwst.step.AmiAnalyzeStep",
+            "jwst.step.AmiAverageStep",
+            "romancal.step.FlatFieldStep",
+        ],
+    )
 
 
 def test_filter_class_names(capsys):
     assert handle_args(["list", "romancal.*"]) == 0
 
-    assert_captured_steps(capsys.readouterr(), [
-        "romancal.pipeline.SomeRomanPipeline",
-        "romancal.step.FlatFieldStep",
-    ])
+    assert_captured_steps(
+        capsys.readouterr(),
+        [
+            "romancal.pipeline.SomeRomanPipeline",
+            "romancal.step.FlatFieldStep",
+        ],
+    )
 
     # Should be case-insensitive:
     assert handle_args(["list", "*.ami*"]) == 0
 
-    assert_captured_steps(capsys.readouterr(), [
-        "jwst.pipeline.Ami3Pipeline",
-        "jwst.step.AmiAnalyzeStep",
-        "jwst.step.AmiAverageStep",
-    ])
+    assert_captured_steps(
+        capsys.readouterr(),
+        [
+            "jwst.pipeline.Ami3Pipeline",
+            "jwst.step.AmiAnalyzeStep",
+            "jwst.step.AmiAverageStep",
+        ],
+    )
 
 
 def test_filter_aliases(capsys):
     assert handle_args(["list", "calwebb*"]) == 0
 
-    assert_captured_steps(capsys.readouterr(), [
-        "jwst.pipeline.Ami3Pipeline",
-        "jwst.pipeline.Coron3Pipeline",
-        "jwst.pipeline.DarkPipeline",
-    ])
+    assert_captured_steps(
+        capsys.readouterr(),
+        [
+            "jwst.pipeline.Ami3Pipeline",
+            "jwst.pipeline.Coron3Pipeline",
+            "jwst.pipeline.DarkPipeline",
+        ],
+    )

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -3,8 +3,8 @@ import subprocess
 import pytest
 
 import stpipe
-from stpipe.cli import handle_args
 from stpipe import entry_points
+from stpipe.cli import handle_args
 from stpipe.entry_points import StepInfo
 
 

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -12,11 +12,41 @@ from stpipe.entry_points import StepInfo
 def monkey_patch_get_steps(monkeypatch):
     def _get_steps():
         return [
-            StepInfo("jwst.pipeline.Ami3Pipeline", "calwebb_ami3", True, "jwst", "0.18.4"),
-            StepInfo("jwst.pipeline.Coron3Pipeline", "calwebb_coron3", True, "jwst", "0.18.4"),
-            StepInfo("romancal.pipeline.SomeRomanPipeline", None, True, "romancal", "0.1.1"),
-            StepInfo("romancal.step.FlatFieldStep", None, False, "romancal", "0.1.1"),
-            StepInfo("razzledazzle.step.RazzleDazzleStep", None, False, "razzledazzle", "9.5.3"),
+            StepInfo(
+                "jwst.pipeline.Ami3Pipeline",
+                "calwebb_ami3",
+                True,
+                "jwst",
+                "0.18.4",
+            ),
+            StepInfo(
+                "jwst.pipeline.Coron3Pipeline",
+                "calwebb_coron3",
+                True,
+                "jwst",
+                "0.18.4",
+            ),
+            StepInfo(
+                "romancal.pipeline.SomeRomanPipeline",
+                None,
+                True,
+                "romancal",
+                "0.1.1",
+            ),
+            StepInfo(
+                "romancal.step.FlatFieldStep",
+                None,
+                False,
+                "romancal",
+                "0.1.1",
+            ),
+            StepInfo(
+                "razzledazzle.step.RazzleDazzleStep",
+                None,
+                False,
+                "razzledazzle",
+                "9.5.3",
+            ),
         ]
 
     monkeypatch.setattr(entry_points, "get_steps", _get_steps)
@@ -35,7 +65,9 @@ def test_version(flag, capsys):
 
 
 def test_package_main():
-    out = subprocess.check_output(["python", "-m", "stpipe", "--version"]).decode("utf-8")
+    out = subprocess.check_output(["python", "-m", "stpipe", "--version"]).decode(
+        "utf-8"
+    )
     assert f"stpipe: {stpipe.__version__}" in out
 
 

--- a/tests/test_format_template.py
+++ b/tests/test_format_template.py
@@ -7,7 +7,7 @@ from stpipe.format_template import FormatTemplate
 
 
 @pytest.mark.parametrize(
-    'key_formats, template, expected, fields, errors',
+    "key_formats, template, expected, fields, errors",
     [
         # No replacement at all.
         (
@@ -22,7 +22,7 @@ from stpipe.format_template import FormatTemplate
             None,
             'name="{name}" value="{value}"',
             'name="fred" value="great"',
-            {'name': 'fred', 'value': 'great'},
+            {"name": "fred", "value": "great"},
             None,
         ),
         # But wait, too many values given:
@@ -30,7 +30,7 @@ from stpipe.format_template import FormatTemplate
             None,
             'name="{name}" value="{value}"',
             'name="fred" value="great"_more',
-            {'name': 'fred', 'value': 'great', 'extra': 'more'},
+            {"name": "fred", "value": "great", "extra": "more"},
             None,
         ),
         # And with too many and not enough:
@@ -38,7 +38,7 @@ from stpipe.format_template import FormatTemplate
             None,
             'name="{name}" value="{value}"',
             'name="{name}" value="great"_more',
-            {'value': 'great', 'extra': 'more'},
+            {"value": "great", "extra": "more"},
             None,
         ),
         # Nothing should be added if value is None
@@ -46,43 +46,43 @@ from stpipe.format_template import FormatTemplate
             None,
             'name="{name}" value="{value}"',
             'name="{name}" value=""',
-            {'value': None},
+            {"value": None},
             None,
         ),
         # Multiple key formats, using none.
         (
             {
-                'field': ['s{:05d}', 's{:s}'],
+                "field": ["s{:05d}", "s{:s}"],
             },
-            'astring',
-            'astring',
+            "astring",
+            "astring",
             {},
             None,
         ),
         # Multiple key formats, using first.
         (
             {
-                'field': ['s{:05d}', 's{:s}'],
+                "field": ["s{:05d}", "s{:s}"],
             },
-            'astring',
-            'astring_s00001',
-            {'field': 1},
+            "astring",
+            "astring_s00001",
+            {"field": 1},
             None,
         ),
         # Multiple key formats, using second.
         (
-            {'field': ['s{:05d}', 's{:s}']},
-            'astring',
-            'astring_smysource',
-            {'field': "mysource"},
+            {"field": ["s{:05d}", "s{:s}"]},
+            "astring",
+            "astring_smysource",
+            {"field": "mysource"},
             None,
         ),
         # No matching formats is an error.
         (
-            {'field': ['s{:05d}']},
-            'astring',
-            'astring_error',
-            {'field': '5.5'},
+            {"field": ["s{:05d}"]},
+            "astring",
+            "astring_error",
+            {"field": "5.5"},
             (RuntimeError,),
         ),
     ],
@@ -107,13 +107,13 @@ def test_separators():
     fmt = FormatTemplate()
 
     # With a different separator:
-    fmt.separator = '---'
-    result = fmt(template, name='fred', value='great', extra='more')
+    fmt.separator = "---"
+    result = fmt(template, name="fred", value="great", extra="more")
     assert result == 'name="fred" value="great"---more'
 
     # Initializing with a different separator:
-    fmt_newsep = FormatTemplate(separator='_now-with_')
-    result = fmt_newsep(template, name='fred', value='great', extra='more')
+    fmt_newsep = FormatTemplate(separator="_now-with_")
+    result = fmt_newsep(template, name="fred", value="great", extra="more")
     assert result == 'name="fred" value="great"_now-with_more'
 
 

--- a/tests/test_format_template.py
+++ b/tests/test_format_template.py
@@ -15,45 +15,40 @@ from stpipe.format_template import FormatTemplate
             'name="{name}" value="{value}"',
             'name="{name}" value="{value}"',
             {},
-            None
+            None,
         ),
-
         # Basic replacement
         (
             None,
             'name="{name}" value="{value}"',
             'name="fred" value="great"',
             {'name': 'fred', 'value': 'great'},
-            None
+            None,
         ),
-
         # But wait, too many values given:
         (
             None,
             'name="{name}" value="{value}"',
             'name="fred" value="great"_more',
             {'name': 'fred', 'value': 'great', 'extra': 'more'},
-            None
+            None,
         ),
-
         # And with too many and not enough:
         (
             None,
             'name="{name}" value="{value}"',
             'name="{name}" value="great"_more',
             {'value': 'great', 'extra': 'more'},
-            None
+            None,
         ),
-
         # Nothing should be added if value is None
         (
             None,
             'name="{name}" value="{value}"',
             'name="{name}" value=""',
             {'value': None},
-            None
+            None,
         ),
-
         # Multiple key formats, using none.
         (
             {
@@ -62,9 +57,8 @@ from stpipe.format_template import FormatTemplate
             'astring',
             'astring',
             {},
-            None
+            None,
         ),
-
         # Multiple key formats, using first.
         (
             {
@@ -73,31 +67,25 @@ from stpipe.format_template import FormatTemplate
             'astring',
             'astring_s00001',
             {'field': 1},
-            None
+            None,
         ),
-
         # Multiple key formats, using second.
         (
-            {
-                'field': ['s{:05d}', 's{:s}']
-            },
+            {'field': ['s{:05d}', 's{:s}']},
             'astring',
             'astring_smysource',
             {'field': "mysource"},
-            None
+            None,
         ),
-
         # No matching formats is an error.
         (
-            {
-                'field': ['s{:05d}']
-            },
+            {'field': ['s{:05d}']},
             'astring',
             'astring_error',
             {'field': '5.5'},
-            (RuntimeError,)
+            (RuntimeError,),
         ),
-    ]
+    ],
 )
 def test_basics(key_formats, template, expected, fields, errors):
     """Test all basic formatting options"""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -8,7 +8,9 @@ from stpipe.integration import SCHEMAS_PATH
 
 
 def test_asdf_extension():
-    for schema_path in glob.glob(os.path.join(SCHEMAS_PATH, "**/*.yaml"), recursive=True):
+    for schema_path in glob.glob(
+        os.path.join(SCHEMAS_PATH, "**/*.yaml"), recursive=True
+    ):
         with open(schema_path) as f:
             yaml_schema = yaml.safe_load(f.read())
             asdf_schema = asdf.schema.load_schema(yaml_schema["id"])

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -52,7 +52,9 @@ def test_record_logs():
     stpipe_logger = stpipe_log.getLogger(stpipe_log.STPIPE_ROOT_LOGGER)
     root_logger = stpipe_log.getLogger()
 
-    assert not any(isinstance(h, stpipe_log.RecordingHandler) for h in root_logger.handlers)
+    assert not any(
+        isinstance(h, stpipe_log.RecordingHandler) for h in root_logger.handlers
+    )
 
     with stpipe_log.record_logs(level=logging.ERROR) as log_records:
         stpipe_logger.warning("Warning from stpipe")
@@ -60,7 +62,9 @@ def test_record_logs():
         root_logger.warning("Warning from root")
         root_logger.error("Error from root")
 
-    assert not any(isinstance(h, stpipe_log.RecordingHandler) for h in root_logger.handlers)
+    assert not any(
+        isinstance(h, stpipe_log.RecordingHandler) for h in root_logger.handlers
+    )
 
     stpipe_logger.error("Additional error from stpipe")
     root_logger.error("Additional error from root")

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -14,7 +14,7 @@ def clean_up_logging():
 
 
 def test_configuration(tmpdir):
-    logfilename = tmpdir.join('output.log')
+    logfilename = tmpdir.join("output.log")
 
     configuration = """
 [.]
@@ -45,7 +45,7 @@ format = '%(message)s'
     with open(logfilename) as fd:
         lines = [x.strip() for x in fd.readlines()]
 
-    assert lines == ['Shown', 'Breaking']
+    assert lines == ["Shown", "Breaking"]
 
 
 def test_record_logs():

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -22,7 +22,9 @@ handler = file:{}
 break_level = ERROR
 level = WARNING
 format = '%(message)s'
-""".format(logfilename)
+""".format(
+        logfilename
+    )
 
     fd = io.StringIO()
     fd.write(configuration)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,8 +1,8 @@
 import shutil
 
-SCRIPTS = ['strun']
+SCRIPTS = ["strun"]
 
 
 def test_scripts_in_path():
     for script in SCRIPTS:
-        assert shutil.which(script) is not None, f'`{script}` not installed'
+        assert shutil.which(script) is not None, f"`{script}` not installed"

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -1,12 +1,14 @@
 """Test step.Step"""
-import pytest
 import logging
+
 import asdf
+import pytest
 
 import stpipe.config_parser as cp
+from stpipe import cmdline
 from stpipe.pipeline import Pipeline
 from stpipe.step import Step
-from stpipe import cmdline
+
 
 # ######################
 # Data and Fixture setup

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -36,7 +36,7 @@ class SimplePipe(Pipeline):
         output_ext = string(default='simplestep')
     """
 
-    step_defs = {'step1': SimpleStep}
+    step_defs = {"step1": SimpleStep}
 
 
 class LoggingPipeline(Pipeline):
@@ -77,22 +77,22 @@ class ListArgStep(Step):
 @pytest.fixture()
 def config_file_pipe(tmpdir):
     """Create a config file"""
-    config_file = str(tmpdir / 'simple_pipe.asdf')
+    config_file = str(tmpdir / "simple_pipe.asdf")
 
     tree = {
-        'class': 'test_step.SimplePipe',
-        'name': 'SimplePipe',
-        'parameters': {
-            'str1': 'from config',
-            'str2': 'from config',
+        "class": "test_step.SimplePipe",
+        "name": "SimplePipe",
+        "parameters": {
+            "str1": "from config",
+            "str2": "from config",
         },
-        'steps': [
+        "steps": [
             {
-                'class': 'test_step.SimpleStep',
-                'name': 'step1',
-                'parameters': {
-                    'str1': 'from config',
-                    'str2': 'from config',
+                "class": "test_step.SimpleStep",
+                "name": "step1",
+                "parameters": {
+                    "str1": "from config",
+                    "str2": "from config",
                 },
             },
         ],
@@ -105,14 +105,14 @@ def config_file_pipe(tmpdir):
 @pytest.fixture()
 def config_file_step(tmpdir):
     """Create a config file"""
-    config_file = str(tmpdir / 'simple_step.asdf')
+    config_file = str(tmpdir / "simple_step.asdf")
 
     tree = {
-        'class': 'test_step.SimpleStep',
-        'name': 'SimpleStep',
-        'parameters': {
-            'str1': 'from config',
-            'str2': 'from config',
+        "class": "test_step.SimpleStep",
+        "name": "SimpleStep",
+        "parameters": {
+            "str1": "from config",
+            "str2": "from config",
         },
     }
     with asdf.AsdfFile(tree) as af:
@@ -123,14 +123,14 @@ def config_file_step(tmpdir):
 @pytest.fixture()
 def config_file_list_arg_step(tmpdir):
     """Create a config file"""
-    config_file = str(tmpdir / 'list_arg_step.asdf')
+    config_file = str(tmpdir / "list_arg_step.asdf")
 
     tree = {
-        'class': 'test_step.ListArgStep',
-        'name': 'ListArgStep',
-        'parameters': {
-            'rotation': None,
-            'pixel_scale_ratio': 1.1,
+        "class": "test_step.ListArgStep",
+        "name": "ListArgStep",
+        "parameters": {
+            "rotation": None,
+            "pixel_scale_ratio": 1.1,
         },
     }
     with asdf.AsdfFile(tree) as af:
@@ -145,14 +145,14 @@ def mock_step_crds(monkeypatch):
     def mock_get_config_from_reference_pipe(dataset, disable=None):
         config = cp.config_from_dict(
             {
-                'str1': 'from crds',
-                'str2': 'from crds',
-                'str3': 'from crds',
-                'steps': {
-                    'step1': {
-                        'str1': 'from crds',
-                        'str2': 'from crds',
-                        'str3': 'from crds',
+                "str1": "from crds",
+                "str2": "from crds",
+                "str3": "from crds",
+                "steps": {
+                    "step1": {
+                        "str1": "from crds",
+                        "str2": "from crds",
+                        "str3": "from crds",
                     },
                 },
             }
@@ -160,16 +160,16 @@ def mock_step_crds(monkeypatch):
         return config
 
     def mock_get_config_from_reference_step(dataset, disable=None):
-        config = cp.config_from_dict({'str1': 'from crds', 'str2': 'from crds', 'str3': 'from crds'})
+        config = cp.config_from_dict({"str1": "from crds", "str2": "from crds", "str3": "from crds"})
         return config
 
     def mock_get_config_from_reference_list_arg_step(dataset, disable=None):
-        config = cp.config_from_dict({'rotation': '15', 'pixel_scale': '0.85'})
+        config = cp.config_from_dict({"rotation": "15", "pixel_scale": "0.85"})
         return config
 
-    monkeypatch.setattr(SimplePipe, 'get_config_from_reference', mock_get_config_from_reference_pipe)
-    monkeypatch.setattr(SimpleStep, 'get_config_from_reference', mock_get_config_from_reference_step)
-    monkeypatch.setattr(ListArgStep, 'get_config_from_reference', mock_get_config_from_reference_list_arg_step)
+    monkeypatch.setattr(SimplePipe, "get_config_from_reference", mock_get_config_from_reference_pipe)
+    monkeypatch.setattr(SimpleStep, "get_config_from_reference", mock_get_config_from_reference_step)
+    monkeypatch.setattr(ListArgStep, "get_config_from_reference", mock_get_config_from_reference_list_arg_step)
 
 
 # #####
@@ -177,26 +177,26 @@ def mock_step_crds(monkeypatch):
 # #####
 def test_build_config_pipe_config_file(mock_step_crds, config_file_pipe):
     """Test that local config overrides defaults and CRDS-supplied file"""
-    config, returned_config_file = SimplePipe.build_config('science.fits', config_file=config_file_pipe)
+    config, returned_config_file = SimplePipe.build_config("science.fits", config_file=config_file_pipe)
     assert returned_config_file == config_file_pipe
-    assert config['str1'] == 'from config'
-    assert config['str2'] == 'from config'
-    assert config['str3'] == 'from crds'
-    assert config['steps']['step1']['str1'] == 'from config'
-    assert config['steps']['step1']['str2'] == 'from config'
-    assert config['steps']['step1']['str3'] == 'from crds'
+    assert config["str1"] == "from config"
+    assert config["str2"] == "from config"
+    assert config["str3"] == "from crds"
+    assert config["steps"]["step1"]["str1"] == "from config"
+    assert config["steps"]["step1"]["str2"] == "from config"
+    assert config["steps"]["step1"]["str3"] == "from crds"
 
 
 def test_build_config_pipe_crds(mock_step_crds):
     """Test that CRDS param reffile overrides a default CRDS configuration"""
-    config, config_file = SimplePipe.build_config('science.fits')
+    config, config_file = SimplePipe.build_config("science.fits")
     assert not config_file
-    assert config['str1'] == 'from crds'
-    assert config['str2'] == 'from crds'
-    assert config['str3'] == 'from crds'
-    assert config['steps']['step1']['str1'] == 'from crds'
-    assert config['steps']['step1']['str2'] == 'from crds'
-    assert config['steps']['step1']['str3'] == 'from crds'
+    assert config["str1"] == "from crds"
+    assert config["str2"] == "from crds"
+    assert config["str3"] == "from crds"
+    assert config["steps"]["step1"]["str1"] == "from crds"
+    assert config["steps"]["step1"]["str2"] == "from crds"
+    assert config["steps"]["step1"]["str3"] == "from crds"
 
 
 def test_build_config_pipe_default():
@@ -209,37 +209,37 @@ def test_build_config_pipe_default():
 def test_build_config_pipe_kwarg(mock_step_crds, config_file_pipe):
     """Test that kwargs override CRDS and local param reffiles"""
     config, returned_config_file = SimplePipe.build_config(
-        'science.fits',
+        "science.fits",
         config_file=config_file_pipe,
-        str1='from kwarg',
-        steps={'step1': {'str1': 'from kwarg'}},
+        str1="from kwarg",
+        steps={"step1": {"str1": "from kwarg"}},
     )
     assert returned_config_file == config_file_pipe
-    assert config['str1'] == 'from kwarg'
-    assert config['str2'] == 'from config'
-    assert config['str3'] == 'from crds'
-    assert config['steps']['step1']['str1'] == 'from kwarg'
-    assert config['steps']['step1']['str2'] == 'from config'
-    assert config['steps']['step1']['str3'] == 'from crds'
+    assert config["str1"] == "from kwarg"
+    assert config["str2"] == "from config"
+    assert config["str3"] == "from crds"
+    assert config["steps"]["step1"]["str1"] == "from kwarg"
+    assert config["steps"]["step1"]["str2"] == "from config"
+    assert config["steps"]["step1"]["str3"] == "from crds"
 
 
 def test_build_config_step_config_file(mock_step_crds, config_file_step):
     """Test that local config overrides defaults and CRDS-supplied file"""
-    config, returned_config_file = SimpleStep.build_config('science.fits', config_file=config_file_step)
+    config, returned_config_file = SimpleStep.build_config("science.fits", config_file=config_file_step)
     assert returned_config_file == config_file_step
-    assert config['str1'] == 'from config'
-    assert config['str2'] == 'from config'
-    assert config['str3'] == 'from crds'
+    assert config["str1"] == "from config"
+    assert config["str2"] == "from config"
+    assert config["str3"] == "from crds"
 
 
 def test_build_config_step_crds(mock_step_crds):
     """Test override of a CRDS configuration"""
-    config, config_file = SimpleStep.build_config('science.fits')
+    config, config_file = SimpleStep.build_config("science.fits")
     assert config_file is None
     assert len(config) == 3
-    assert config['str1'] == 'from crds'
-    assert config['str2'] == 'from crds'
-    assert config['str3'] == 'from crds'
+    assert config["str1"] == "from crds"
+    assert config["str2"] == "from crds"
+    assert config["str3"] == "from crds"
 
 
 def test_build_config_step_default():
@@ -251,27 +251,27 @@ def test_build_config_step_default():
 
 def test_build_config_step_kwarg(mock_step_crds, config_file_step):
     """Test that kwargs override everything"""
-    config, returned_config_file = SimpleStep.build_config('science.fits', config_file=config_file_step, str1='from kwarg')
+    config, returned_config_file = SimpleStep.build_config("science.fits", config_file=config_file_step, str1="from kwarg")
     assert returned_config_file == config_file_step
-    assert config['str1'] == 'from kwarg'
-    assert config['str2'] == 'from config'
-    assert config['str3'] == 'from crds'
+    assert config["str1"] == "from kwarg"
+    assert config["str2"] == "from config"
+    assert config["str3"] == "from crds"
 
 
 def test_step_list_args(mock_step_crds, config_file_list_arg_step):
     """Test that list arguments, provided as comma-separated values are parsed
     correctly.
     """
-    config, returned_config_file = ListArgStep.build_config('science.fits', config_file=config_file_list_arg_step)
+    config, returned_config_file = ListArgStep.build_config("science.fits", config_file=config_file_list_arg_step)
     assert returned_config_file == config_file_list_arg_step
     c, *_ = cmdline.just_the_step_from_cmdline(
         [
-            'filename.fits',
-            '--output_shape',
-            '1500,1300',
-            '--crpix=123,456',
-            '--pixel_scale=0.75',
-            '--config-file',
+            "filename.fits",
+            "--output_shape",
+            "1500,1300",
+            "--crpix=123,456",
+            "--pixel_scale=0.75",
+            "--config-file",
             returned_config_file,
         ],
         ListArgStep,
@@ -286,12 +286,12 @@ def test_step_list_args(mock_step_crds, config_file_list_arg_step):
     with pytest.raises(ValueError) as e:
         cmdline.just_the_step_from_cmdline(
             [
-                'filename.fits',
-                '--output_shape',
-                '1500,1300,90',
-                '--crpix=123,456',
-                '--pixel_scale=0.75',
-                '--config-file',
+                "filename.fits",
+                "--output_shape",
+                "1500,1300,90",
+                "--crpix=123,456",
+                "--pixel_scale=0.75",
+                "--config-file",
                 returned_config_file,
             ],
             ListArgStep,
@@ -301,12 +301,12 @@ def test_step_list_args(mock_step_crds, config_file_list_arg_step):
     with pytest.raises(ValueError) as e:
         cmdline.just_the_step_from_cmdline(
             [
-                'filename.fits',
-                '--output_shape',
-                '1500,',
-                '--crpix=123,456',
-                '--pixel_scale=0.75',
-                '--config-file',
+                "filename.fits",
+                "--output_shape",
+                "1500,",
+                "--crpix=123,456",
+                "--pixel_scale=0.75",
+                "--config-file",
                 returned_config_file,
             ],
             ListArgStep,
@@ -316,40 +316,40 @@ def test_step_list_args(mock_step_crds, config_file_list_arg_step):
     with pytest.raises(ValueError) as e:
         cmdline.just_the_step_from_cmdline(
             [
-                'filename.fits',
-                '--output_shape',
-                '1500',
-                '--crpix=123,456',
-                '--pixel_scale=0.75',
-                '--config-file',
+                "filename.fits",
+                "--output_shape",
+                "1500",
+                "--crpix=123,456",
+                "--pixel_scale=0.75",
+                "--config-file",
                 returned_config_file,
             ],
             ListArgStep,
         )
-    assert e.value.args[0] == "Config parameter 'output_shape': the value " "\"1500\" is of the wrong type."
+    assert e.value.args[0] == "Config parameter 'output_shape': the value " '"1500" is of the wrong type.'
 
     with pytest.raises(ValueError) as e:
         cmdline.just_the_step_from_cmdline(
             [
-                'filename.fits',
-                '--output_shape',
-                '1500.5,1300.2',
-                '--crpix=123,456',
-                '--pixel_scale=0.75',
-                '--config-file',
+                "filename.fits",
+                "--output_shape",
+                "1500.5,1300.2",
+                "--crpix=123,456",
+                "--pixel_scale=0.75",
+                "--config-file",
                 returned_config_file,
             ],
             ListArgStep,
         )
-    assert e.value.args[0] == "Config parameter 'output_shape': the value " "\"1500.5\" is of the wrong type."
+    assert e.value.args[0] == "Config parameter 'output_shape': the value " '"1500.5" is of the wrong type.'
 
 
 def test_logcfg_routing(tmpdir):
     cfg = f"""[*]\nlevel = INFO\nhandler = file:{tmpdir}/myrun.log"""
 
-    logcfg_file = str(tmpdir / 'stpipe-log.cfg')
+    logcfg_file = str(tmpdir / "stpipe-log.cfg")
 
-    with open(logcfg_file, 'w') as f:
+    with open(logcfg_file, "w") as f:
         f.write(cfg)
 
     LoggingPipeline.call(logcfg=logcfg_file)
@@ -362,10 +362,10 @@ def test_logcfg_routing(tmpdir):
                     logdict[log].removeHandler(handler)
                     handler.close()
 
-    with open(tmpdir / 'myrun.log') as f:
-        fulltext = '\n'.join([line for line in f])
+    with open(tmpdir / "myrun.log") as f:
+        fulltext = "\n".join([line for line in f])
 
-    assert 'called out a warning' in fulltext
+    assert "called out a warning" in fulltext
 
 
 def test_log_records():

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -296,7 +296,7 @@ def test_step_list_args(mock_step_crds, config_file_list_arg_step):
             ],
             ListArgStep,
         )
-    assert e.value.args[0] == "Config parameter 'output_shape': the value " "\"['1500', '1300', '90']\" is too long."
+    assert e.value.args[0] == "Config parameter 'output_shape': the value \"['1500', '1300', '90']\" is too long."
 
     with pytest.raises(ValueError) as e:
         cmdline.just_the_step_from_cmdline(
@@ -311,7 +311,7 @@ def test_step_list_args(mock_step_crds, config_file_list_arg_step):
             ],
             ListArgStep,
         )
-    assert e.value.args[0] == "Config parameter 'output_shape': the value " "\"['1500']\" is too short."
+    assert e.value.args[0] == "Config parameter 'output_shape': the value \"['1500']\" is too short."
 
     with pytest.raises(ValueError) as e:
         cmdline.just_the_step_from_cmdline(
@@ -326,7 +326,7 @@ def test_step_list_args(mock_step_crds, config_file_list_arg_step):
             ],
             ListArgStep,
         )
-    assert e.value.args[0] == "Config parameter 'output_shape': the value " '"1500" is of the wrong type.'
+    assert e.value.args[0] == "Config parameter 'output_shape': the value \"1500\" is of the wrong type."
 
     with pytest.raises(ValueError) as e:
         cmdline.just_the_step_from_cmdline(
@@ -341,7 +341,7 @@ def test_step_list_args(mock_step_crds, config_file_list_arg_step):
             ],
             ListArgStep,
         )
-    assert e.value.args[0] == "Config parameter 'output_shape': the value " '"1500.5" is of the wrong type.'
+    assert e.value.args[0] == "Config parameter 'output_shape': the value \"1500.5\" is of the wrong type."
 
 
 def test_logcfg_routing(tmpdir):

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -316,7 +316,8 @@ def test_step_list_args(mock_step_crds, config_file_list_arg_step):
         )
     assert (
         e.value.args[0]
-        == "Config parameter 'output_shape': the value \"['1500', '1300', '90']\" is too long."
+        == "Config parameter 'output_shape': the value \"['1500', '1300', '90']\" is"
+        " too long."
     )
 
     with pytest.raises(ValueError) as e:

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -160,16 +160,26 @@ def mock_step_crds(monkeypatch):
         return config
 
     def mock_get_config_from_reference_step(dataset, disable=None):
-        config = cp.config_from_dict({"str1": "from crds", "str2": "from crds", "str3": "from crds"})
+        config = cp.config_from_dict(
+            {"str1": "from crds", "str2": "from crds", "str3": "from crds"}
+        )
         return config
 
     def mock_get_config_from_reference_list_arg_step(dataset, disable=None):
         config = cp.config_from_dict({"rotation": "15", "pixel_scale": "0.85"})
         return config
 
-    monkeypatch.setattr(SimplePipe, "get_config_from_reference", mock_get_config_from_reference_pipe)
-    monkeypatch.setattr(SimpleStep, "get_config_from_reference", mock_get_config_from_reference_step)
-    monkeypatch.setattr(ListArgStep, "get_config_from_reference", mock_get_config_from_reference_list_arg_step)
+    monkeypatch.setattr(
+        SimplePipe, "get_config_from_reference", mock_get_config_from_reference_pipe
+    )
+    monkeypatch.setattr(
+        SimpleStep, "get_config_from_reference", mock_get_config_from_reference_step
+    )
+    monkeypatch.setattr(
+        ListArgStep,
+        "get_config_from_reference",
+        mock_get_config_from_reference_list_arg_step,
+    )
 
 
 # #####
@@ -177,7 +187,9 @@ def mock_step_crds(monkeypatch):
 # #####
 def test_build_config_pipe_config_file(mock_step_crds, config_file_pipe):
     """Test that local config overrides defaults and CRDS-supplied file"""
-    config, returned_config_file = SimplePipe.build_config("science.fits", config_file=config_file_pipe)
+    config, returned_config_file = SimplePipe.build_config(
+        "science.fits", config_file=config_file_pipe
+    )
     assert returned_config_file == config_file_pipe
     assert config["str1"] == "from config"
     assert config["str2"] == "from config"
@@ -225,7 +237,9 @@ def test_build_config_pipe_kwarg(mock_step_crds, config_file_pipe):
 
 def test_build_config_step_config_file(mock_step_crds, config_file_step):
     """Test that local config overrides defaults and CRDS-supplied file"""
-    config, returned_config_file = SimpleStep.build_config("science.fits", config_file=config_file_step)
+    config, returned_config_file = SimpleStep.build_config(
+        "science.fits", config_file=config_file_step
+    )
     assert returned_config_file == config_file_step
     assert config["str1"] == "from config"
     assert config["str2"] == "from config"
@@ -251,7 +265,9 @@ def test_build_config_step_default():
 
 def test_build_config_step_kwarg(mock_step_crds, config_file_step):
     """Test that kwargs override everything"""
-    config, returned_config_file = SimpleStep.build_config("science.fits", config_file=config_file_step, str1="from kwarg")
+    config, returned_config_file = SimpleStep.build_config(
+        "science.fits", config_file=config_file_step, str1="from kwarg"
+    )
     assert returned_config_file == config_file_step
     assert config["str1"] == "from kwarg"
     assert config["str2"] == "from config"
@@ -262,7 +278,9 @@ def test_step_list_args(mock_step_crds, config_file_list_arg_step):
     """Test that list arguments, provided as comma-separated values are parsed
     correctly.
     """
-    config, returned_config_file = ListArgStep.build_config("science.fits", config_file=config_file_list_arg_step)
+    config, returned_config_file = ListArgStep.build_config(
+        "science.fits", config_file=config_file_list_arg_step
+    )
     assert returned_config_file == config_file_list_arg_step
     c, *_ = cmdline.just_the_step_from_cmdline(
         [
@@ -296,7 +314,10 @@ def test_step_list_args(mock_step_crds, config_file_list_arg_step):
             ],
             ListArgStep,
         )
-    assert e.value.args[0] == "Config parameter 'output_shape': the value \"['1500', '1300', '90']\" is too long."
+    assert (
+        e.value.args[0]
+        == "Config parameter 'output_shape': the value \"['1500', '1300', '90']\" is too long."
+    )
 
     with pytest.raises(ValueError) as e:
         cmdline.just_the_step_from_cmdline(
@@ -311,7 +332,10 @@ def test_step_list_args(mock_step_crds, config_file_list_arg_step):
             ],
             ListArgStep,
         )
-    assert e.value.args[0] == "Config parameter 'output_shape': the value \"['1500']\" is too short."
+    assert (
+        e.value.args[0]
+        == "Config parameter 'output_shape': the value \"['1500']\" is too short."
+    )
 
     with pytest.raises(ValueError) as e:
         cmdline.just_the_step_from_cmdline(
@@ -326,7 +350,10 @@ def test_step_list_args(mock_step_crds, config_file_list_arg_step):
             ],
             ListArgStep,
         )
-    assert e.value.args[0] == "Config parameter 'output_shape': the value \"1500\" is of the wrong type."
+    assert (
+        e.value.args[0]
+        == "Config parameter 'output_shape': the value \"1500\" is of the wrong type."
+    )
 
     with pytest.raises(ValueError) as e:
         cmdline.just_the_step_from_cmdline(
@@ -341,7 +368,10 @@ def test_step_list_args(mock_step_crds, config_file_list_arg_step):
             ],
             ListArgStep,
         )
-    assert e.value.args[0] == "Config parameter 'output_shape': the value \"1500.5\" is of the wrong type."
+    assert (
+        e.value.args[0]
+        == "Config parameter 'output_shape': the value \"1500.5\" is of the wrong type."
+    )
 
 
 def test_logcfg_routing(tmpdir):
@@ -372,4 +402,6 @@ def test_log_records():
     pipeline = LoggingPipeline()
     pipeline.run()
 
-    assert any(r.message == "This step has called out a warning." for r in pipeline.log_records)
+    assert any(
+        r.message == "This step has called out a warning." for r in pipeline.log_records
+    )

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -15,6 +15,7 @@ from stpipe.step import Step
 # ######################
 class SimpleStep(Step):
     """A Step with parameters"""
+
     spec = """
         str1 = string(default='default')
         str2 = string(default='default')
@@ -23,8 +24,10 @@ class SimpleStep(Step):
         output_ext = string(default='simplestep')
     """
 
+
 class SimplePipe(Pipeline):
     """A Pipeline with parameters and one step"""
+
     spec = """
         str1 = string(default='default')
         str2 = string(default='default')
@@ -37,9 +40,10 @@ class SimplePipe(Pipeline):
 
 
 class LoggingPipeline(Pipeline):
-    """ A Pipeline that utilizes self.log
-        to log a warning
+    """A Pipeline that utilizes self.log
+    to log a warning
     """
+
     spec = """
         str1 = string(default='default')
         output_ext = string(default='simplestep')
@@ -57,6 +61,7 @@ class LoggingPipeline(Pipeline):
 
 class ListArgStep(Step):
     """A Step with parameters"""
+
     spec = """
         output_shape = int_list(min=2, max=2, default=None)  # [y, x] - numpy convention
         crpix = float_list(min=2, max=2, default=None)
@@ -79,16 +84,18 @@ def config_file_pipe(tmpdir):
         'name': 'SimplePipe',
         'parameters': {
             'str1': 'from config',
-            'str2': 'from config'
+            'str2': 'from config',
         },
         'steps': [
-            {'class': 'test_step.SimpleStep',
-             'name': 'step1',
-             'parameters': {
-                 'str1' : 'from config',
-                 'str2' : 'from config'
-             }},
-        ]
+            {
+                'class': 'test_step.SimpleStep',
+                'name': 'step1',
+                'parameters': {
+                    'str1': 'from config',
+                    'str2': 'from config',
+                },
+            },
+        ],
     }
     with asdf.AsdfFile(tree) as af:
         af.write_to(config_file)
@@ -105,8 +112,8 @@ def config_file_step(tmpdir):
         'name': 'SimpleStep',
         'parameters': {
             'str1': 'from config',
-            'str2': 'from config'
-        }
+            'str2': 'from config',
+        },
     }
     with asdf.AsdfFile(tree) as af:
         af.write_to(config_file)
@@ -124,8 +131,7 @@ def config_file_list_arg_step(tmpdir):
         'parameters': {
             'rotation': None,
             'pixel_scale_ratio': 1.1,
-
-        }
+        },
     }
     with asdf.AsdfFile(tree) as af:
         af.write_to(config_file)
@@ -135,13 +141,22 @@ def config_file_list_arg_step(tmpdir):
 @pytest.fixture
 def mock_step_crds(monkeypatch):
     """Mock various crds calls from Step"""
+
     def mock_get_config_from_reference_pipe(dataset, disable=None):
-        config = cp.config_from_dict({
-            'str1': 'from crds', 'str2': 'from crds', 'str3': 'from crds',
-            'steps' : {
-                'step1': {'str1': 'from crds', 'str2': 'from crds', 'str3': 'from crds'},
+        config = cp.config_from_dict(
+            {
+                'str1': 'from crds',
+                'str2': 'from crds',
+                'str3': 'from crds',
+                'steps': {
+                    'step1': {
+                        'str1': 'from crds',
+                        'str2': 'from crds',
+                        'str3': 'from crds',
+                    },
+                },
             }
-        })
+        )
         return config
 
     def mock_get_config_from_reference_step(dataset, disable=None):
@@ -193,8 +208,12 @@ def test_build_config_pipe_default():
 
 def test_build_config_pipe_kwarg(mock_step_crds, config_file_pipe):
     """Test that kwargs override CRDS and local param reffiles"""
-    config, returned_config_file = SimplePipe.build_config('science.fits', config_file=config_file_pipe,
-                                                           str1='from kwarg', steps={'step1': {'str1': 'from kwarg'}})
+    config, returned_config_file = SimplePipe.build_config(
+        'science.fits',
+        config_file=config_file_pipe,
+        str1='from kwarg',
+        steps={'step1': {'str1': 'from kwarg'}},
+    )
     assert returned_config_file == config_file_pipe
     assert config['str1'] == 'from kwarg'
     assert config['str2'] == 'from config'
@@ -240,21 +259,22 @@ def test_build_config_step_kwarg(mock_step_crds, config_file_step):
 
 
 def test_step_list_args(mock_step_crds, config_file_list_arg_step):
-    """ Test that list arguments, provided as comma-separated values are parsed
-        correctly.
+    """Test that list arguments, provided as comma-separated values are parsed
+    correctly.
     """
-    config, returned_config_file = ListArgStep.build_config(
-        'science.fits',
-        config_file=config_file_list_arg_step
-    )
+    config, returned_config_file = ListArgStep.build_config('science.fits', config_file=config_file_list_arg_step)
     assert returned_config_file == config_file_list_arg_step
     c, *_ = cmdline.just_the_step_from_cmdline(
-        ['filename.fits',
-         '--output_shape', '1500,1300',
-         '--crpix=123,456',
-         '--pixel_scale=0.75',
-         '--config-file', returned_config_file],
-        ListArgStep
+        [
+            'filename.fits',
+            '--output_shape',
+            '1500,1300',
+            '--crpix=123,456',
+            '--pixel_scale=0.75',
+            '--config-file',
+            returned_config_file,
+        ],
+        ListArgStep,
     )
     assert c.rotation is None
     assert c.pixel_scale == 0.75
@@ -265,60 +285,71 @@ def test_step_list_args(mock_step_crds, config_file_list_arg_step):
 
     with pytest.raises(ValueError) as e:
         cmdline.just_the_step_from_cmdline(
-                ['filename.fits',
-                 '--output_shape', '1500,1300,90',
-                 '--crpix=123,456',
-                 '--pixel_scale=0.75',
-                 '--config-file', returned_config_file],
-                ListArgStep
+            [
+                'filename.fits',
+                '--output_shape',
+                '1500,1300,90',
+                '--crpix=123,456',
+                '--pixel_scale=0.75',
+                '--config-file',
+                returned_config_file,
+            ],
+            ListArgStep,
         )
-    assert (e.value.args[0] == "Config parameter 'output_shape': the value "
-            "\"['1500', '1300', '90']\" is too long.")
+    assert e.value.args[0] == "Config parameter 'output_shape': the value " "\"['1500', '1300', '90']\" is too long."
 
     with pytest.raises(ValueError) as e:
         cmdline.just_the_step_from_cmdline(
-                ['filename.fits',
-                 '--output_shape', '1500,',
-                 '--crpix=123,456',
-                 '--pixel_scale=0.75',
-                 '--config-file', returned_config_file],
-                ListArgStep
+            [
+                'filename.fits',
+                '--output_shape',
+                '1500,',
+                '--crpix=123,456',
+                '--pixel_scale=0.75',
+                '--config-file',
+                returned_config_file,
+            ],
+            ListArgStep,
         )
-    assert (e.value.args[0] == "Config parameter 'output_shape': the value "
-            "\"['1500']\" is too short.")
+    assert e.value.args[0] == "Config parameter 'output_shape': the value " "\"['1500']\" is too short."
 
     with pytest.raises(ValueError) as e:
         cmdline.just_the_step_from_cmdline(
-                ['filename.fits',
-                 '--output_shape', '1500',
-                 '--crpix=123,456',
-                 '--pixel_scale=0.75',
-                 '--config-file', returned_config_file],
-                ListArgStep
+            [
+                'filename.fits',
+                '--output_shape',
+                '1500',
+                '--crpix=123,456',
+                '--pixel_scale=0.75',
+                '--config-file',
+                returned_config_file,
+            ],
+            ListArgStep,
         )
-    assert (e.value.args[0] == "Config parameter 'output_shape': the value "
-            "\"1500\" is of the wrong type.")
+    assert e.value.args[0] == "Config parameter 'output_shape': the value " "\"1500\" is of the wrong type."
 
     with pytest.raises(ValueError) as e:
         cmdline.just_the_step_from_cmdline(
-                ['filename.fits',
-                 '--output_shape', '1500.5,1300.2',
-                 '--crpix=123,456',
-                 '--pixel_scale=0.75',
-                 '--config-file', returned_config_file],
-                ListArgStep
+            [
+                'filename.fits',
+                '--output_shape',
+                '1500.5,1300.2',
+                '--crpix=123,456',
+                '--pixel_scale=0.75',
+                '--config-file',
+                returned_config_file,
+            ],
+            ListArgStep,
         )
-    assert (e.value.args[0] == "Config parameter 'output_shape': the value "
-            "\"1500.5\" is of the wrong type.")
+    assert e.value.args[0] == "Config parameter 'output_shape': the value " "\"1500.5\" is of the wrong type."
 
 
 def test_logcfg_routing(tmpdir):
-
     cfg = f"""[*]\nlevel = INFO\nhandler = file:{tmpdir}/myrun.log"""
 
     logcfg_file = str(tmpdir / 'stpipe-log.cfg')
 
-    with open(logcfg_file,'w') as f:
+    with open(logcfg_file, 'w') as f:
         f.write(cfg)
 
     LoggingPipeline.call(logcfg=logcfg_file)


### PR DESCRIPTION
Apply the the code formatters:

- [`isort`](https://pycqa.github.io/isort/) to consistently sort imports
- [`black`](https://black.readthedocs.io/en/stable/) to consistently format the code base.

These will help keep the codebase consistently formatted, and are recommend to be used in conjunction with the `ruff` linter that `stpipe` is already using.

I also adjusted the the line-length restriction from 130 down to a more reasonable (and the `black` standard) length of 88.

Note that this is base on PR #79 and so it should be merged after it.