### PR TITLE
Fix datetime.utcnow() deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
         - macos: py311-xdist
         - linux: py311-cov-xdist
           coverage: 'codecov'
+        - linux: py312-xdist
   test_downstream:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@
 - Fix regex issue in internal configobj [#108]
 - Remove bundled ``configobj`` package in favor of the ``configobj`` package
   bundled into ``astropy``. [#122]
+- Fix ``datetime.utcnow()`` DeprecationWarning [#134]
 
 0.5.1 (2023-10-02)
 ==================

--- a/src/stpipe/config.py
+++ b/src/stpipe/config.py
@@ -4,7 +4,7 @@ will eventually fully replace config_parser.py, but we'll need to maintain
 both until we replace configobj with traitlets.
 """
 from copy import deepcopy
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 
 import asdf
 
@@ -111,7 +111,7 @@ class StepConfig:
             meta = deepcopy(_META_TEMPLATE)
             meta["date"] = meta["date"].replace(
                 _TEMPLATE_PLACEHOLDER,
-                datetime.now(UTC)
+                datetime.now(timezone.utc)
                 .replace(microsecond=0)
                 .isoformat()
                 .removesuffix("+00:00"),

--- a/src/stpipe/config.py
+++ b/src/stpipe/config.py
@@ -4,7 +4,7 @@ will eventually fully replace config_parser.py, but we'll need to maintain
 both until we replace configobj with traitlets.
 """
 from copy import deepcopy
-from datetime import datetime
+from datetime import UTC, datetime
 
 import asdf
 
@@ -111,7 +111,10 @@ class StepConfig:
             meta = deepcopy(_META_TEMPLATE)
             meta["date"] = meta["date"].replace(
                 _TEMPLATE_PLACEHOLDER,
-                datetime.utcnow().replace(microsecond=0).isoformat(),
+                datetime.now(UTC)
+                .replace(microsecond=0)
+                .isoformat()
+                .removesuffix("+00:00"),
             )
             meta["description"] = meta["description"].replace(
                 _TEMPLATE_PLACEHOLDER, self.class_name


### PR DESCRIPTION
This fixes the following deprecation warning:

```
DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC)
```

Note that when you pass any timezone to `datetime.now()`, it returns the offset from UTC (format +HH:MM) appended to the string.  The offset from UTC is always zero, and `datetime.utcnow()` didn't include it.  So here it is removed so that timestamps have a consistent format.