### PR TITLE
align style checks with other spacetelescope repos

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+exclude: ".*\\.asdf$"
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
@@ -19,6 +21,8 @@ repos:
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
     hooks:
+      - id: python-check-blanket-noqa
+      - id: python-check-mock-methods
       - id: rst-directive-colons
       - id: rst-inline-touching-normal
       - id: text-unicode-replacement-char
@@ -37,22 +41,8 @@ repos:
       - id: ruff
         args: ["--fix", "--show-fixes"]
         exclude: "scripts/strun"
-      - id: ruff-format
 
-  - repo: https://github.com/adamchainz/blacken-docs
-    rev: 1.16.0
+  - repo: https://github.com/psf/black
+    rev: 24.2.0
     hooks:
-      - id: blacken-docs
-        additional_dependencies:
-          - black==22.12.0
-
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v4.0.0-alpha.8"
-    hooks:
-      - id: prettier
-
-  - repo: https://github.com/scientific-python/cookie
-    rev: 2024.01.24
-    hooks:
-      - id: sp-repo-review
-        additional_dependencies: ["repo-review[cli]"]
+      - id: black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ extend-select = [
 ]
 ignore = [
     "ISC001",  # conflicts with ruff formatter
+    "UP038",  # results in slower code
 ]
 
 [tool.ruff.lint.extend-per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,36 +110,9 @@ extend-select = [
     "F",      # Pyflakes
     "W", "E", # pycodestyle
     "I",      # isort
-    "N",      # pep8-naming
     "UP",     # pyupgrade
     "S",      # flake8-bandit
-    # "BLE",    # flake8-blind-except
-    "B",      # flake8-bugbear
-    "A",       # flake8-builtins (prevent shadowing of builtins)
-    "C4",      # flake8-comprehensions (best practices for comprehensions)
-    "T10",     # flake8-debugger (prevent debugger statements in code)
-    "ISC",     # flake8-implicit-str-concat (prevent implicit string concat)
-    "ICN",     # flake8-import-conventions (enforce import conventions)
-    "INP",     # flake8-no-pep420 (prevent use of PEP420, i.e. implicit name spaces)
-    "G",       # flake8-logging-format (best practices for logging)
-    "PIE",     # flake8-pie (misc suggested improvement linting)
-    "T20",     # flake8-print (prevent print statements in code)
-    "PT",      # flake8-pytest-style (best practices for pytest)
-    "Q",       # flake8-quotes (best practices for quotes)
-    "RSE",     # flake8-raise (best practices for raising exceptions)
-    "RET",     # flake8-return (best practices for return statements)
-    # "SLF",     # flake8-self (prevent private member access)
-    "TID",     # flake8-tidy-imports (prevent banned api and best import practices)
-    "INT",     # flake8-gettext (when to use printf style strings)
-    "ARG",     # flake8-unused-arguments (prevent unused arguments)
-    # "PTH",     # flake8-use-pathlib (prefer pathlib over os.path)
-    "ERA",     # eradicate (remove commented out code)
-    "PGH",     # pygrep (simple grep checks)
-    # "PL",      # pylint (general linting, flake8 alternative)
-    "FLY",     # flynt (f-string conversion where possible)
     "NPY",     # NumPy-specific checks (recommendations from NumPy)
-    "PERF",    # Perflint (performance linting)
-    "RUF",     # ruff specific checks
 ]
 ignore = [
     "ISC001",  # conflicts with ruff formatter
@@ -169,11 +142,3 @@ force-exclude = "^/(\n  (\n      \\.eggs\n    | \\.git\n    | \\.pytest_cache\n 
 
 [tool.codespell]
 skip = "*.pdf,*.fits,*.asdf,.tox,build,./tags,.git,docs/_build"
-
-[tool.repo-review]
-ignore = [
-    "GH200",  # Use dependabot
-    "PC140",  # add MyPy to pre-commit
-    "PC901",  # custom pre-comit.ci message
-    "MY100",  # Use MyPy
-]

--- a/src/stpipe/cli/__init__.py
+++ b/src/stpipe/cli/__init__.py
@@ -2,6 +2,7 @@
 Support for the new 'stpipe' CLI (see stpipe.cmdline for the
 implementation of 'strun').
 """
+
 from .main import handle_args
 
 __all__ = ["handle_args"]

--- a/src/stpipe/cli/list.py
+++ b/src/stpipe/cli/list.py
@@ -2,6 +2,7 @@
 Implements the 'stpipe list' command, which lists available
 Step subclasses.
 """
+
 import argparse
 import re
 import sys

--- a/src/stpipe/cli/main.py
+++ b/src/stpipe/cli/main.py
@@ -1,6 +1,7 @@
 """
 Main function and argument parser for stpipe.
 """
+
 import argparse
 import sys
 import traceback

--- a/src/stpipe/cmdline.py
+++ b/src/stpipe/cmdline.py
@@ -1,6 +1,7 @@
 """
 Various utilities to handle running Steps from the commandline.
 """
+
 import io
 import os
 import os.path

--- a/src/stpipe/config.py
+++ b/src/stpipe/config.py
@@ -3,6 +3,7 @@ Implementation of Step methods related to ASDF config files.  This module
 will eventually fully replace config_parser.py, but we'll need to maintain
 both until we replace configobj with traitlets.
 """
+
 from copy import deepcopy
 from datetime import datetime, timezone
 

--- a/src/stpipe/config_parser.py
+++ b/src/stpipe/config_parser.py
@@ -1,6 +1,7 @@
 """
 Our configuration files are ConfigObj/INI files.
 """
+
 import logging
 import os
 import os.path

--- a/src/stpipe/crds_client.py
+++ b/src/stpipe/crds_client.py
@@ -7,6 +7,7 @@ WARNING:  stpipe and crds have circular dependencies.  Do not use crds imports
 directly in modules other than this crds_client so that dependency order and
 general integration can be managed here.
 """
+
 import re
 
 import crds

--- a/src/stpipe/format_template.py
+++ b/src/stpipe/format_template.py
@@ -2,6 +2,7 @@
 
 Format template string allowing partial formatting.
 """
+
 from collections import defaultdict
 from string import Formatter
 

--- a/src/stpipe/function_wrapper.py
+++ b/src/stpipe/function_wrapper.py
@@ -1,6 +1,7 @@
 """
 A Step whose only purpose is to wrap an ordinary function.
 """
+
 from .step import Step
 
 

--- a/src/stpipe/hooks.py
+++ b/src/stpipe/hooks.py
@@ -1,6 +1,7 @@
 """
 Pre- and post-hooks
 """
+
 import ast
 import inspect
 

--- a/src/stpipe/integration.py
+++ b/src/stpipe/integration.py
@@ -1,6 +1,7 @@
 """
 Entry point implementations.
 """
+
 import os
 
 from asdf.resource import DirectoryResourceMapping

--- a/src/stpipe/log.py
+++ b/src/stpipe/log.py
@@ -1,6 +1,7 @@
 """
 Logging setup etc.
 """
+
 import fnmatch
 import io
 import logging

--- a/src/stpipe/pipeline.py
+++ b/src/stpipe/pipeline.py
@@ -1,6 +1,7 @@
 """
 Pipeline
 """
+
 from collections.abc import Sequence
 from os.path import dirname, join
 from typing import ClassVar

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -1,6 +1,7 @@
 """
 Step
 """
+
 import gc
 import os
 import sys
@@ -103,9 +104,9 @@ class Step:
         for reference_file_type in cls.reference_file_types:
             override_name = crds_client.get_override_name(reference_file_type)
             spec[override_name] = "is_string_or_datamodel(default=None)"
-            spec.inline_comments[
-                override_name
-            ] = f"# Override the {reference_file_type} reference file"
+            spec.inline_comments[override_name] = (
+                f"# Override the {reference_file_type} reference file"
+            )
         return spec
 
     @classmethod
@@ -481,9 +482,9 @@ class Step:
                             if isinstance(args[0], Sequence):
                                 for model in args[0]:
                                     try:
-                                        model[
-                                            f"meta.cal_step.{self.class_alias}"
-                                        ] = "SKIPPED"
+                                        model[f"meta.cal_step.{self.class_alias}"] = (
+                                            "SKIPPED"
+                                        )
                                     except AttributeError as e:  # noqa: PERF203
                                         self.log.info(
                                             "Could not record skip into DataModel "

--- a/src/stpipe/utilities.py
+++ b/src/stpipe/utilities.py
@@ -1,6 +1,7 @@
 """
 Utilities
 """
+
 import inspect
 import os
 import sys

--- a/tests/test_format_template.py
+++ b/tests/test_format_template.py
@@ -1,4 +1,5 @@
 """FormatTemplate tests"""
+
 from functools import partial
 
 import pytest

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -1,4 +1,5 @@
 """Test step.Step"""
+
 import logging
 import re
 from typing import ClassVar


### PR DESCRIPTION
This repo includes many style checks etc that do not align with other spacetelescope repos. This PR updates the checks to align more closely with those in romancal and jwst by doing the following:
- disable the scientific python repo-review (this prevented other style check changes and has not been adopted as a standard for stsci)
- use black instead of ruff-format
- remove the many ruff rules enabled in the pyproject.toml (leaving the isort, pyupgrade, bandit, pyflakes and other rules to roughly align with jwst and romancal)

The main motivation for this is to keep a more consistent standard across the repositories. While working on the `ModelLibrary` it has been tested in jwst (aligned to match that style), then moved to romancal (which imposed a slightly different set of checks and required re-formatting) and now in [stpipe](https://github.com/spacetelescope/stpipe/pull/156) the style check and pre-commit autoformatting is further reformatting the code. This is making it difficult to track the changes and highlights inconsistencies in code style requirements across repositories. This PR attempts to reduce those differences.

Much of the changes in this PR are due to the ruff-format to black change. As black is used in jwst, romancal, stdatamodels, roman_datamodels this seems like the standard.