### PR TITLE
Install dev wheels properly

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -49,11 +49,13 @@ deps =
     jwst: jwst[test] @ git+https://github.com/spacetelescope/jwst.git
     romancal: romancal[test] @ git+https://github.com/spacetelescope/romancal.git
     oldestdeps: minimum_dependencies
+    devdeps: numpy>=0.0.dev0
+    devdeps: astropy>=0.0.dev0
 pass_env =
     CRDS_*
     CI
 set_env =
-    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+    devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
     jwst: CRDS_SERVER_URL=https://jwst-crds.stsci.edu
     romancal: CRDS_SERVER_URL=https://roman-crds.stsci.edu
 package =
@@ -64,7 +66,6 @@ allowlist_externals =
 commands_pre =
     oldestdeps: minimum_dependencies stpipe --filename requirements-min.txt
     oldestdeps: pip install -r requirements-min.txt
-    devdeps: pip install numpy>=0.0.dev0 git+https://github.com/astropy/astropy -U --upgrade-strategy eager
     pip freeze
 commands =
     pytest \


### PR DESCRIPTION
You can simplify dev wheels install and you can install astropy dev from wheel.

Why does this look so familiar. Deja vu.