### PR TITLE
WIP: JP-3563: Raise warning instead of error for unexpected values in config

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,8 @@
 ==================
 
 - Remove unused ``Step.closeout`` [#152]
+- Issue a warning instead of a validation error for extra values in
+  configuration files. [#153]
 
 0.5.2 (2024-03-21)
 ==================

--- a/src/stpipe/config_parser.py
+++ b/src/stpipe/config_parser.py
@@ -299,8 +299,13 @@ def config_from_dict(d, spec=None, root_dir=None, allow_missing=False):
 
 
 def validate(
-    config, spec, section=None, validator=None, root_dir=None,
-        allow_missing=False, allow_extra=False
+    config,
+    spec,
+    section=None,
+    validator=None,
+    root_dir=None,
+    allow_missing=False,
+    allow_extra=False,
 ):
     """
     Parse config_file, in INI format, and do validation with the

--- a/src/stpipe/config_parser.py
+++ b/src/stpipe/config_parser.py
@@ -372,7 +372,10 @@ def validate(
                 sections = "root"
             else:
                 sections = "/".join(sections)
-            messages.append(f"Extra value {name!r} in {sections}")
+
+            # For unrecognized values, just raise a warning
+            message = f"Extra value {name!r} in {sections}"
+            warnings.warn(message, RuntimeWarning, stacklevel=2)
 
         if len(messages):
             raise ValidationError("\n".join(messages))

--- a/src/stpipe/pipeline.py
+++ b/src/stpipe/pipeline.py
@@ -196,7 +196,7 @@ class Pipeline(Step):
                 crds_parameters,
                 crds_observatory=crds_observatory,
             )
-        #
+
         # Now merge any config parameters from the step cfg file
         logger.debug("Retrieving pipeline %s parameters from CRDS", reftype.upper())
         try:
@@ -211,6 +211,14 @@ class Pipeline(Step):
             if ref_file != "N/A":
                 logger.info("%s parameters found: %s", reftype.upper(), ref_file)
                 refcfg = cls.merge_pipeline_config(refcfg, ref_file)
+
+                # Validate now to warn and remove any extra values found
+                # in CRDS reference files.
+                spec = cls.load_spec_file()
+                spec["name"] = "string(default='')"
+                spec["class"] = "string(default='')"
+                config_parser.validate(refcfg, spec, allow_extra=True)
+
             else:
                 logger.debug("No %s reference files found.", reftype.upper())
 

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -900,6 +900,13 @@ class Step:
                 "%s parameters retrieved from CRDS: %s", reftype.upper(), ref_pars
             )
 
+            # Validate now to warn and remove any extra values found
+            # in CRDS reference files.
+            spec = cls.load_spec_file()
+            spec["name"] = "string(default='')"
+            spec["class"] = "string(default='')"
+            config_parser.validate(ref, spec, allow_extra=True)
+
             return ref
 
         logger.debug("No %s reference files found.", reftype.upper())

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -77,9 +77,7 @@ def test_validate_extra_value_warning(action, monkeypatch):
 
     spec = config_parser.load_spec_file(MockStep)
 
-    monkeypatch.setattr(
-        config_parser, "EXTRA_VALUE_WARNING_ACTION", action
-    )
+    monkeypatch.setattr(config_parser, "EXTRA_VALUE_WARNING_ACTION", action)
     if action == "error":
         # Error is raised
         with pytest.raises(

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -61,8 +61,9 @@ def test_preserve_comments_deprecation(value):
     assert "inline comment (with parentheses)" in spec.inline_comments["bar"]
 
 
-@pytest.mark.parametrize("action",
-                         ["default", "error", "ignore", "always", "module", "once"])
+@pytest.mark.parametrize(
+    "action", ["default", "error", "ignore", "always", "module", "once"]
+)
 def test_validate_extra_value_warning(action):
     """Test that extra values in the configuration raise warnings.
 
@@ -78,8 +79,9 @@ def test_validate_extra_value_warning(action):
     config_parser.EXTRA_VALUE_WARNING_ACTION = action
     if action == "error":
         # Error is raised
-        with pytest.raises(config_parser.ValidationError,
-                           match="Extra value 'unexpected'"):
+        with pytest.raises(
+            config_parser.ValidationError, match="Extra value 'unexpected'"
+        ):
             config_parser.validate(config, spec)
     elif action == "ignore":
         # No warnings or errors issued
@@ -88,6 +90,7 @@ def test_validate_extra_value_warning(action):
             config_parser.validate(config, spec)
     else:
         # Warning is issued
-        with pytest.warns(config_parser.ValidationError,
-                          match="Extra value 'unexpected'"):
+        with pytest.warns(
+            config_parser.ValidationError, match="Extra value 'unexpected'"
+        ):
             config_parser.validate(config, spec)

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -58,3 +58,15 @@ def test_preserve_comments_deprecation(value):
     assert "initial comment" in spec.initial_comment[0]
     assert "final comment" in spec.final_comment[0]
     assert "inline comment (with parentheses)" in spec.inline_comments["bar"]
+
+
+def test_validate_extra_value():
+    """Test that extra values in the configuration raise warnings only."""
+    config = ConfigObj({'expected': True, 'unexpected': False})
+
+    class MockStep:
+        spec = "expected = boolean(default=False) # Expected parameter"
+
+    spec = config_parser.load_spec_file(MockStep)
+    with pytest.warns(RuntimeWarning, match="Extra value 'unexpected'"):
+        config_parser.validate(config, spec)

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -62,7 +62,7 @@ def test_preserve_comments_deprecation(value):
 
 def test_validate_extra_value():
     """Test that extra values in the configuration raise warnings only."""
-    config = ConfigObj({'expected': True, 'unexpected': False})
+    config = ConfigObj({"expected": True, "unexpected": False})
 
     class MockStep:
         spec = "expected = boolean(default=False) # Expected parameter"

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -60,9 +60,7 @@ def test_preserve_comments_deprecation(value):
     assert "inline comment (with parentheses)" in spec.inline_comments["bar"]
 
 
-@pytest.mark.parametrize(
-    "allow_extra", [True, False]
-)
+@pytest.mark.parametrize("allow_extra", [True, False])
 def test_validate_extra_value_warning(allow_extra):
     """
     Test that extra values in the configuration raise warnings or errors.

--- a/tests/test_config_parser.py
+++ b/tests/test_config_parser.py
@@ -64,7 +64,7 @@ def test_preserve_comments_deprecation(value):
 @pytest.mark.parametrize(
     "action", ["default", "error", "ignore", "always", "module", "once"]
 )
-def test_validate_extra_value_warning(action):
+def test_validate_extra_value_warning(action, monkeypatch):
     """Test that extra values in the configuration raise warnings.
 
     The warning behavior can be configured by modifying the
@@ -76,7 +76,10 @@ def test_validate_extra_value_warning(action):
         spec = "expected = boolean(default=False) # Expected parameter"
 
     spec = config_parser.load_spec_file(MockStep)
-    config_parser.EXTRA_VALUE_WARNING_ACTION = action
+
+    monkeypatch.setattr(
+        config_parser, "EXTRA_VALUE_WARNING_ACTION", action
+    )
     if action == "error":
         # Error is raised
         with pytest.raises(

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -190,7 +190,6 @@ def _mock_crds_reffile(monkeypatch, config_file_step, config_file_pipe):
         return config_file_pipe
 
     class SimpleModel:
-
         def __init__(self, *args, **kwargs):
             pass
 
@@ -209,27 +208,18 @@ def _mock_crds_reffile(monkeypatch, config_file_step, config_file_pipe):
     class SimplePipeModel(SimpleModel):
         crds_observatory = "pipe"
 
-    monkeypatch.setattr(
-        crds_client, "get_reference_file", mock_crds_get_reference_file
-    )
+    monkeypatch.setattr(crds_client, "get_reference_file", mock_crds_get_reference_file)
 
-    monkeypatch.setattr(
-        SimpleStep, "_datamodels_open", SimpleStepModel
-    )
-    monkeypatch.setattr(
-        SimplePipe, "_datamodels_open", SimplePipeModel
-    )
+    monkeypatch.setattr(SimpleStep, "_datamodels_open", SimpleStepModel)
+    monkeypatch.setattr(SimplePipe, "_datamodels_open", SimplePipeModel)
 
     small_spec = """
     str1 = string(default='default')
     output_ext = string(default='simplestep')
     """
-    monkeypatch.setattr(
-        SimpleStep, "spec", small_spec
-    )
-    monkeypatch.setattr(
-        SimplePipe, "spec", small_spec
-    )
+    monkeypatch.setattr(SimpleStep, "spec", small_spec)
+    monkeypatch.setattr(SimplePipe, "spec", small_spec)
+
 
 # #####
 # Tests


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3563](https://jira.stsci.edu/browse/JP-3563)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes https://github.com/spacetelescope/jwst/issues/8335

<!-- describe the changes comprising this PR here -->
For future-proofing pipeline runs with new steps, unexpected values in pipeline or step configuration now raise warnings instead of ValidationErrors.  Unexpected steps or parameter values are ignored.  This allows an older pipeline version to be used with a newer parameter reference file.

