### PR TITLE
remove unsupported system_packages rtd config setting

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -22,7 +22,6 @@ sphinx:
 # Install regular dependencies.
 # Then, install special pinning for RTD.
 python:
-  system_packages: false
   install:
     - method: pip
       path: .


### PR DESCRIPTION
RTD no longer supports any system_packages setting:
https://blog.readthedocs.com/drop-support-system-packages/

This PR removes the unused system_packages setting