### PR TITLE
Print out jwst or romancal versions from strun --version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 0.5.1 (unreleased)
 ==================
 
--
+- Print out ``jwst`` or ``romancal`` versions from ``strun --version``. [#98]
 
 0.5.0 (2023-04-19)
 ==================

--- a/scripts/strun
+++ b/scripts/strun
@@ -14,9 +14,8 @@ Other status codes are Step implementation-specific.
 import sys
 
 from stpipe import Step
-from stpipe.exceptions import StpipeExitException
 from stpipe.cli.main import _print_versions
-
+from stpipe.exceptions import StpipeExitException
 
 if __name__ == "__main__":
     if "--version" in sys.argv:

--- a/scripts/strun
+++ b/scripts/strun
@@ -13,13 +13,14 @@ Other status codes are Step implementation-specific.
 
 import sys
 
-import stpipe
 from stpipe import Step
 from stpipe.exceptions import StpipeExitException
+from stpipe.cli.main import _print_versions
+
 
 if __name__ == "__main__":
     if "--version" in sys.argv:
-        sys.stdout.write(f"{stpipe.__version__}\n")
+        _print_versions()
         sys.exit(0)
 
     try:


### PR DESCRIPTION
This modifies the version printout from `strun` to include the version of any stpipe entry points, i.e. `jwst` and `romancal`.  I.e. it mimics what `stpipe --version` does.

```
$ strun --version
stpipe: 0.5.0
jwst: 1.11.3
```

Resolves https://github.com/spacetelescope/jwst/issues/7470