### PR TITLE
enable nolegacypath tox factor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         - macos: py311-xdist
         - linux: py311-cov-xdist
           coverage: 'codecov'
-        - linux: py312-xdist
+        - linux: py312-xdist-nolegacypath
   test_downstream:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     check-{style,security,build}
-    test{,-warnings,-cov,-xdist,-oldestdeps,-devdeps}
+    test{,-warnings,-cov,-xdist,-oldestdeps,-devdeps}{-nolegacypath}
     test-{jwst,romancal}-xdist
     build-{docs,dist}
 
@@ -68,6 +68,7 @@ commands_pre =
 commands =
     pytest \
     warnings: -W error \
+    nolegacypath: -p no:legacypath \
     xdist: -n auto \
     jwst: --pyargs jwst --ignore-glob=timeconversion --ignore-glob=associations --ignore-glob=*/scripts/* \
     romancal: --pyargs romancal \


### PR DESCRIPTION
Fixes: https://github.com/spacetelescope/stpipe/issues/145

Add a `nolegacypath` tox factor that run pytest with `-p no:legacypath` which will produce errors if legacy "non-path" fixtures/features are used.

A tox factor was added to allow the downstream jobs (like romancal and jwst) to run without `-p no:legacypath` as we are mainly concerned here that stpipe does not use legacy path features in it's test suite (not the test suites of romancal and jwst).