### PR TITLE
deprecate `preserve_comments` fix spec parsing for inline comments with closing parenthesis

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 - Print out ``jwst`` or ``romancal`` versions from ``strun --version``. [#98]
 - Print default parameter values for ``strun <step_alias> --help`` [#101]
 - Move ``strun`` to entrypoints [#101]
+- Deprecate ``preserve_comments`` fix spec parsing for inline comments with
+  a closing parenthesis [#107]
 
 0.5.0 (2023-04-19)
 ==================

--- a/src/stpipe/cmdline.py
+++ b/src/stpipe/cmdline.py
@@ -279,7 +279,7 @@ def just_the_step_from_cmdline(args, cls=None):
     # all of the expected reference files
 
     # load_spec_file is a method of both Step and Pipeline
-    spec = step_class.load_spec_file(preserve_comments=True)
+    spec = step_class.load_spec_file()
 
     parser2 = _build_arg_parser_from_spec(spec, step_class, parent=parser1)
 

--- a/src/stpipe/config_parser.py
+++ b/src/stpipe/config_parser.py
@@ -5,6 +5,7 @@ import logging
 import os
 import os.path
 import textwrap
+import warnings
 from inspect import isclass
 
 from asdf import ValidationError as AsdfValidationError
@@ -20,6 +21,7 @@ from .extern.configobj.configobj import (
     get_extra_values,
 )
 from .extern.configobj.validate import ValidateError, Validator, VdtTypeError
+from .utilities import _not_set
 
 # Configure logger
 logger = logging.getLogger(__name__)
@@ -130,7 +132,7 @@ def _config_obj_from_step_config(config):
     return configobj
 
 
-def get_merged_spec_file(cls, preserve_comments=False):
+def get_merged_spec_file(cls, preserve_comments=_not_set):
     """
     Creates a merged spec file for a Step class and all of its
     subclasses.
@@ -141,6 +143,8 @@ def get_merged_spec_file(cls, preserve_comments=False):
         A class or instance of a `Step`-based class.
 
     preserve_comments : bool, optional
+        This argument is deprecated and appears to have no
+        effect on the returned spec.
         When True, preserve the comments in the spec file
     """
     if not isclass(cls):
@@ -162,7 +166,7 @@ def get_merged_spec_file(cls, preserve_comments=False):
     return config
 
 
-def load_spec_file(cls, preserve_comments=False):
+def load_spec_file(cls, preserve_comments=_not_set):
     """
     Load the spec file corresponding to the given class.
 
@@ -172,6 +176,8 @@ def load_spec_file(cls, preserve_comments=False):
         A class or instance of a `Step`-based class.
 
     preserve_comments: bool
+        This argument is deprecated and appears to have no
+        effect on the returned spec.
         True to keep comments in the resulting `ConfigObj`
 
     Returns
@@ -179,6 +185,9 @@ def load_spec_file(cls, preserve_comments=False):
     spec_file: ConfigObj
         The resulting configuration object
     """
+    if preserve_comments is not _not_set:
+        msg = "preserve_comments is deprecated"
+        warnings.warn(msg, DeprecationWarning)
     # Don't use 'hasattr' here, because we don't want to inherit spec
     # from the base class.
     if not isclass(cls):

--- a/src/stpipe/config_parser.py
+++ b/src/stpipe/config_parser.py
@@ -199,7 +199,6 @@ def load_spec_file(cls, preserve_comments=False):
     if spec_file:
         return ConfigObj(
             spec_file,
-            _inspec=not preserve_comments,
             raise_errors=True,
             list_values=False,
         )

--- a/src/stpipe/pipeline.py
+++ b/src/stpipe/pipeline.py
@@ -7,6 +7,7 @@ from os.path import dirname, join
 from . import config_parser, crds_client, log
 from .extern.configobj.configobj import ConfigObj, Section
 from .step import Step, get_disable_crds_steppars
+from .utilities import _not_set
 
 # For classmethods, the logger to use is the
 # delegator, since the pipeline has not yet been instantiated.
@@ -112,7 +113,7 @@ class Pipeline(Step):
         return config
 
     @classmethod
-    def load_spec_file(cls, preserve_comments=False):
+    def load_spec_file(cls, preserve_comments=_not_set):
         spec = config_parser.get_merged_spec_file(
             cls, preserve_comments=preserve_comments
         )

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -29,6 +29,7 @@ except ImportError:
 from . import config, config_parser, crds_client, log, utilities
 from .datamodel import AbstractDataModel
 from .format_template import FormatTemplate
+from .utilities import _not_set
 
 
 class Step:
@@ -90,7 +91,7 @@ class Step:
         return config
 
     @classmethod
-    def load_spec_file(cls, preserve_comments=False):
+    def load_spec_file(cls, preserve_comments=_not_set):
         spec = config_parser.get_merged_spec_file(
             cls, preserve_comments=preserve_comments
         )
@@ -105,7 +106,7 @@ class Step:
 
     @classmethod
     def print_configspec(cls):
-        specfile = cls.load_spec_file(preserve_comments=True)
+        specfile = cls.load_spec_file()
         specfile.write(sys.stdout.buffer)
 
     @classmethod

--- a/src/stpipe/utilities.py
+++ b/src/stpipe/utilities.py
@@ -135,3 +135,16 @@ def get_fully_qualified_class_name(cls_or_obj):
         return cls.__name__  # Avoid reporting __builtin__
     else:
         return module + "." + cls.__name__
+
+
+class _NotSet:
+    """
+    Special value indicating that a parameter is not set.  Distinct
+    from None. Instead of using this class use the _not_set instance
+    below
+    """
+
+    pass
+
+
+_not_set = _NotSet()

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -1,7 +1,11 @@
+import contextlib
 from collections.abc import Mapping
+
+import pytest
 
 from stpipe import config_parser
 from stpipe.extern.configobj.configobj import ConfigObj, Section
+from stpipe.utilities import _not_set
 
 
 def test_merge_config_nested_mapping():
@@ -31,3 +35,26 @@ def test_merge_config_nested_mapping():
     config_parser.merge_config(config, {"foo": TestMapping({"bar": "baz"})})
     assert isinstance(config["foo"], TestMapping)
     assert config["foo"]["bar"] == "baz"
+
+
+@pytest.mark.parametrize("value", [True, False, None, _not_set])
+def test_preserve_comments_deprecation(value):
+    class Foo:
+        spec = """
+        # initial comment
+        bar = string(default='bam')  # an inline comment (with parentheses)
+        # final comment
+        """
+
+    # if preserve_comments is _not_set there should be no warning
+    if value is _not_set:
+        ctx = contextlib.nullcontext()
+    else:
+        ctx = pytest.warns(DeprecationWarning)
+
+    with ctx:
+        spec = config_parser.load_spec_file(Foo, preserve_comments=value)
+
+    assert "initial comment" in spec.initial_comment[0]
+    assert "final comment" in spec.final_comment[0]
+    assert "inline comment (with parentheses)" in spec.inline_comments["bar"]


### PR DESCRIPTION
Fixes #105 

The `preserve_comments` argument ends up mapping to the `_inspec` argument for `ConfigObj`. Setting this appears to break parsing of spec lines that contain inline comments with a closing parenthesis. The `preserve_comments` argument also appears to have no effect on parsing comments (aside from introducing the bug above).

This PR deprecates `preserve_comments` and removes internal usage of the `_inspec` argument. This should fix parsing inline comments for closing parenthesis (this is tested in the included test) and have no effect on comment parsing (also included in the test).

Doing a quick search through romancal and jwst I see no usage of the `preserve_comments` argument so I don't expect either of those packages to require updates. Hopefully regression tests (to be run below) will reveal if there are any issues with these changes.