### PR TITLE
drop support for Python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,7 @@ jobs:
     with:
       envs: |
         - linux: test-oldestdeps-cov-xdist
-          python-version: 3.8
-        - linux: test-xdist
-          python-version: '3.8'
+          python-version: 3.9
         - linux: test-xdist
           python-version: '3.9'
         - linux: test-xdist

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -13,8 +13,6 @@ jobs:
     with:
       envs: |
         - macos: test-xdist
-          python-version: 3.8
-        - macos: test-xdist
           python-version: 3.9
         - macos: test-xdist
           python-version: 3.10

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@
 - Apply the ``isort`` and ``black`` code formatters and reduce the line length
   maximum to 88 characters. [#80]
 - Add spell checking through the ``codespell`` tool. [#81]
+- Drop support for Python 3.8 [#93]
 
 0.4.6 (2023-03-27)
 ==================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = 'stpipe'
 description = 'Framework for calibration pipeline software'
 readme = 'README.md'
-requires-python = '>=3.8'
+requires-python = '>=3.9'
 license = { file = 'LICENSE' }
 authors = [{ name = 'STScI', email = 'help@stsci.edu' }]
 classifiers = [


### PR DESCRIPTION
Numpy is imminently dropping support for Python 3.8