### PR TITLE
Remove `stdatamodels` dependency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,12 +3,12 @@
 
 - Remove use of deprecated ``pytest-openfiles`` ``pytest`` plugin. This has been replaced by
   catching ``ResourceWarning`` s. [#90]
-
 - Start using ``pre-commit`` to handle style checks. [#79]
 - Apply the ``isort`` and ``black`` code formatters and reduce the line length
   maximum to 88 characters. [#80]
 - Add spell checking through the ``codespell`` tool. [#81]
 - Drop support for Python 3.8 [#93]
+- Remove ``stdatamodels`` dependency, as it is no longer used. [#91]
 
 0.4.6 (2023-03-27)
 ==================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
     'asdf>=2.13',
     'crds>=7.4.1.3',
     'astropy>=5.0.4',
-    'stdatamodels>=0.2.4',
     'importlib_metadata>=4.11.4',
 ]
 dynamic = ['version']

--- a/src/stpipe/crds_client.py
+++ b/src/stpipe/crds_client.py
@@ -12,7 +12,6 @@ import re
 import crds
 from crds.core import config, crds_cache_locking, heavy_client, log
 from crds.core.exceptions import CrdsError
-from stdatamodels import s3_utils
 
 __all__ = [
     "check_reference_open",
@@ -33,7 +32,7 @@ def get_multiple_reference_paths(parameters, reference_file_types, observatory):
     ----------
     parameters : dict
         Parameters used by CRDS to compute best references.  Can
-        be obtained from `~stdatamodels.DataModel.get_crds_parameters`.
+        be obtained from `DataModel.get_crds_parameters`.
 
     reference_file_types : list of str
         List of reference file types.
@@ -81,12 +80,8 @@ def check_reference_open(refpath):
     Ignore reference path values of "N/A" or "" for checking.
     """
     if refpath != "N/A" and refpath.strip() != "":
-        if s3_utils.is_s3_uri(refpath):
-            if not s3_utils.object_exists(refpath):
-                raise RuntimeError("S3 object does not exist: " + refpath)
-        else:
-            with open(refpath, "rb"):
-                pass
+        with open(refpath, "rb"):
+            pass
     return refpath
 
 

--- a/src/stpipe/extern/configobj/validate.py
+++ b/src/stpipe/extern/configobj/validate.py
@@ -163,9 +163,6 @@ __all__ = (
 
 import re
 import sys
-from pprint import pprint
-
-from stdatamodels import DataModel
 
 #TODO - #21 - six is part of the repo now, but we didn't switch over to it here
 # this could be replaced if six is used for compatibility, or there are no


### PR DESCRIPTION
`romancal` has a dependency of `stdatamodels`; however, there should not be a dependency of the Roman pipeline on JWST pipeline specific packages.

The dependency is due to the `stdatamodels.s3_utils` module, which is a thing wrapper of the now unsupported `stsci-aws-utils` package. The introduction of `s3_utils` was largely due to an experiment to see if the `jwst` pipeline could load reference files from S3. While this experiment was apparently successful, it was intended to be a one-off demonstration and has been largely unused since it completed. @eslavich can provide more details. Moreover, the implantation of S3 support requires client code in `jwst` and `romancal` to know the source of input data (S3 or local filesystem) and handle the opening of internal files in a distinct fashion.  Ideally the steps consuming reference files should not have to be aware of the origin of their files. Instead, CRDS, which provides these files to the steps, should handle this type of detail.