### PR TITLE
Fix pre- and post-hooks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,5 @@ jobs:
         CRDS_CLIENT_RETRY_COUNT: 3
         CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
       envs: |
-        - linux: py311-jwst-xdist
+        - linux: py311-jwst-cov-xdist
         - linux: py311-romancal-xdist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         - linux: py39-oldestdeps-cov-xdist
         - linux: py310-xdist
         - macos: py311-xdist
-        - linux: py311-cov-xdist
+        - linux: py311-upstreamdeps-cov-xdist
           coverage: 'codecov'
         - linux: py312-xdist-nolegacypath
   test_downstream:
@@ -37,4 +37,5 @@ jobs:
         CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
       envs: |
         - linux: py311-jwst-cov-xdist
+          coverage: 'codecov'
         - linux: py311-romancal-xdist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         - linux: py39-oldestdeps-cov-xdist
         - linux: py310-xdist
         - macos: py311-xdist
-        - linux: py311-upstreamdeps-cov-xdist
+        - linux: py311-downstreamdeps-cov-xdist
           coverage: 'codecov'
         - linux: py312-xdist-nolegacypath
   test_downstream:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
         - linux: py39-oldestdeps-cov-xdist
         - linux: py310-xdist
         - macos: py311-xdist
+        - linux: py311-cov-xdist
+          coverage: 'codecov'
         - linux: py311-downstreamdeps-cov-xdist
           coverage: 'codecov'
         - linux: py312-xdist-nolegacypath
@@ -36,6 +38,5 @@ jobs:
         CRDS_CLIENT_RETRY_COUNT: 3
         CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
       envs: |
