### PR TITLE
Add `verbose` to Step and Pipeline

### DIFF
--- a/src/stpipe/pipeline.py
+++ b/src/stpipe/pipeline.py
@@ -23,6 +23,7 @@ class Pipeline(Step):
 
     # Configuration
     spec = """
+    verbose = boolean(default=True)  # Show verbose output
     """
     # A set of steps used in the Pipeline.  Should be overridden by
     # the subclass.
@@ -53,6 +54,11 @@ class Pipeline(Step):
                 )
 
             setattr(self, key, new_step)
+
+        if self.verbose:
+            self.log.setLevel(log.logging.DEBUG)
+        else:
+            self.log.setLevel(log.logging.CRITICAL)
 
     @property
     def reference_file_types(self):

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -51,6 +51,7 @@ class Step:
     suffix             = string(default=None)        # Default suffix for output files
     search_output_file = boolean(default=True)       # Use outputfile define in parent step
     input_dir          = string(default=None)        # Input directory
+    verbose            = boolean(default=True)       # Show verbose output
     """  # noqa: E501
     # Nickname used to refer to this class in lieu of the fully-qualified class
     # name.  Must be globally unique!
@@ -362,7 +363,10 @@ class Step:
         # Create a new logger for this step
         self.log = log.getLogger(self.qualified_name)
 
-        self.log.setLevel(log.logging.DEBUG)
+        if self.verbose:
+            self.log.setLevel(log.logging.DEBUG)
+        else:
+            self.log.setLevel(log.logging.CRITICAL)
 
         # Log the fact that we have been init-ed.
         self.log.info(

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -8,6 +8,7 @@ import pytest
 
 import stpipe.config_parser as cp
 from stpipe import cmdline
+from stpipe.log import record_logs
 from stpipe.pipeline import Pipeline
 from stpipe.step import Step
 
@@ -73,6 +74,21 @@ class ListArgStep(Step):
         pixel_scale_ratio = float(default=0.65)
         output_ext = string(default='listargstep')
     """
+
+
+class ProcessStep(Step):
+    """A Step with parameters"""
+
+    spec = """
+        str1 = string(default='default')
+        str2 = string(default='default')
+        str3 = string(default='default')
+        str4 = string(default='default')
+        output_ext = string(default='simplestep')
+    """
+
+    def process(self):
+        return None
 
 
 @pytest.fixture()
@@ -407,3 +423,31 @@ def test_log_records():
     assert any(
         r.message == "This step has called out a warning." for r in pipeline.log_records
     )
+
+
+def test_step_verbose():
+    # Run method
+    with record_logs() as logs_run:
+        step = ProcessStep(verbose=False)
+        _ = step.run()
+
+    # Call method
+    with record_logs() as logs_call:
+        _ = ProcessStep.call(verbose=False)
+
+    assert len(logs_run) == 0
+    assert len(logs_call) == 0
+
+
+def test_pipeline_verbose():
+    # Run method
+    with record_logs() as logs_run:
+        pipe = LoggingPipeline(verbose=False)
+        _ = pipe.run()
+
+    # Call method
+    with record_logs() as logs_call:
+        _ = LoggingPipeline.call(verbose=False)
+
+    assert len(logs_run) == 0
+    assert len(logs_call) == 0


### PR DESCRIPTION
This PR adds a new `verbose` argument to Step and Pipeline which may fix issue #49.

However, changing the logging level from DEBUG to CRITICAL also makes it impossible to record log messages (as you can see in the tests I use `record_logs` to check if there is any output). I am not sure if there is a way to prevent log messages from being output to the console and still record the logs.

Another concern is that the `get_config_from_reference` class method uses the delegator logger instead of the logger created by the pipeline. This delegator logger cannot be controlled by `verbose` before the pipeline is initiated. So some logs may still be output to the console.
https://github.com/spacetelescope/stpipe/blob/9e7c4416fa8776c00843c18390a1dc2d7b4179d0/src/stpipe/pipeline.py#L143C11-L143C11

Although not good enough, this PR can still work as a workaround for those who do not want the logs printed to the console.