### PR TITLE
prepare ci/docs for renaming default branch to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
     tags:
       - "*"
   pull_request:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 Please open a new issue or new pull request for bugs, feedback, or new features you would like to see. If there is an issue you would like to work on, please leave a comment and we will be happy to assist. New contributions and contributors are very welcome!
 
-The main development work is done on the "master" branch. The "stable" branch is protected and used for official releases. The rest of the branches are for release maintenance and should not be used normally. Unless otherwise told by a maintainer, pull requests should be made and submitted to the "master" branch.
+The main development work is done on the "main" branch. The "stable" branch is protected and used for official releases. The rest of the branches are for release maintenance and should not be used normally. Unless otherwise told by a maintainer, pull requests should be made and submitted to the "main" branch.
 
 New to GitHub or open source projects? If you are unsure about where to start or haven't used GitHub before, please feel free to contact the package maintainers.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # stpipe
 
 [![CI](https://github.com/spacetelescope/stpipe/actions/workflows/ci.yml/badge.svg)](https://github.com/spacetelescope/stpipe/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/spacetelescope/stpipe/branch/master/graph/badge.svg?token=Mm9I0X1o4X)](https://codecov.io/gh/spacetelescope/stpipe)
+[![codecov](https://codecov.io/gh/spacetelescope/stpipe/branch/main/graph/badge.svg?token=Mm9I0X1o4X)](https://codecov.io/gh/spacetelescope/stpipe)
 
 Provides base classes and command-line tools for implementing calibration pipeline software.


### PR DESCRIPTION
This PR updates the CI and docs to refer to a renamed "main" branch.

As no downstream package appears to reference a specific branch for stpipe (and instead uses the default branch) we should be able to:
- rename the default branch to "main"
- merge this PR

It's possible codecov may need to be updated to use "main" (if it's not using the default branch).

Github does quite a number of helpful things when the branch is renamed (see https://github.com/github/renaming#renaming-existing-branches) so if acceptable I would propose we rename the branch, merge this PR, and deal with any fallout (although I do not expect any).

xref: https://github.com/spacetelescope/stdatamodels/pull/247