### PR TITLE
Remove lingering NumPy references 

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 envlist =
     check-{style,security,build}
     test{,-warnings,-cov,-xdist,-oldestdeps,-devdeps}
-    test-numpy{120,121,122}
     test-{jwst,romancal}-xdist
     build-{docs,dist}
 
@@ -49,7 +48,6 @@ deps =
     jwst: jwst[test] @ git+https://github.com/spacetelescope/jwst.git
     romancal: romancal[test] @ git+https://github.com/spacetelescope/romancal.git
     oldestdeps: minimum_dependencies
-    devdeps: numpy>=0.0.dev0
     devdeps: astropy>=0.0.dev0
 pass_env =
     CRDS_*


### PR DESCRIPTION
`stpipe` has no direct `numpy` dependencies, any `numpy` related things within it are lingering effects of its extraction from JWST.