### PR TITLE
Start using `codespell`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-# automatically requests pull request reviews for files matching the given pattern; the last match takes precendence
+# automatically requests pull request reviews for files matching the given pattern; the last match takes precedence
 
 *       @spacetelescope/stpipe-maintainers

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,14 @@ repos:
     - id: rst-inline-touching-normal
     - id: text-unicode-replacement-char
 
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.2.2
+  hooks:
+    - id: codespell
+      args: ["--write-changes"]
+      additional_dependencies:
+        - tomli
+
 - repo: https://github.com/asottile/pyupgrade
   rev: 'v3.3.1'
   hooks:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@
 - Start using ``pre-commit`` to handle style checks. [#79]
 - Apply the ``isort`` and ``black`` code formatters and reduce the line length
   maximum to 88 characters. [#80]
+- Add spell checking through the ``codespell`` tool. [#81]
 
 0.4.6 (2023-03-27)
 ==================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,3 +115,8 @@ force-exclude = '''
   )/
 )
 '''
+
+[tool.codespell]
+skip="*.pdf,*.fits,*.asdf,.tox,build,./tags,.git,docs/_build"
+# ignore-words-list="""
+# """

--- a/src/stpipe/datamodel.py
+++ b/src/stpipe/datamodel.py
@@ -18,7 +18,7 @@ class AbstractDataModel(abc.ABC):
     @classmethod
     def __subclasshook__(cls, C):
         """
-        Psuedo subclass check based on these attributes and methods
+        Pseudo subclass check based on these attributes and methods
         """
         if cls is AbstractDataModel:
             mro = C.__mro__

--- a/src/stpipe/extern/__init__.py
+++ b/src/stpipe/extern/__init__.py
@@ -2,7 +2,7 @@
 This package contains python package(s) that are bundled with jwst but are
 external to jwst, and hence are developed in a separate source tree.
 
-Currenty the bundled external dependencies are:
+Currently the bundled external dependencies are:
 
 .. _ConfigObj: https://github.com/DiffSK/configobj
 """

--- a/src/stpipe/extern/configobj/configobj.py
+++ b/src/stpipe/extern/configobj/configobj.py
@@ -848,7 +848,7 @@ class Section(dict):
         unless ``raise_errors=False``, in which case set the return value to
         ``False``.
 
-        Any unrecognised keyword arguments you pass to walk, will be pased on
+        Any unrecognised keyword arguments you pass to walk, will be passed on
         to the function you pass in.
 
         Note: if ``call_on_sections`` is ``True`` then - on encountering a

--- a/src/stpipe/extern/configobj/configobj.py
+++ b/src/stpipe/extern/configobj/configobj.py
@@ -245,7 +245,7 @@ class DuplicateError(ConfigObjError):
 
 class ConfigspecError(ConfigObjError):
     """
-    An error occured whilst parsing a configspec.
+    An error occurred whilst parsing a configspec.
     """
 
 
@@ -844,7 +844,7 @@ class Section(dict):
 
         Return a dictionary of the return values
 
-        If the function raises an exception, raise the errror
+        If the function raises an exception, raise the error
         unless ``raise_errors=False``, in which case set the return value to
         ``False``.
 
@@ -1526,7 +1526,7 @@ class ConfigObj(Section):
         into strings.
         """
         if not isinstance(value, str):
-            # intentially 'str' because it's just whatever the "normal"
+            # intentionally 'str' because it's just whatever the "normal"
             # string type is for the python version we're dealing with
             return str(value)
         else:
@@ -1724,7 +1724,7 @@ class ConfigObj(Section):
         Handle an error according to the error settings.
 
         Either raise the error or store it.
-        The error will have occured at ``cur_index``
+        The error will have occurred at ``cur_index``
         """
         line = infile[cur_index]
         cur_index += 1
@@ -1781,7 +1781,7 @@ class ConfigObj(Section):
                 for val in value])
         if not isinstance(value, str):
             if self.stringify:
-                # intentially 'str' because it's just whatever the "normal"
+                # intentionally 'str' because it's just whatever the "normal"
                 # string type is for the python version we're dealing with
                 value = str(value)
             else:

--- a/src/stpipe/extern/configobj/validate.py
+++ b/src/stpipe/extern/configobj/validate.py
@@ -942,7 +942,7 @@ def is_boolean(value):
         except KeyError:
             raise VdtTypeError(value)
     # we do an equality test rather than an identity test
-    # this ensures Python 2.2 compatibilty
+    # this ensures Python 2.2 compatibility
     # and allows 0 and 1 to represent True and False
     if value == False:
         return False
@@ -1229,7 +1229,7 @@ def force_list(value, min=None, max=None):
     trailing comma that turns a single value into a list.
 
     You can optionally specify the minimum and maximum number of members.
-    A minumum of greater than one will fail if the user only supplies a
+    A minimum of greater than one will fail if the user only supplies a
     string.
 
     >>> vtor.check('force_list', ())

--- a/src/stpipe/format_template.py
+++ b/src/stpipe/format_template.py
@@ -37,7 +37,7 @@ class FormatTemplate(Formatter):
         A Python format string
 
     separator : string
-        Separater to use for values which have no
+        Separator to use for values which have no
         matching replacement strings
 
     key_formats : dict or None

--- a/src/stpipe/format_template.py
+++ b/src/stpipe/format_template.py
@@ -111,7 +111,7 @@ class FormatTemplate(Formatter):
         ----------
         separator : str
             For key/value pairs given that do not have a
-            replacement field, the values are appened to
+            replacement field, the values are appended to
             the string using this separator.
 
         key_formats : {key: format(, ...)}

--- a/src/stpipe/log.py
+++ b/src/stpipe/log.py
@@ -229,7 +229,7 @@ class DelegationHandler(logging.Handler):
     """
     A handler that delegates messages along to the currently active
     `Step` logger.  It only delegates messages that come from outside
-    of the `stpipe` heirarchy, in order to prevent infinite recursion.
+    of the `stpipe` hierarchy, in order to prevent infinite recursion.
 
     Since we could be multi-threaded and each thread may be running a
     different thread, we need to manage a dictionary mapping the

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -581,7 +581,7 @@ class Step:
 
     def prefetch(self, *args):
         """Prefetch reference files,  nominally called when
-        self.prefetch_references is True.  Can be called explictly
+        self.prefetch_references is True.  Can be called explicitly
         when self.prefetch_refences is False.
         """
         # prefetch truly occurs at the Pipeline (or subclass) level.
@@ -673,7 +673,7 @@ class Step:
         return self.name.lower()
 
     def search_attr(self, attribute, default=None, parent_first=False):
-        """Return first non-None attribute in step heirarchy
+        """Return first non-None attribute in step hierarchy
 
         Parameters
         ----------


### PR DESCRIPTION
[`codespell`](https://github.com/codespell-project/codespell) is a tool which is designed to check for misspelled words in source code. This PR sets up a reasonable configuration for `codespell`, fixes all the errors `codespell` uncovered, and adds `codespell` to the basic style checks for `stpipe`. Note that `codespell` can both autofix many common misspellings and be configured to ignore some misspellings by adding words to the `ignore-words-list` in the `pyproject.toml` file.

Note that this PR is built on top of the changes in #80 and so should be merged after PR #80