### PR TITLE
install numpy<2 in oldestdeps

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -68,6 +68,9 @@ allowlist_externals =
     echo
 commands_pre =
     oldestdeps: minimum_dependencies stpipe --filename requirements-min.txt
+# this package doesn't depend on numpy directly but the old versions of dependencies
+# will allow numpy 2.0 to be installed (and won't work with numpy 2.0). So we pin it.
+    oldestdeps: pip install numpy<2.0
     oldestdeps: pip install -r requirements-min.txt
     pip freeze
 commands =


### PR DESCRIPTION
Numpy is not a direct dependency and the oldest versions of our dependencies don't pin numpy < 2.0 (and they don't work for numpy 2.0). To allow the oldest deps job to continue to be useful this PR adds a numpy < 2 pin for only the oldest deps job.

See https://github.com/spacetelescope/stpipe/actions/runs/9552146949/job/26328047481?pr=159 for the numerous failures from importing astropy.tables.