### PR TITLE
Apply `flynt`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,12 @@ repos:
       additional_dependencies:
         - tomli
 
+- repo: https://github.com/ikamensh/flynt/
+  rev: '0.78'
+  hooks:
+    - id: flynt
+      exclude: "src/stpipe/extern/.*"
+
 - repo: https://github.com/asottile/pyupgrade
   rev: 'v3.3.1'
   hooks:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@
 - Add spell checking through the ``codespell`` tool. [#81]
 - Drop support for Python 3.8 [#93]
 - Remove ``stdatamodels`` dependency, as it is no longer used. [#91]
+- Add ``flynt`` string update checking tool. [#92]
 
 0.4.6 (2023-03-27)
 ==================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,9 @@ force-exclude = '''
 )
 '''
 
+[tool.flynt]
+exclude = ["src/stpipe/extern/*"]
+
 [tool.codespell]
 skip="*.pdf,*.fits,*.asdf,.tox,build,./tags,.git,docs/_build"
 # ignore-words-list="""

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -16,15 +16,13 @@ def clean_up_logging():
 def test_configuration(tmpdir):
     logfilename = tmpdir.join("output.log")
 
-    configuration = """
+    configuration = f"""
 [.]
-handler = file:{}
+handler = file:{logfilename}
 break_level = ERROR
 level = WARNING
 format = '%(message)s'
-""".format(
-        logfilename
-    )
+"""
 
     fd = io.StringIO()
     fd.write(configuration)


### PR DESCRIPTION
`flynt` is a tool to help update Python strings to using modern methods.

This PR applies `flynt` to `stpipe` and updates its `pre-commit` to continue to check that `flynt` does not find more things to upgrade.