### PR TITLE
Remove use of `pytest-openfiles`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
 ==================
 
 - Remove use of deprecated ``pytest-openfiles`` ``pytest`` plugin. This has been replaced by
-  catching ``ResourceWarning`` s. [#7526]
+  catching ``ResourceWarning`` s. [#90]
 
 0.4.6 (2023-03-27)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+0.5.0 (unreleased)
+==================
+
+- Remove use of deprecated ``pytest-openfiles`` ``pytest`` plugin. This has been replaced by
+  catching ``ResourceWarning`` s. [#7526]
+
 0.4.6 (2023-03-27)
 ==================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ docs = [
 test = [
     'pytest >=7.0.0',
     'pytest-doctestplus >=0.10.0',
-    'pytest-openfiles >=0.5.0',
 ]
 
 [project.urls]
@@ -67,12 +66,15 @@ minversion = 4.6
 doctest_plus = true
 doctest_rst = true
 text_file_format = 'rst'
-addopts = '--open-files'
+addopts = ''
 norecursedirs = [
     'src/stpipe/extern',
 ]
 testpaths = [
     'tests',
+]
+filterwarnings = [
+    "error::ResourceWarning",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
`pytest-openfiles` has been deprecated and is interfering with the use of fixtures in our test code (ones that handle files). This PR switches `ResourceWarnings` into errors which will catch almost all cases of files left open. The only cases it does not catch is if an open file handle is assigned to a global variable as the "warning" will not be emitted until python stops running, which occurs after pytest has completed.

Similar to spacetelescope/romancal#666