### PR TITLE
to match jwst testing, ignore scripts in jwst ci job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
       - run: pip install ".[test]" pytest-xdist pytest-cov
       - run: pip install "jwst[test] @ git+https://github.com/spacetelescope/jwst.git"
       - run: pip freeze
-      - run: pytest -n auto --cov-report=xml --cov=src/stpipe --ignore-glob=timeconversion --ignore-glob=associations --pyargs jwst
+      - run: pytest -n auto --cov-report=xml --cov=src/stpipe --ignore-glob=timeconversion --ignore-glob=associations --ignore-glob=scripts --pyargs jwst
         env:
           CRDS_SERVER_URL: https://jwst-crds.stsci.edu
       - run: coverage report -m


### PR DESCRIPTION
this package suffers from the same issue as gwcs: https://github.com/spacetelescope/gwcs/pull/444

jwst ignores the scripts directory for pytest
https://github.com/spacetelescope/jwst/blob/4285c4efb95bc368f36456e9e106e6aba6abd597/setup.cfg#L152

this PR replicates that ignore to address CI failures seen for:
#82 