### PR TITLE
TEST: Use `ModelContainer.get_crds_parameters`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@
 - Fix ``datetime.utcnow()`` DeprecationWarning [#134]
 - Provide ``asn_n_members=1`` when opening the ``Step`` dataset for
   ``get_crds_parameters`` [#142]
+- Use ``ModelContainer.get_crds_parameters`` instead of ``get_crds_parameters``
+  on the first model in the container [#144]
 
 0.5.1 (2023-10-02)
 ==================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@
 - Remove bundled ``configobj`` package in favor of the ``configobj`` package
   bundled into ``astropy``. [#122]
 - Fix ``datetime.utcnow()`` DeprecationWarning [#134]
+- Provide ``asn_n_members=1`` when opening the ``Step`` dataset for
+  ``get_crds_parameters`` [#142]
 
 0.5.1 (2023-10-02)
 ==================

--- a/src/stpipe/pipeline.py
+++ b/src/stpipe/pipeline.py
@@ -183,12 +183,8 @@ class Pipeline(Step):
         #
         # Iterate over the steps in the pipeline
         with cls._datamodels_open(dataset, asn_n_members=1) as model:
-            if isinstance(model, Sequence):
-                crds_parameters = model._models[0].get_crds_parameters()
-                crds_observatory = model.crds_observatory
-            else:
-                crds_parameters = model.get_crds_parameters()
-                crds_observatory = model.crds_observatory
+            crds_parameters = model.get_crds_parameters()
+            crds_observatory = model.crds_observatory
 
         for cal_step in cls.step_defs.keys():
             cal_step_class = cls.step_defs[cal_step]

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -841,9 +841,6 @@ class Step:
             # log as such and return an empty config object
             try:
                 with cls._datamodels_open(dataset, asn_n_members=1) as model:
-                    if isinstance(model, Sequence):
-                        # Pull out first model in ModelContainer
-                        model = model[0]
                     crds_parameters = model.get_crds_parameters()
                     crds_observatory = model.crds_observatory
             except (OSError, TypeError, ValueError):

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -840,12 +840,12 @@ class Step:
             # If the dataset is not an operable instance of AbstractDataModel,
             # log as such and return an empty config object
             try:
-                model = cls._datamodels_open(dataset)
-                if isinstance(model, Sequence):
-                    # Pull out first model in ModelContainer
-                    model = model[0]
-                crds_parameters = model.get_crds_parameters()
-                crds_observatory = model.crds_observatory
+                with cls._datamodels_open(dataset, asn_n_members=1) as model:
+                    if isinstance(model, Sequence):
+                        # Pull out first model in ModelContainer
+                        model = model[0]
+                    crds_parameters = model.get_crds_parameters()
+                    crds_observatory = model.crds_observatory
             except (OSError, TypeError, ValueError):
                 logger.warning("Input dataset is not an instance of AbstractDataModel.")
                 disable = True

--- a/tox.ini
+++ b/tox.ini
@@ -45,7 +45,7 @@ extras =
 deps =
     xdist: pytest-xdist
     cov: pytest-cov
-    jwst: jwst[test] @ git+https://github.com/spacetelescope/jwst.git
+    jwst: jwst[test] @ git+https://github.com/braingram/jwst.git@model_container_get_crds_parameters
     romancal: romancal[test] @ git+https://github.com/spacetelescope/romancal.git
     oldestdeps: minimum_dependencies
     devdeps: astropy>=0.0.dev0


### PR DESCRIPTION
Requires: https://github.com/spacetelescope/jwst/pull/8310
as `ModelContainer.get_crds_parameters` (unused prior to this PR) fails for `ModelContainer` instances not read from an association.