### PR TITLE
use `pytest.importorskip` on test utils

### DIFF
--- a/tests/test_abstract_datamodel.py
+++ b/tests/test_abstract_datamodel.py
@@ -9,7 +9,7 @@ from stpipe.datamodel import AbstractDataModel
 
 def test_roman_datamodel():
     roman_datamodels = pytest.importorskip("roman_datamodels.datamodels")
-    import roman_datamodels.tests.util as rutil
+    rutil = pytest.importorskip("roman_datamodels.tests.util")
 
     roman_image_tree = rutil.mk_level2_image()
     image_model = roman_datamodels.ImageModel(roman_image_tree)


### PR DESCRIPTION
closes #114

use `pytest.importorskip` to import util to make test image, to keep abstract model tests from failing if `roman_datamodels` is not installed

https://github.com/spacetelescope/stpipe/blob/58def5a69834835e5d9b2cd7ad97bbef36c24d8c/src/stpipe/tests/test_abstract_datamodel.py#L8-L13
