### PR TITLE
Put context around model opening.

### DIFF
--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -825,12 +825,12 @@ class Step:
             # If the dataset is not an operable instance of AbstractDataModel,
             # log as such and return an empty config object
             try:
-                model = cls._datamodels_open(dataset)
-                if isinstance(model, Sequence):
-                    # Pull out first model in ModelContainer
-                    model = model[0]
-                crds_parameters = model.get_crds_parameters()
-                crds_observatory = model.crds_observatory
+                with cls._datamodels_open(dataset) as model:
+                    if isinstance(model, Sequence):
+                        # Pull out first model in ModelContainer
+                        model = model[0]
+                    crds_parameters = model.get_crds_parameters()
+                    crds_observatory = model.crds_observatory
             except (OSError, TypeError, ValueError):
                 logger.warning("Input dataset is not an instance of AbstractDataModel.")
                 disable = True


### PR DESCRIPTION
stpipe currently leaves some files open due to this block, which trigger `ResourceWarning: unclosed file` in the Roman regression tests.  This PR adds a context manager around the model opening to close these files.  This eliminates the ResourceWarnings in romancal.

I have not run any detailed tests against stpipe, but wanted to be able to point people to this PR, thus the draft status.

In the context of Roman I am told that opening a model with units triggers also opening all of the associated binary extensions (lazy loading isn't used there?).  So pulling these parameters ends up being pretty expensive.  But we need to address that on the Roman side.