### PR TITLE
Provide `asn_n_members=1` when opening dataset for `Step` to call `get_crds_parameters`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@
 - Remove bundled ``configobj`` package in favor of the ``configobj`` package
   bundled into ``astropy``. [#122]
 - Fix ``datetime.utcnow()`` DeprecationWarning [#134]
+- Provide ``asn_n_members=1`` when opening the ``Step`` dataset for
+  ``get_crds_parameters`` [#142]
 
 0.5.1 (2023-10-02)
 ==================

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -840,12 +840,12 @@ class Step:
             # If the dataset is not an operable instance of AbstractDataModel,
             # log as such and return an empty config object
             try:
-                model = cls._datamodels_open(dataset)
-                if isinstance(model, Sequence):
-                    # Pull out first model in ModelContainer
-                    model = model[0]
-                crds_parameters = model.get_crds_parameters()
-                crds_observatory = model.crds_observatory
+                with cls._datamodels_open(dataset, asn_n_members=1) as model:
+                    if isinstance(model, Sequence):
+                        # Pull out first model in ModelContainer
+                        model = model[0]
+                    crds_parameters = model.get_crds_parameters()
+                    crds_observatory = model.crds_observatory
             except (OSError, TypeError, ValueError):
                 logger.warning("Input dataset is not an instance of AbstractDataModel.")
                 disable = True


### PR DESCRIPTION
This PR improves the consistency of the parameters used for `_datamodels_open` by providing `asn_n_members=1` for `Step` (to match what is done in `Pipeline`).

Fixes https://github.com/spacetelescope/jwst/issues/8262

Romancal regtests all pass: https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/608/
JWST regtests show 4 unrelated errors: https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/1226/
(the same errors are seen in a run without this PR using the current JWST default branch: ttps://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/1227/
