### PR TITLE
require python >= 3.8 and update minimum dependencies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@
 
 - add ``importlib.metadata`` as a dependency and update loading of entry_points to drop
   usage of pkg_resources [#84]
+- update minimum python to 3.8 and ASDF version to 2.8 [#87]
 
 0.4.5 (2022-12-23)
 ==================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = 'stpipe'
 description = 'Framework for calibration pipeline software'
 readme = 'README.md'
-requires-python = '>=3.7'
+requires-python = '>=3.8'
 license = { file = 'LICENSE' }
 authors = [{ name = 'STScI', email = 'help@stsci.edu' }]
 classifiers = [
@@ -12,7 +12,7 @@ classifiers = [
     'Programming Language :: Python :: 3',
 ]
 dependencies = [
-    'asdf>=2.7.1',
+    'asdf>=2.8.0',
     'crds>=7.4.1.3',
     'astropy>=5.0.4',
     'stdatamodels>=0.2.4',
@@ -30,8 +30,8 @@ docs = [
     'tomli; python_version <"3.11"',
 ]
 test = [
-    'pytest >=4.6.0',
-    'pytest-doctestplus',
+    'pytest >=7.0.0',
+    'pytest-doctestplus >=0.10.0',
     'pytest-openfiles >=0.5.0',
 ]
 


### PR DESCRIPTION
While testing the minimum ASDF version for #82 I noticed a few other minimum version issues.

The CI only tests python >= 3.8 (this PR updates the `pyproject.toml` minimum python version to reflect this).

I was unable to get the tests to pass locally (running in python 3.10) with the minimum versions lists in the `pyproject.toml`. The changes in this PR were sufficient to allow the tests to pass.