### PR TITLE
Switch to using mamba for RTD

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,22 +5,31 @@
 # Required
 version: 2
 
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "mambaforge-4.10"
+
+conda:
+  environment: docs/rtd_environment.yaml
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   builder: html
   configuration: docs/source/conf.py
   fail_on_warning: true
 
-# Optionally build your docs in additional formats such as PDF and ePub
-formats:
-  - htmlzip
-  - pdf
-
-# Optionally set the version of Python and requirements required to build your docs
+# Install regular dependencies.
+# Then, install special pinning for RTD.
 python:
-  version: 3.8
+  system_packages: false
   install:
     - method: pip
       path: .
       extra_requirements:
         - docs
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats:
+  - htmlzip
+  - pdf

--- a/docs/rtd_environment.yaml
+++ b/docs/rtd_environment.yaml
@@ -1,0 +1,8 @@
+name: rtd311
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.11
+  - pip
+  - graphviz


### PR DESCRIPTION
Properly switches RTD to using `mamba` to build python environment.