### PR TITLE
replace regex in configobj

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@
 - Move ``strun`` to entrypoints [#101]
 - Deprecate ``preserve_comments`` fix spec parsing for inline comments with
   a closing parenthesis [#107]
+- Fix regex issue in internal configobj [#108]
 
 0.5.0 (2023-04-19)
 ==================

--- a/src/stpipe/extern/configobj/validate.py
+++ b/src/stpipe/extern/configobj/validate.py
@@ -537,7 +537,7 @@ class Validator:
     """
 
     # this regex does the initial parsing of the checks
-    _func_re = re.compile(r'(.+?)\((.*)\)', re.DOTALL)
+    _func_re = re.compile(r'([^\(\)]+?)\((.*)\)', re.DOTALL)
 
     # this regex takes apart keyword arguments
     _key_arg = re.compile(r'^([a-zA-Z_][a-zA-Z0-9_]*)\s*=\s*(.*)$',  re.DOTALL)


### PR DESCRIPTION
fixes #106 

This is a contrived example (which ultimately fails with `stpipe.config_parser.ValidationError: Config parameter 'foo': missing`):
```python
﻿﻿import stpipe

n = 65000

class Foo(stpipe.Step):
    spec = "foo = " + ")" * n + "(" * n

f = Foo()
```

Running the above example with stpipe main takes ~12 seconds to fail. With this PR it takes ~0.7 seconds (on my machine).

As mentioned in #106 this seems like a low risk as the user could also write a step that includes a `while True`. It seems worthwhile to fix the regex as the replacement appears equivalent and faster.