### PR TITLE
Filter out log messages about non-existing pars- reffiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
         - macos: py311-xdist
         - linux: py311-cov-xdist
           coverage: 'codecov'
+        - linux: py311-downstreamdeps-cov-xdist
+          coverage: 'codecov'
         - linux: py312-xdist
   test_downstream:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ jobs:
   test:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:
+      setenv: |
+        CRDS_PATH: /tmp/data/crds_cache
+        CRDS_CLIENT_RETRY_COUNT: 3
+        CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
       envs: |
         - linux: py39-oldestdeps-cov-xdist
         - linux: py310-xdist

--- a/.github/workflows/ci_cron.yml
+++ b/.github/workflows/ci_cron.yml
@@ -23,6 +23,10 @@ jobs:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     if: (github.repository == 'spacetelescope/stpipe' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'Weekly CI')))
     with:
+      setenv: |
+        CRDS_PATH: /tmp/data/crds_cache
+        CRDS_CLIENT_RETRY_COUNT: 3
+        CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
       envs: |
         - macos: py39-xdist
         - macos: py310-xdist

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@
 - Remove bundled ``configobj`` package in favor of the ``configobj`` package
   bundled into ``astropy``. [#122]
 - Fix ``datetime.utcnow()`` DeprecationWarning [#134]
+- Filter out log messages about non-existing pars- reffiles [#135]
 
 0.5.1 (2023-10-02)
 ==================

--- a/src/stpipe/crds_client.py
+++ b/src/stpipe/crds_client.py
@@ -52,10 +52,9 @@ def get_multiple_reference_paths(parameters, reference_file_types, observatory):
     log.set_log_time(True)
 
     def parsfilter(record):
-        if not record.getMessage().strip().startswith(
-            "Error determining best reference for 'pars-"
-        ):
-            return True
+        if "Error determining best reference for 'pars-" in record.getMessage():
+            return False
+        return True
 
     logging.getLogger("CRDS").addFilter(parsfilter)
 

--- a/src/stpipe/crds_client.py
+++ b/src/stpipe/crds_client.py
@@ -8,6 +8,7 @@ directly in modules other than this crds_client so that dependency order and
 general integration can be managed here.
 """
 import re
+import logging
 
 import crds
 from crds.core import config, crds_cache_locking, heavy_client, log
@@ -49,6 +50,13 @@ def get_multiple_reference_paths(parameters, reference_file_types, observatory):
         raise TypeError("First argument must be a dict of parameters")
 
     log.set_log_time(True)
+
+    def filter_pars_errors(record):
+        return not record.getMessage().startswith(
+            "Error determining best reference for 'pars-"
+            )
+    log.prepend_crds_filter(filter_pars_errors)
+
     return _get_refpaths(parameters, tuple(reference_file_types), observatory)
 
 

--- a/src/stpipe/crds_client.py
+++ b/src/stpipe/crds_client.py
@@ -7,6 +7,7 @@ WARNING:  stpipe and crds have circular dependencies.  Do not use crds imports
 directly in modules other than this crds_client so that dependency order and
 general integration can be managed here.
 """
+import logging
 import re
 
 import crds
@@ -50,10 +51,13 @@ def get_multiple_reference_paths(parameters, reference_file_types, observatory):
 
     log.set_log_time(True)
 
-    def filter_pars_errors(record):
-        return not record.startswith("Error determining best reference for 'pars-")
+    def parsfilter(record):
+        if not record.getMessage().strip().startswith(
+            "Error determining best reference for 'pars-"
+        ):
+            return True
 
-    log.prepend_crds_filter(filter_pars_errors)
+    logging.getLogger("CRDS").addFilter(parsfilter)
 
     return _get_refpaths(parameters, tuple(reference_file_types), observatory)
 

--- a/src/stpipe/crds_client.py
+++ b/src/stpipe/crds_client.py
@@ -8,7 +8,6 @@ directly in modules other than this crds_client so that dependency order and
 general integration can be managed here.
 """
 import re
-import logging
 
 import crds
 from crds.core import config, crds_cache_locking, heavy_client, log
@@ -52,9 +51,8 @@ def get_multiple_reference_paths(parameters, reference_file_types, observatory):
     log.set_log_time(True)
 
     def filter_pars_errors(record):
-        return not record.getMessage().startswith(
-            "Error determining best reference for 'pars-"
-            )
+        return not record.startswith("Error determining best reference for 'pars-")
+
     log.prepend_crds_filter(filter_pars_errors)
 
     return _get_refpaths(parameters, tuple(reference_file_types), observatory)

--- a/tests/test_crds_client.py
+++ b/tests/test_crds_client.py
@@ -1,5 +1,5 @@
-from crds.core.exceptions import CrdsLookupError
 import pytest
+from crds.core.exceptions import CrdsLookupError
 
 from stpipe import crds_client
 

--- a/tests/test_crds_client.py
+++ b/tests/test_crds_client.py
@@ -3,9 +3,8 @@ import pytest
 from stpipe import crds_client
 
 
-def test_pars_log_filtering(caplog, monkeypatch):
-    monkeypatch.setenv("CRDS_SERVER_URL", "https://jwst-crds.stsci.edu")
-    # A bogus pars- reffile will raise an exception in CRDS
+def test_missing_pars_log_filtering(caplog):
+    # A made-up pars- reffile will raise an exception in CRDS
     with pytest.raises(Exception, match="Error determining best reference"):
         crds_client.get_multiple_reference_paths(
             parameters={

--- a/tests/test_crds_client.py
+++ b/tests/test_crds_client.py
@@ -1,0 +1,38 @@
+import pytest
+
+from stpipe import crds_client
+
+
+@pytest.mark.skip(
+    "CRDS logs via stderr and pytest can't capture it. "
+    "See https://github.com/pytest-dev/pytest/issues/5997"
+)
+def test_pars_log_filtering(caplog):
+    # A bogus pars- reffile will raise an exception in CRDS
+    with pytest.raises(Exception, match="Error determining best reference"):
+        crds_client.get_multiple_reference_paths(
+            parameters={
+                "meta.instrument.detector": "NRCA1",
+                "meta.instrument.filter": "F140M",
+                "meta.instrument.name": "NIRCAM",
+                "meta.instrument.pupil": "CLEAR",
+                "meta.observation.date": "2012-04-22",
+                "meta.subarray.name": "FULL",
+                "meta.subarray.xsize": 2048,
+                "meta.subarray.xstart": 1,
+                "meta.subarray.ysize": 2048,
+                "meta.subarray.ystart": 1,
+                "meta.telescope": "JWST",
+            },
+            reference_file_types=["pars-crunchyfrogstep"],
+            observatory="jwst",
+        )
+
+    # The following will always be true because of a bug in how pytest handles
+    # oddball logging setups, as used by crds.  See issue
+    # https://github.com/pytest-dev/pytest/issues/5997
+    # So don't rely on this test passing (currently) to be actually testing what
+    # you think it is.
+    assert (
+        "Error determining best reference for 'pars-snowblindstep'" not in caplog.text
+    )

--- a/tests/test_crds_client.py
+++ b/tests/test_crds_client.py
@@ -4,10 +4,10 @@ from stpipe import crds_client
 
 
 @pytest.mark.skip(
-    "CRDS logs via stderr and pytest can't capture it. "
+    "CRDS logs in a non-standard way, and pytest can't capture it. "
     "See https://github.com/pytest-dev/pytest/issues/5997"
 )
-def test_pars_log_filtering(capfd):
+def test_pars_log_filtering(caplog):
     # A bogus pars- reffile will raise an exception in CRDS
     with pytest.raises(Exception, match="Error determining best reference"):
         crds_client.get_multiple_reference_paths(
@@ -33,7 +33,6 @@ def test_pars_log_filtering(capfd):
     # https://github.com/pytest-dev/pytest/issues/5997
     # So don't rely on this test passing (currently) to be actually testing what
     # you think it is.
-    captured = capfd.readouterr()
     assert (
-        "Error determining best reference for 'pars-crunchyfrogstep'" not in captured.err
+        "Error determining best reference for 'pars-crunchyfrogstep'" not in caplog.text
     )

--- a/tests/test_crds_client.py
+++ b/tests/test_crds_client.py
@@ -1,23 +1,18 @@
+from crds.core.exceptions import CrdsLookupError
 import pytest
 
 from stpipe import crds_client
 
 
-def test_missing_pars_log_filtering(caplog):
+def test_missing_pars_log_filtering(capfd):
+    # CRDS needs stdatamodels to handle JWST lookups
+    pytest.importorskip("stdatamodels.jwst")
+
     # A made-up pars- reffile will raise an exception in CRDS
-    with pytest.raises(Exception, match="Error determining best reference"):
+    with pytest.raises(CrdsLookupError):
         crds_client.get_multiple_reference_paths(
             parameters={
-                "meta.instrument.detector": "NRCA1",
-                "meta.instrument.filter": "F140M",
                 "meta.instrument.name": "NIRCAM",
-                "meta.instrument.pupil": "CLEAR",
-                "meta.observation.date": "2012-04-22",
-                "meta.subarray.name": "FULL",
-                "meta.subarray.xsize": 2048,
-                "meta.subarray.xstart": 1,
-                "meta.subarray.ysize": 2048,
-                "meta.subarray.ystart": 1,
                 "meta.telescope": "JWST",
             },
             reference_file_types=["pars-crunchyfrogstep"],
@@ -29,6 +24,7 @@ def test_missing_pars_log_filtering(caplog):
     # https://github.com/pytest-dev/pytest/issues/5997
     # So don't rely on this test passing (currently) to be actually testing what
     # you think it is.
+    capture = capfd.readouterr()
     assert (
-        "Error determining best reference for 'pars-crunchyfrogstep'" not in caplog.text
+        "Error determining best reference for 'pars-crunchyfrogstep'" not in capture.err
     )

--- a/tests/test_crds_client.py
+++ b/tests/test_crds_client.py
@@ -1,8 +1,12 @@
+import os
+from unittest import mock
+
 import pytest
 
 from stpipe import crds_client
 
 
+@mock.patch.dict(os.environ, {"CRDS_SERVER_URL": "https://jwst-crds.stsci.edu"})
 def test_pars_log_filtering(caplog):
     # A bogus pars- reffile will raise an exception in CRDS
     with pytest.raises(Exception, match="Error determining best reference"):

--- a/tests/test_crds_client.py
+++ b/tests/test_crds_client.py
@@ -1,13 +1,10 @@
-import os
-from unittest import mock
-
 import pytest
 
 from stpipe import crds_client
 
 
-@mock.patch.dict(os.environ, {"CRDS_SERVER_URL": "https://jwst-crds.stsci.edu"})
-def test_pars_log_filtering(caplog):
+def test_pars_log_filtering(caplog, monkeypatch):
+    monkeypatch.setenv("CRDS_SERVER_URL", "https://jwst-crds.stsci.edu")
     # A bogus pars- reffile will raise an exception in CRDS
     with pytest.raises(Exception, match="Error determining best reference"):
         crds_client.get_multiple_reference_paths(

--- a/tests/test_crds_client.py
+++ b/tests/test_crds_client.py
@@ -7,7 +7,7 @@ from stpipe import crds_client
     "CRDS logs via stderr and pytest can't capture it. "
     "See https://github.com/pytest-dev/pytest/issues/5997"
 )
-def test_pars_log_filtering(caplog):
+def test_pars_log_filtering(capfd):
     # A bogus pars- reffile will raise an exception in CRDS
     with pytest.raises(Exception, match="Error determining best reference"):
         crds_client.get_multiple_reference_paths(
@@ -33,6 +33,7 @@ def test_pars_log_filtering(caplog):
     # https://github.com/pytest-dev/pytest/issues/5997
     # So don't rely on this test passing (currently) to be actually testing what
     # you think it is.
+    captured = capfd.readouterr()
     assert (
-        "Error determining best reference for 'pars-snowblindstep'" not in caplog.text
+        "Error determining best reference for 'pars-crunchyfrogstep'" not in captured.err
     )

--- a/tests/test_crds_client.py
+++ b/tests/test_crds_client.py
@@ -3,10 +3,6 @@ import pytest
 from stpipe import crds_client
 
 
-@pytest.mark.skip(
-    "CRDS logs in a non-standard way, and pytest can't capture it. "
-    "See https://github.com/pytest-dev/pytest/issues/5997"
-)
 def test_pars_log_filtering(caplog):
     # A bogus pars- reffile will raise an exception in CRDS
     with pytest.raises(Exception, match="Error determining best reference"):

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     check-{style,security,build}
-    test{,-warnings,-cov,-xdist,-oldestdeps,-devdeps}
+    test{,-warnings,-cov,-xdist,-oldestdeps,-devdeps,-downstreamdeps}
     test-{jwst,romancal}-xdist
     build-{docs,dist}
 
@@ -37,6 +37,7 @@ description =
     jwst: of JWST pipeline
     romancal: of Romancal pipeline
     oldestdeps: with the oldest supported version of key dependencies
+    downstreamdeps: with the downstream packages that depend on stpipe
     warnings: treating warnings as errors
     cov: with coverage
     xdist: using parallel processing
@@ -49,6 +50,7 @@ deps =
     romancal: romancal[test] @ git+https://github.com/spacetelescope/romancal.git
     oldestdeps: minimum_dependencies
     devdeps: astropy>=0.0.dev0
+    downstreamdeps: stdatamodels
 pass_env =
     CRDS_*
     CI

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ pass_env =
     CI
 set_env =
     devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
-    jwst: CRDS_SERVER_URL=https://jwst-crds.stsci.edu
+    !romancal: CRDS_SERVER_URL=https://jwst-crds.stsci.edu
     romancal: CRDS_SERVER_URL=https://roman-crds.stsci.edu
 package =
     !cov: wheel


### PR DESCRIPTION
This fixes the issue where custom steps added through `entry_points` check for non-existing CRDS `pars-` reffiles and log an error message.  This PR filters out those log messages.  In fact, it filters out all these missing pars- reffile log messages.

Before:

```
$ pip install snowblind
$ strun snowblind jw01335008001_02101_00001_nrs1_jump.fits
2024-01-22 13:58:54,829 - CRDS - ERROR -  Error determining best reference for 'pars-snowblindstep'  =   Unknown reference type 'pars-snowblindstep'
2024-01-22 13:58:54,829 - stpipe.SnowblindStep - INFO - SnowblindStep instance created.
...
```

With this PR:

```
$ strun snowblind jw01335008001_02101_00001_nrs1_jump.fits
2024-01-22 14:00:08,499 - stpipe.SnowblindStep - INFO - SnowblindStep instance created.
...
```

I've added a test, but because CRDS does non-standard logging via stderr, pytest's known bug in capturing these log messages make the test not work unless you run `pytest -s`. 

Resolves spacetelescope/jwst#5251

And perhaps this is a better solution (and easier to maintain) than spacetelescope/crds#774