-        - linux: py311-jwst-cov-xdist
-          coverage: 'codecov'
+        - linux: py311-jwst-xdist
         - linux: py311-romancal-xdist

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@
   ``get_crds_parameters`` [#142]
 - Fix bug in handling of ``pathlib.Path`` objects as ``Step`` inputs [#143]
 - Log readable Step parameters [#140]
+- Fix handling of functions and subprocesses as Step pre- and post-hooks.  Add
+  ability to pass imported python functions and ``Step`` subclasses directly as
+  hooks. And allow ``Step`` subclass instances with set parameters as hooks. [#133]
 
 0.5.1 (2023-10-02)
 ==================

--- a/src/stpipe/config_parser.py
+++ b/src/stpipe/config_parser.py
@@ -80,7 +80,7 @@ def _get_output_file_check(root_dir):
 
 
 def _is_datamodel(value):
-    """Verify that value is either is a DataModel."""
+    """Verify that value is a DataModel."""
     if isinstance(value, AbstractDataModel):
         return value
 

--- a/src/stpipe/format_template.py
+++ b/src/stpipe/format_template.py
@@ -127,7 +127,7 @@ class FormatTemplate(Formatter):
         if key_formats:
             self.key_formats.update(key_formats)
 
-    def format(self, format_string, **kwargs):  # noqa: A003
+    def format(self, format_string, **kwargs):
         """Perform the formatting
 
         Parameters

--- a/src/stpipe/format_template.py
+++ b/src/stpipe/format_template.py
@@ -127,7 +127,7 @@ class FormatTemplate(Formatter):
         if key_formats:
             self.key_formats.update(key_formats)
 
-    def format(self, format_string, **kwargs):
+    def format(self, format_string, **kwargs):  # noqa: A003
         """Perform the formatting
 
         Parameters

--- a/src/stpipe/function_wrapper.py
+++ b/src/stpipe/function_wrapper.py
@@ -9,8 +9,12 @@ class FunctionWrapper(Step):
     This Step wraps an ordinary Python function.
     """
 
-    def __init__(self, func, *args):
-        Step.__init__(self, func.__name__, *args)
+    spec = """
+    output_ext = string(default="fits")
+    """
+
+    def __init__(self, func, *args, **kwargs):
+        Step.__init__(self, func.__name__, *args, **kwargs)
 
         self._func = func
 

--- a/src/stpipe/hooks.py
+++ b/src/stpipe/hooks.py
@@ -8,9 +8,9 @@ from . import function_wrapper, utilities
 from .step import Step
 
 
-def hook_from_string_or_class(step, hooktype, num, command):
+def hook_from_string(step, hooktype, num, command):
     """
-    Generate hook from string (or pass along the class)
+    Generate hook from string, function, Step or Step instance
 
     Parameters
     ----------
@@ -105,7 +105,4 @@ def get_hook_objects(step, hooktype, hooks):
     -------
     list of callables that can be run as a hook
     """
-    return [
-        hook_from_string_or_class(step, hooktype, i, hook)
-        for i, hook in enumerate(hooks)
-    ]
+    return [hook_from_string(step, hooktype, i, hook) for i, hook in enumerate(hooks)]

--- a/src/stpipe/hooks.py
+++ b/src/stpipe/hooks.py
@@ -1,15 +1,14 @@
 """
 Pre- and post-hooks
 """
-import contextlib
 import inspect
-import types
 
+from . import function_wrapper
 from . import utilities
 from .step import Step
 
 
-def hook_from_string_or_class(step, type, num, command):
+def hook_from_string_or_class(step, hooktype, num, command):
     """
     Generate hook from string (or pass along the class)
 
@@ -17,7 +16,7 @@ def hook_from_string_or_class(step, type, num, command):
     ----------
     step : `stpipe.step.Step`
         Parent step instance to which this hook is attached, i.e. "self"
-    type : str, "pre" or "post"
+    hooktype : str, "pre" or "post"
         Type of hook pre-hook , or post-hook
     num : int
         The number, in order, of the pre- or post-hook in the list
@@ -26,54 +25,58 @@ def hook_from_string_or_class(step, type, num, command):
     Returns
     -------
     `stpipe.step.Step`
-
     """
-    name = f"{type}_hook{num:d}"
+    name = f"{hooktype}_hook{num:d}"
 
     step_class = None
+    step_func = None
 
-    # hook is a string of the fully-qualified name of a class, i.e. from strun
+    # hook is a string of the fully-qualified name of a class or function
     if isinstance(command, str):
         try:
-            step_class = utilities.import_class(command, subclassof=Step, config_file=step.config_file)
+            # String points to a Step subclass
+            step_class = utilities.import_class(
+                command, subclassof=Step, config_file=step.config_file
+            )
         except ImportError:
+            # String is possibly a subproc, so handle this later
             pass
+        except TypeError:
+            # String points to a function
+            step_func = utilities.import_func(command)
         else:
-            name = step_class.class_alias
+            if step_class.class_alias is not None:
+                name = step_class.class_alias
             return step_class(name, parent=step, config_file=step.config_file)
+
+        # hook is a string of the fully-qualified name of a function
+        if step_func is not None:
+            return function_wrapper.FunctionWrapper(
+                step_func, parent=step, config_file=step.config_file
+            )
 
     # hook is an already-imported Step subclass
     if inspect.isclass(command) and issubclass(command, Step):
         step_class = command
-        name = step_class.class_alias
+        if step_class.class_alias is not None:
+            name = step_class.class_alias
         return step_class(name, parent=step, config_file=step.config_file)
 
     # hook is an instance of a Step subclass
     if isinstance(command, Step):
-        command.name = command.class_alias
+        if command.class_alias is not None:
+            command.name = command.class_alias
+        else:
+            command.name = name
         return command
 
-    # hook is a string of the fully-qualified name of a function not subclassing Step
-    step_func = None
-    with contextlib.suppress(Exception):
-        step_func = utilities.import_class(
-            command, types.FunctionType, step.config_file
-        )
-
-    if step_func is not None:
-        from . import function_wrapper
-
-        return function_wrapper.FunctionWrapper(
-            step_func, parent=step, config_file=step.config_file
-        )
-
-    # hook is a command-line script of some sort
+    # hook is a command-line script or system call
     from .subproc import SystemCall
 
     return SystemCall(name, parent=step, command=command)
 
 
-def get_hook_objects(step, type, hooks):
+def get_hook_objects(step, hooktype, hooks):
     """
     Get list of pre- or post-hooks for a step
 
@@ -81,7 +84,7 @@ def get_hook_objects(step, type, hooks):
     ----------
     step : `stpipe.step.Step`
         instance to which this is a hook
-    type : str, "pre" or "post"
+    hooktype : str, "pre" or "post"
         strings, to indicate whether it is a pre- or post-hook
     hooks : str or class
         path to executible script, or Step class to run as hook
@@ -90,4 +93,5 @@ def get_hook_objects(step, type, hooks):
     -------
     list of callables that can be run as a hook
     """
-    return [hook_from_string_or_class(step, type, i, hook) for i, hook in enumerate(hooks)]
+    return [hook_from_string_or_class(step, hooktype, i, hook)
+            for i, hook in enumerate(hooks)]

--- a/src/stpipe/hooks.py
+++ b/src/stpipe/hooks.py
@@ -3,8 +3,7 @@ Pre- and post-hooks
 """
 import inspect
 
-from . import function_wrapper
-from . import utilities
+from . import function_wrapper, utilities
 from .step import Step
 
 
@@ -87,11 +86,13 @@ def get_hook_objects(step, hooktype, hooks):
     hooktype : str, "pre" or "post"
         strings, to indicate whether it is a pre- or post-hook
     hooks : str or class
-        path to executible script, or Step class to run as hook
+        path to executable script, or Step class to run as hook
 
     Returns
     -------
     list of callables that can be run as a hook
     """
-    return [hook_from_string_or_class(step, hooktype, i, hook)
-            for i, hook in enumerate(hooks)]
+    return [
+        hook_from_string_or_class(step, hooktype, i, hook)
+        for i, hook in enumerate(hooks)
+    ]

--- a/src/stpipe/hooks.py
+++ b/src/stpipe/hooks.py
@@ -2,22 +2,58 @@
 Pre- and post-hooks
 """
 import contextlib
+import inspect
 import types
 
 from . import utilities
 from .step import Step
 
 
-def hook_from_string(step, type, num, command):  # noqa: A002
+def hook_from_string_or_class(step, type, num, command):
+    """
+    Generate hook from string (or pass along the class)
+
+    Parameters
+    ----------
+    step : `stpipe.step.Step`
+        Parent step instance to which this hook is attached, i.e. "self"
+    type : str, "pre" or "post"
+        Type of hook pre-hook , or post-hook
+    num : int
+        The number, in order, of the pre- or post-hook in the list
+    command : str or `stpipe.step.Step` instance
+
+    Returns
+    -------
+    `stpipe.step.Step`
+
+    """
     name = f"{type}_hook{num:d}"
 
     step_class = None
-    with contextlib.suppress(Exception):
-        step_class = utilities.import_class(command, Step, step.config_file)
 
-    if step_class is not None:
+    # hook is a string of the fully-qualified name of a class, i.e. from strun
+    if isinstance(command, str):
+        try:
+            step_class = utilities.import_class(command, subclassof=Step, config_file=step.config_file)
+        except ImportError:
+            pass
+        else:
+            name = step_class.class_alias
+            return step_class(name, parent=step, config_file=step.config_file)
+
+    # hook is an already-imported Step subclass
+    if inspect.isclass(command) and issubclass(command, Step):
+        step_class = command
+        name = step_class.class_alias
         return step_class(name, parent=step, config_file=step.config_file)
 
+    # hook is an instance of a Step subclass
+    if isinstance(command, Step):
+        command.name = command.class_alias
+        return command
+
+    # hook is a string of the fully-qualified name of a function not subclassing Step
     step_func = None
     with contextlib.suppress(Exception):
         step_func = utilities.import_class(
@@ -31,10 +67,27 @@ def hook_from_string(step, type, num, command):  # noqa: A002
             step_func, parent=step, config_file=step.config_file
         )
 
+    # hook is a command-line script of some sort
     from .subproc import SystemCall
 
     return SystemCall(name, parent=step, command=command)
 
 
-def get_hook_objects(step, type_, hooks):
-    return [hook_from_string(step, type_, i, hook) for i, hook in enumerate(hooks)]
+def get_hook_objects(step, type, hooks):
+    """
+    Get list of pre- or post-hooks for a step
+
+    Parameters
+    ----------
+    step : `stpipe.step.Step`
+        instance to which this is a hook
+    type : str, "pre" or "post"
+        strings, to indicate whether it is a pre- or post-hook
+    hooks : str or class
+        path to executible script, or Step class to run as hook
+
+    Returns
+    -------
+    list of callables that can be run as a hook
+    """
+    return [hook_from_string_or_class(step, type, i, hook) for i, hook in enumerate(hooks)]

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -42,8 +42,8 @@ class Step:
     """
 
     spec = """
-    pre_hooks          = string_list(default=list())
-    post_hooks         = string_list(default=list())
+    pre_hooks          = list(default=list())        # List of Step classes to run before step
+    post_hooks         = list(default=list())        # List of Step classes to run after step
     output_file        = output_file(default=None)   # File to save output to.
     output_dir         = string(default=None)        # Directory path for output files
     output_ext         = string()                    # Default type of output

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -465,7 +465,6 @@ class Step:
                     hook_results = pre_hook.run(*hook_args)
                     if hook_results is not None:
                         hook_args = hook_results
-                self.log.info("hook_args: %s", hook_args)
                 args = hook_args
 
                 self._reference_files_used = []

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -465,6 +465,7 @@ class Step:
                     hook_results = pre_hook.run(*hook_args)
                     if hook_results is not None:
                         hook_args = hook_results
+                self.log.info("hook_args: %s", hook_args)
                 args = hook_args
 
                 self._reference_files_used = []

--- a/src/stpipe/subproc.py
+++ b/src/stpipe/subproc.py
@@ -26,7 +26,6 @@ class SystemCall(Step):
     """  # noqa: E501
 
     def process(self, *args):
-
         newargs = []
         for i, arg in enumerate(args):
             if isinstance(arg, AbstractDataModel):

--- a/src/stpipe/subproc.py
+++ b/src/stpipe/subproc.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 
+from .datamodel import AbstractDataModel
 from .step import Step
 
 
@@ -11,30 +12,25 @@ class SystemCall(Step):
 
     spec = """
     # SystemCall is a step to run external processes as Steps.
-
     # The command can pass along arguments that were passed to the step.
     # To refer to positional arguments, use {0}, {1}, {2}, etc.
     # To refer to keyword arguments, use {keyword}.
+
     command = string() # The command to execute
-
     env = string_list(default=list()) # Environment variables to define
-
     log_stdout = boolean(default=True) # Do we want to log STDOUT?
-
     log_stderr = boolean(default=True) # Do we want to log STDERR?
-
     exitcode_as_exception = boolean(default=True) # Should a non-zero exit code be converted into an exception?
-
     failure_as_exception = boolean(default=True) # If subprocess fails to run at all, should that be an exception?
+    output_ext = string(default="fits")
     """  # noqa: E501
 
     def process(self, *args):
-        from .. import datamodels  # noqa: TID252
 
         newargs = []
         for i, arg in enumerate(args):
-            if isinstance(arg, datamodels.DataModel):
-                filename = f"{self.qualified_name}.{i:04d}.{arg.getfileext()}"
+            if isinstance(arg, AbstractDataModel):
+                filename = f"{self.qualified_name}.{i:04d}.{self.output_ext}"
                 arg.save(filename)
                 newargs.append(filename)
             else:
@@ -75,3 +71,6 @@ class SystemCall(Step):
 
             if self.exitcode_as_exception and err != 0:
                 raise OSError(f"{cmd_str!r} returned error code {err}")
+        finally:
+            p.stdout.close()
+            p.stderr.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+import os
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def tmp_cwd(tmp_path):
+    """Perform test in a pristine temporary working directory."""
+    old_dir = Path.cwd()
+    os.chdir(tmp_path)
+    try:
+        yield tmp_path
+    finally:
+        os.chdir(old_dir)

--- a/tests/test_abstract_datamodel.py
+++ b/tests/test_abstract_datamodel.py
@@ -17,7 +17,7 @@ def test_roman_datamodel():
 
 
 def test_jwst_datamodel():
-    jwst_datamodel = pytest.importorskip("jwst.datamodels")
+    jwst_datamodel = pytest.importorskip("stdatamodels.jwst.datamodels")
     image_model = jwst_datamodel.ImageModel()
     assert isinstance(image_model, AbstractDataModel)
 

--- a/tests/test_abstract_datamodel.py
+++ b/tests/test_abstract_datamodel.py
@@ -9,9 +9,9 @@ from stpipe.datamodel import AbstractDataModel
 
 def test_roman_datamodel():
     roman_datamodels = pytest.importorskip("roman_datamodels.datamodels")
-    import roman_datamodels.tests.util as rutil
+    from roman_datamodels.maker_utils import mk_level2_image
 
-    roman_image_tree = rutil.mk_level2_image()
+    roman_image_tree = mk_level2_image()
     image_model = roman_datamodels.ImageModel(roman_image_tree)
     assert isinstance(image_model, AbstractDataModel)
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,7 +1,8 @@
 import pytest
 
-Step = pytest.importorskip("jwst.stpipe.Step")
-Pipeline = pytest.importorskip("jwst.stpipe.Pipeline")
+pytest.importorskip("jwst")
+
+from jwst.stpipe import Pipeline, Step  # noqa: E402
 
 
 class ShovelPixelsStep(Step):
@@ -33,6 +34,7 @@ class MyPipeline(Pipeline):
         result = self.cancelnoise(result)
 
         return result
+
 
 
 class HookStep(Step):
@@ -131,12 +133,12 @@ def test_hook_as_string_of_importable_function(caplog):
     assert "Running hook_function on data array of size (10, 10)" in caplog.text
 
 
-def test_hook_as_subproccess(caplog, tmp_path):
+def test_hook_as_subproccess(caplog, tmp_cwd):
     """Test a string of a terminal command"""
     datamodels = pytest.importorskip("stdatamodels.jwst.datamodels")
     model = datamodels.ImageModel((10, 10))
     filename = "test_hook_as_subprocess.fits"
-    path = tmp_path / filename
+    path = tmp_cwd / filename
     model.save(path)
 
     # Run post_hooks of "fitsinfo" and "fitsheader" CLI scripts from astropy

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,7 +1,5 @@
 import pytest
-
-from jwst.stpipe import Step, Pipeline
-
+from jwst.stpipe import Pipeline, Step
 
 pytest.importorskip("jwst")
 
@@ -38,7 +36,6 @@ class MyPipeline(Pipeline):
 
 
 class HookStep(Step):
-
     class_alias = "myhook"
 
     spec = """

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,6 +1,5 @@
 import pytest
 
-
 Step = pytest.importorskip("jwst.stpipe.Step")
 Pipeline = pytest.importorskip("jwst.stpipe.Pipeline")
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -24,7 +24,7 @@ class CancelNoiseStep(Step):
 class MyPipeline(Pipeline):
     class_alias = "mypipeline"
 
-    step_defs = {
+    step_defs = {  # noqa: RUF012
         "shovelpixels": ShovelPixelsStep,
         "cancelnoise": CancelNoiseStep,
     }
@@ -33,7 +33,7 @@ class MyPipeline(Pipeline):
         result = self.shovelpixels(input_data)
         result = self.cancelnoise(result)
 
-        return result
+        return result  # noqa: RET504
 
 
 class HookStep(Step):

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -63,13 +63,13 @@ def test_hook_as_step_class(caplog):
     datamodels = pytest.importorskip("stdatamodels.jwst.datamodels")
     model = datamodels.ImageModel((10, 10))
 
-    steps = dict(
-        cancelnoise=dict(
-            post_hooks=[
+    steps = {
+        "cancelnoise": {
+            "post_hooks": [
                 HookStep,
             ]
-        )
-    )
+        }
+    }
 
     MyPipeline.call(model, steps=steps)
 
@@ -82,13 +82,13 @@ def test_hook_as_step_instance(caplog):
     datamodels = pytest.importorskip("stdatamodels.jwst.datamodels")
     model = datamodels.ImageModel((10, 10))
 
-    steps = dict(
-        shovelpixels=dict(
-            post_hooks=[
+    steps = {
+        "shovelpixels": {
+            "post_hooks": [
                 HookStep(param1="foo", param2=3),
             ]
-        )
-    )
+        }
+    }
 
     MyPipeline.call(model, steps=steps)
 
@@ -100,13 +100,13 @@ def test_hook_as_string_of_importable_step_class(caplog):
     datamodels = pytest.importorskip("stdatamodels.jwst.datamodels")
     model = datamodels.ImageModel((10, 10))
 
-    steps = dict(
-        shovelpixels=dict(
-            post_hooks=[
+    steps = {
+        "shovelpixels": {
+            "post_hooks": [
                 "test_hooks.HookStep",
             ]
-        )
-    )
+        }
+    }
 
     MyPipeline.call(model, steps=steps)
 
@@ -118,13 +118,13 @@ def test_hook_as_string_of_importable_function(caplog):
     datamodels = pytest.importorskip("stdatamodels.jwst.datamodels")
     model = datamodels.ImageModel((10, 10))
 
-    steps = dict(
-        shovelpixels=dict(
-            post_hooks=[
+    steps = {
+        "shovelpixels": {
+            "post_hooks": [
                 "test_hooks.hook_function",
             ]
-        )
-    )
+        }
+    }
 
     MyPipeline.call(model, steps=steps)
 
@@ -140,14 +140,14 @@ def test_hook_as_subproccess(caplog, tmp_path):
     model.save(path)
 
     # Run post_hooks of "fitsinfo" and "fitsheader" CLI scripts from astropy
-    steps = dict(
-        shovelpixels=dict(
-            post_hooks=[
+    steps = {
+        "shovelpixels": {
+            "post_hooks": [
                 "fitsinfo {0}",
                 "fitsheader {0}",
             ]
-        )
-    )
+        }
+    }
 
     MyPipeline.call(model, steps=steps)
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,7 +1,8 @@
 import pytest
-from jwst.stpipe import Pipeline, Step
 
-pytest.importorskip("jwst")
+
+Step = pytest.importorskip("jwst.stpipe.Step")
+Pipeline = pytest.importorskip("jwst.stpipe.Pipeline")
 
 
 class ShovelPixelsStep(Step):

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -36,7 +36,6 @@ class MyPipeline(Pipeline):
         return result
 
 
-
 class HookStep(Step):
     class_alias = "myhook"
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,163 @@
+import pytest
+
+from jwst.stpipe import Step, Pipeline
+
+
+pytest.importorskip("jwst")
+
+
+class ShovelPixelsStep(Step):
+    class_alias = "shovelpixels"
+
+    def process(self, input_data):
+        self.log.info("Shoveling...")
+        return input_data
+
+
+class CancelNoiseStep(Step):
+    class_alias = "cancelnoise"
+
+    def process(self, input_data):
+        self.log.info("De-noising...")
+        return input_data
+
+
+class MyPipeline(Pipeline):
+    class_alias = "mypipeline"
+
+    step_defs = {
+        "shovelpixels": ShovelPixelsStep,
+        "cancelnoise": CancelNoiseStep,
+    }
+
+    def process(self, input_data):
+        result = self.shovelpixels(input_data)
+        result = self.cancelnoise(result)
+
+        return result
+
+
+class HookStep(Step):
+
+    class_alias = "myhook"
+
+    spec = """
+    param1 = string(default="bar")
+    param2 = float(default=1)
+    """
+
+    def process(self, input_data):
+        self.log.info("Running HookStep with %s and %s", self.param1, self.param2)
+
+        return input_data
+
+
+def hook_function(input_data):
+    import logging
+
+    log = logging.getLogger(__name__)
+    log.info("Running hook_function on data array of size %s", input_data.shape)
+
+    return input_data
+
+
+def test_hook_as_step_class(caplog):
+    """Test an imported Step subclass can be a hook"""
+    datamodels = pytest.importorskip("stdatamodels.jwst.datamodels")
+    model = datamodels.ImageModel((10, 10))
+
+    steps = dict(
+        cancelnoise=dict(
+            post_hooks=[
+                HookStep,
+            ]
+        )
+    )
+
+    MyPipeline.call(model, steps=steps)
+
+    assert "Running HookStep with bar and 1" in caplog.text
+    assert "cancelnoise.myhook" in caplog.text
+
+
+def test_hook_as_step_instance(caplog):
+    """Test an imported Step subclass instance with parameters can be a hook"""
+    datamodels = pytest.importorskip("stdatamodels.jwst.datamodels")
+    model = datamodels.ImageModel((10, 10))
+
+    steps = dict(
+        shovelpixels=dict(
+            post_hooks=[
+                HookStep(param1="foo", param2=3),
+            ]
+        )
+    )
+
+    MyPipeline.call(model, steps=steps)
+
+    assert "Running HookStep with foo and 3" in caplog.text
+
+
+def test_hook_as_string_of_importable_step_class(caplog):
+    """Test a string of a fully-qualified path to Step subclass can be a hook"""
+    datamodels = pytest.importorskip("stdatamodels.jwst.datamodels")
+    model = datamodels.ImageModel((10, 10))
+
+    steps = dict(
+        shovelpixels=dict(
+            post_hooks=[
+                "test_hooks.HookStep",
+            ]
+        )
+    )
+
+    MyPipeline.call(model, steps=steps)
+
+    assert "Running HookStep" in caplog.text
+
+
+def test_hook_as_string_of_importable_function(caplog):
+    """Test a string of a fully-qualified function path can be a hook"""
+    datamodels = pytest.importorskip("stdatamodels.jwst.datamodels")
+    model = datamodels.ImageModel((10, 10))
+
+    steps = dict(
+        shovelpixels=dict(
+            post_hooks=[
+                "test_hooks.hook_function",
+            ]
+        )
+    )
+
+    MyPipeline.call(model, steps=steps)
+
+    assert "Running hook_function on data array of size (10, 10)" in caplog.text
+
+
+def test_hook_as_subproccess(caplog, tmp_path):
+    """Test a string of a terminal command"""
+    datamodels = pytest.importorskip("stdatamodels.jwst.datamodels")
+    model = datamodels.ImageModel((10, 10))
+    filename = "test_hook_as_subprocess.fits"
+    path = tmp_path / filename
+    model.save(path)
+
+    # Run post_hooks of "fitsinfo" and "fitsheader" CLI scripts from astropy
+    steps = dict(
+        shovelpixels=dict(
+            post_hooks=[
+                "fitsinfo {0}",
+                "fitsheader {0}",
+            ]
+        )
+    )
+
+    MyPipeline.call(model, steps=steps)
+
+    # Logs from fitsinfo
+    assert "shovelpixels.post_hook0" in caplog.text
+    assert "SystemCall instance created" in caplog.text
+    assert f"hook_args: (<ImageModel(10, 10) from {filename}>,)" in caplog.text
+
+    # logs from fitsheader
+    assert "DATAMODL= 'ImageModel'" in caplog.text

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -11,14 +11,15 @@ def test_func():
 class HovercraftFullOfEels:
     pass
 
-class Foo(Step):
 
+class Foo(Step):
     def process(self, input_data):
         pass
 
 
 def test_import_class():
     from stpipe import Step
+
     step_class = import_class("stpipe.Step", subclassof=Step)
     assert step_class is Step
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -47,3 +47,8 @@ def test_import_func_on_class():
 def test_import_class_no_module():
     with pytest.raises(ImportError):
         import_class("Foo", subclassof=Step)
+
+
+def test_import_func_no_module():
+    with pytest.raises(ImportError):
+        import_func("foo")

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -4,7 +4,7 @@ from stpipe import Step
 from stpipe.utilities import import_class, import_func
 
 
-def test_func():
+def what_is_your_quest():
     pass
 
 
@@ -26,7 +26,7 @@ def test_import_class():
 
 def test_import_class_on_func():
     with pytest.raises(TypeError):
-        import_class("test_utilities.test_func", subclassof=Step)
+        import_class("test_utilities.what_is_your_quest", subclassof=Step)
 
 
 def test_import_class_not_subclass():
@@ -35,8 +35,8 @@ def test_import_class_not_subclass():
 
 
 def test_import_func():
-    step_func = import_func("test_utilities.test_func")
-    assert step_func is test_func
+    step_func = import_func("test_utilities.what_is_your_quest")
+    assert step_func is what_is_your_quest
 
 
 def test_import_func_on_class():

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,0 +1,48 @@
+import pytest
+
+from stpipe import Step
+from stpipe.utilities import import_class, import_func
+
+
+def test_func():
+    pass
+
+
+class HovercraftFullOfEels:
+    pass
+
+class Foo(Step):
+
+    def process(self, input_data):
+        pass
+
+
+def test_import_class():
+    from stpipe import Step
+    step_class = import_class("stpipe.Step", subclassof=Step)
+    assert step_class is Step
+
+
+def test_import_class_on_func():
+    with pytest.raises(TypeError):
+        import_class("test_utilities.test_func", subclassof=Step)
+
+
+def test_import_class_not_subclass():
+    with pytest.raises(TypeError):
+        import_class("test_utilities.HovercraftFullOfEels", subclassof=Step)
+
+
+def test_import_func():
+    step_func = import_func("test_utilities.test_func")
+    assert step_func is test_func
+
+
+def test_import_func_on_class():
+    with pytest.raises(TypeError):
+        import_func("test_utilities.HovercraftFullOfEels")
+
+
+def test_import_class_no_module():
+    with pytest.raises(ImportError):
+        import_class("Foo", subclassof=Step)

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     check-{style,security,build}
-    test{,-warnings,-cov,-xdist,-oldestdeps,-devdeps,-upstreamdeps}{-nolegacypath}
+    test{,-warnings,-cov,-xdist,-oldestdeps,-devdeps,-downstreamdeps}{-nolegacypath}
     test-{jwst,romancal}-xdist
     build-{docs,dist}
 
@@ -37,7 +37,7 @@ description =
     jwst: of JWST pipeline
     romancal: of Romancal pipeline
     oldestdeps: with the oldest supported version of key dependencies
-    upstreamdeps: with the upstream packages that depend on stpipe
+    downstreamdeps: with the downstream packages that depend on stpipe
     warnings: treating warnings as errors
     cov: with coverage
     xdist: using parallel processing
@@ -50,9 +50,6 @@ deps =
     romancal: romancal[test] @ git+https://github.com/spacetelescope/romancal.git
     oldestdeps: minimum_dependencies
     devdeps: astropy>=0.0.dev0
-    upstreamdeps: jwst
-    upstreamdeps: roman_datamodels
-    upstreamdeps: stdatamodels
 pass_env =
     CRDS_*
     CI
@@ -69,6 +66,8 @@ commands_pre =
     oldestdeps: minimum_dependencies stpipe --filename requirements-min.txt
     oldestdeps: pip install -r requirements-min.txt
     pip freeze
+    downstreamdeps: pip install jwst
+    downstreamdeps: pip install stdatamodels
 commands =
     pytest \
     warnings: -W error \

--- a/tox.ini
+++ b/tox.ini
@@ -59,6 +59,7 @@ pass_env =
 set_env =
     devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
     jwst: CRDS_SERVER_URL=https://jwst-crds.stsci.edu
+    downstreamdeps: CRDS_SERVER_URL=https://jwst-crds.stsci.edu
     romancal: CRDS_SERVER_URL=https://roman-crds.stsci.edu
 package =
     !cov: wheel

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     check-{style,security,build}
-    test{,-warnings,-cov,-xdist,-oldestdeps,-devdeps}{-nolegacypath}
+    test{,-warnings,-cov,-xdist,-oldestdeps,-devdeps,-upstreamdeps}{-nolegacypath}
     test-{jwst,romancal}-xdist
     build-{docs,dist}
 
@@ -37,6 +37,7 @@ description =
     jwst: of JWST pipeline
     romancal: of Romancal pipeline
     oldestdeps: with the oldest supported version of key dependencies
+    upstreamdeps: with the upstream packages that depend on stpipe
     warnings: treating warnings as errors
     cov: with coverage
     xdist: using parallel processing
@@ -49,6 +50,9 @@ deps =
     romancal: romancal[test] @ git+https://github.com/spacetelescope/romancal.git
     oldestdeps: minimum_dependencies
     devdeps: astropy>=0.0.dev0
+    upstreamdeps: jwst
+    upstreamdeps: roman_datamodels
+    upstreamdeps: stdatamodels
 pass_env =
     CRDS_*
     CI

--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,9 @@ deps =
     romancal: romancal[test] @ git+https://github.com/spacetelescope/romancal.git
     oldestdeps: minimum_dependencies
     devdeps: astropy>=0.0.dev0
+    downstreamdeps: jwst
+    downstreamdeps: stdatamodels
+    downstreamdeps: roman_datamodels
 pass_env =
     CRDS_*
     CI
@@ -66,8 +69,6 @@ commands_pre =
     oldestdeps: minimum_dependencies stpipe --filename requirements-min.txt
     oldestdeps: pip install -r requirements-min.txt
     pip freeze
-    downstreamdeps: pip install jwst
-    downstreamdeps: pip install stdatamodels
 commands =
     pytest \
     warnings: -W error \


### PR DESCRIPTION
Currently pre- and post-hooks only work as strings pointing to importable Step subclasses.  This made sense back when the foreseen use case of the pipeline was with `strun` at the command line, where all args are strings.

This PR fixes hooks to work with our current use cases.  It adds the possibility of using a defined function or defined `Step` subclass as hook, or an instance with parameters set of a `Step` subclass.  And it tests all the cases.

So now a hook can be a list of a number of useful things, not just a list of strings.

Hooks before:

```python
post_hooks = ["mypackage.MyFirstStep", "mypackage.MySecondStep"]  # string pointing to Step subclass
post_hooks = ["mypackage.my_function"]  # string pointing to a function that is Step.process() equivalent
post_hooks = ["fitsinfo {0}"]  # string pointing to system call
```

With this PR, we can also now use the following as hooks:

```python
from mypackage import MyFirstStep, my_function


post_hooks = [MyFirstStep]  # imported Step subclass
post_hooks = [my_function]  # imported function that is Step.process() equivalent
post_hooks = [MyFirstStep(param1=True, param2=3.5)]  # imported Step instance
post_hooks = ["mypackage.MyFirstStep(param1=True, param2=3.5)"]  # string pointing to Step subclass instance
```

Also added an extra CI job that runs the unit tests with some downstream dependencies.  There's always been tests in this package that depend on `stdatamodels` and `roman_datamodels`, but these have been skipped since the recent-ish github actions workflow updates, and subsequently the `roman_datamodels` test had a broken import.  I've chosen to test the hooks with `jwst` as an optional test dependency, as that's the lowest overhead way to do it without having to create a bunch of redundant test infrastructure.