### PR TITLE
del model in map_function

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@
 - remove Windows tests and add info box indicating lack of Windows support to README [#163]
 - add ``ModelLibrary`` container class [#156]
 - add ``ModelLibrary`` docs [#168]
+- improve memory usage of ``ModelLibrary.map_function`` [#181]
 
 0.6.1 (unreleased)
 ==================

--- a/src/stpipe/library.py
+++ b/src/stpipe/library.py
@@ -743,6 +743,9 @@ class AbstractModelLibrary(abc.ABC):
                     # this is in a finally to allow cleanup if the generator is
                     # deleted after it finishes (when it's not fully consumed)
                     self.shelve(model, index, modify)
+                # remove the local reference to model here to allow it
+                # to be garbage collected before the next model is generated
+                del model
 
     def _model_to_filename(self, model):
         """


### PR DESCRIPTION
This PR makes a minor change to `AbstractModelLibrary.map_function` to reduce memory usage. More details can be found in the issue but the tldr is that this prevents having 2x models in memory during `map_function`.

Fixes: https://github.com/spacetelescope/stpipe/issues/173