### PR TITLE
update entry_points to use importlib.metadata

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,8 @@
 0.4.6 (unreleased)
 ==================
 
--
+- add ``importlib.metadata`` as a dependency and update loading of entry_points to drop
+  usage of pkg_resources [#84]
 
 0.4.5 (2022-12-23)
 ==================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     'crds>=7.4.1.3',
     'astropy>=5.0.4',
     'stdatamodels>=0.2.4',
+    'importlib_metadata>=4.11.4',
 ]
 dynamic = ['version']
 

--- a/src/stpipe/entry_points.py
+++ b/src/stpipe/entry_points.py
@@ -1,6 +1,7 @@
-from pkg_resources import iter_entry_points
 from collections import namedtuple
 import warnings
+
+from importlib_metadata import entry_points
 
 
 STEPS_GROUP = "stpipe.steps"
@@ -23,8 +24,8 @@ def get_steps():
     """
     steps = []
 
-    for entry_point in iter_entry_points(group=STEPS_GROUP):
-        package_name = entry_point.dist.project_name
+    for entry_point in entry_points(group=STEPS_GROUP):
+        package_name = entry_point.dist.name
         package_version = entry_point.dist.version
         package_steps = []
 


### PR DESCRIPTION
~EDIT: The `astropy>=5.0.4` dependency has a `python >= 3.8` requirement:
https://github.com/astropy/astropy/blob/326435449ad8d859f1abf36800c3fb88d49c27ea/setup.cfg#L35
and the CI does not test 3.7. This PR increases the minimum python version to 3.8 which allows for use of importlib.metadata (see conversation below: https://github.com/spacetelescope/stpipe/pull/84#discussion_r1125726227)~

use of pkg_resources is discouraged:
https://setuptools.pypa.io/en/latest/pkg_resources.html

additionally, this should fix potential version conflicts where dependency versions are checked on entry point loading for pkg_resources which can cause tests in CI jobs to fail when testing against a development version. Here is one example:

jwst pins stdatamodels to <1.2
stdatamodels tests against jwst as part of it's CI
stdatamodels development is currently on 1.2
the CI job installs the development >=1.2 version of stdatamodels and development version of jwst (install is forced to ignore the version conflict)
the CI job runs and all stpipe tests fail, raising `VersionConflict` when the jwst stpipe entry point is loaded due to pkg_resources checking versions at runtime:
https://github.com/spacetelescope/stdatamodels/actions/runs/4315086232/jobs/7528977635#step:12:848

Testing locally this runtime version checking does not appear to happen with importlib.metadata.