### PR TITLE
Remove unused code to simplify filename generation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,10 @@
 ==================
 
 - Remove unused ``Step.closeout`` [#152]
+- Remove unused ``Pipeline.set_input_filename``, ``Step.name_format``,
+  ``Step.resolve_file_name``, ``format`` argument to ``Step.save_model``,
+  ``name_format``, ``component_format`` and ``separator`` arguments to
+  ``Step._make_output_path`` and ``Step.reference_uri_to_cache_path``. [#154]
 
 0.5.2 (2024-03-21)
 ==================

--- a/src/stpipe/pipeline.py
+++ b/src/stpipe/pipeline.py
@@ -245,11 +245,6 @@ class Pipeline(Step):
         config_parser.merge_config(refcfg, pipeline_cfg)
         return refcfg
 
-    def set_input_filename(self, path):
-        self._input_filename = path
-        for key in self.step_defs:
-            getattr(self, key).set_input_filename(path)
-
     def _precache_references(self, input_file):
         """
         Precache all of the expected reference files before the Step's

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -60,12 +60,6 @@ class Step:
     # name.  Must be globally unique!
     class_alias = None
 
-    # String defining the format of the output name, which defines how
-    # **components are inserted into the output file name. If None, use the
-    # default formatting, which is to append Step.suffix to the name. If False,
-    # use basepath as its own format string, containing {suffix}.
-    name_format = None
-
     # Correction parameters. These store and use whatever information a Step
     # may need to perform its operations without re-calculating, or to use
     # from a previous run of the Step.  The structure is up to each Step.
@@ -550,12 +544,10 @@ class Step:
                         if len(results_to_save) <= 1:
                             idx = None
                         if isinstance(result, AbstractDataModel):
-                            self.save_model(result, idx=idx, format=self.name_format)
+                            self.save_model(result, idx=idx)
                         elif hasattr(result, "save"):
                             try:
-                                output_path = self.make_output_path(
-                                    idx=idx, name_format=self.name_format
-                                )
+                                output_path = self.make_output_path(idx=idx)
                             except AttributeError:
                                 self.log.warning(
                                     "`save_results` has been requested, but cannot"

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -623,13 +623,6 @@ class Step:
         """
         raise NotImplementedError("Steps have to override process().")
 
-    def resolve_file_name(self, file_name):
-        """
-        Resolve a file name expressed relative to this Step's
-        configuration file.
-        """
-        return join(dirname(self.config_file or ""), file_name)
-
     @classmethod
     def call(cls, *args, **kwargs):
         """

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -891,20 +891,6 @@ class Step:
         logger.debug("No %s reference files found.", reftype.upper())
         return config_parser.ConfigObj()
 
-    @classmethod
-    def reference_uri_to_cache_path(cls, reference_uri, observatory):
-        """Convert an abstract CRDS reference URI to an absolute file path in the CRDS
-        cache.  Reference URI's are typically output to dataset headers to record the
-        reference files used.
-
-        e.g. 'crds://jwst_miri_flat_0177.fits'  -->
-            '/grp/crds/cache/references/jwst/jwst_miri_flat_0177.fits'
-
-        The CRDS cache is typically located relative to env var CRDS_PATH
-        with default value /grp/crds/cache.   See also https://jwst-crds.stsci.edu
-        """
-        return crds_client.reference_uri_to_cache_path(reference_uri, observatory)
-
     def set_primary_input(self, obj, exclusive=True):
         """
         Sets the name of the master input file and input directory.

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -949,7 +949,6 @@ class Step:
         idx=None,
         output_file=None,
         force=False,
-        format=None,  # noqa: A002
         **components,
     ):
         """
@@ -974,13 +973,6 @@ class Step:
             Regardless of whether `save_results` is `False`
             and no `output_file` is specified, try saving.
 
-        format : str
-            The format of the file name.  This is a format
-            string that defines where `suffix` and the other
-            components go in the file name. If False,
-            it will be presumed `output_file` will have
-            all the necessary formatting.
-
         components : dict
             Other components to add to the file name.
 
@@ -1001,7 +993,6 @@ class Step:
                 self.save_model,
                 suffix=suffix,
                 force=force,
-                format=format,
                 **components,
             )
             output_path = model.save(
@@ -1020,7 +1011,6 @@ class Step:
                     basepath=output_file,
                     suffix=suffix,
                     idx=idx,
-                    name_format=format,
                     **components,
                 )
             )
@@ -1040,9 +1030,6 @@ class Step:
         basepath=None,
         ext=None,
         suffix=None,
-        name_format=None,
-        component_format="",
-        separator="_",
         **components,
     ):
         """Create the output path
@@ -1066,17 +1053,6 @@ class Step:
             If None, the `Step` default will be used.
             If False, no suffix replacement will be done.
 
-        name_format : str or None
-            The format string to use to form the base name.
-            If False, it will be presumed that `basepath`
-            has all the necessary formatting.
-
-        component_format : str
-            Format to use for the components
-
-        separator : str
-            Separator to use between replacement components
-
         components : dict
             dict of string replacements.
 
@@ -1087,10 +1063,10 @@ class Step:
         Notes
         -----
         The values found in the `components` dict are placed in the string
-        where the "{components}" replacement field is specified. If there are
-        more than one component, the components are separated by the `separator`
-        string.
+        where the "{components}" replacement field is specified separated by
+        underscores.
         """
+        separator = "_"
         if basepath is None and step.search_output_file:
             basepath = step.search_attr("output_file")
         if basepath is None:
@@ -1120,25 +1096,18 @@ class Step:
             suffix_sep = None
 
         # Setup formatting
-        if name_format is None:
-            name_format = default_name_format
-        elif not name_format:
-            name_format = basename + ".{ext}"
-            basename = ""
-            suffix_sep = ""
-            separator = ""
         formatter = FormatTemplate(
             separator=separator,
             remove_unused=True,
         )
 
         if len(components):
-            component_str = formatter(component_format, **components)
+            component_str = formatter("", **components)
         else:
             component_str = ""
 
         basename = formatter(
-            name_format,
+            default_name_format,
             basename=basename,
             suffix=suffix,
             suffix_sep=suffix_sep,


### PR DESCRIPTION
This PR removes some unused code in stpipe. Most of this is related to filename generation which will hopefully be somewhat easier to understand after this PR:
- `Pipeline.set_input_filename`
- `Step.name_format`: ~Requires https://github.com/spacetelescope/jwst/pull/8539 to first remove the 1 usage in jwst.~
- `Step.resolve_file_name`
- the `format` argument to `Step.save_model`
- the `name_format` `component_format` and `separator` arguments to `Step._make_output_path`
- remove ([now unused](https://github.com/spacetelescope/jwst/pull/8542)) `Step.reference_uri_to_cache_path`

jwst regtests: https://plwishmaster.stsci.edu:8081/job/RT/job/JWST-Developers-Pull-Requests/1519/ shows 1 unrelated error (`test_duplicate_names` which randomly fails)
romancal regtests: https://plwishmaster.stsci.edu:8081/job/RT/job/Roman-Developers-Pull-Requests/825/ passed with no errors