### PR TITLE
JP-3721: Simplify ModelContainer

### DIFF
--- a/changes/190.misc.rst
+++ b/changes/190.misc.rst
@@ -1,0 +1,1 @@
+improve support for list-like input into Step

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -492,9 +492,11 @@ class Step:
                                     )
                                 library.shelve(model, i)
 
-                    elif (isinstance(args[0], Sequence)) and \
-                         (not isinstance(args[0], str)) and \
-                         (self.class_alias is not None):
+                    elif (
+                        (isinstance(args[0], Sequence))
+                        and (not isinstance(args[0], str))
+                        and (self.class_alias is not None)
+                    ):
                         # handle ModelContainer or list of models
                         if args[0] and isinstance(args[0][0], AbstractDataModel):
                             for model in args[0]:
@@ -509,12 +511,12 @@ class Step:
                                         e,
                                     )
 
-                    elif isinstance(args[0], AbstractDataModel) and \
-                        self.class_alias is not None:
+                    elif (
+                        isinstance(args[0], AbstractDataModel)
+                        and self.class_alias is not None
+                    ):
                         try:
-                            args[0][
-                                f"meta.cal_step.{self.class_alias}"
-                            ] = "SKIPPED"
+                            args[0][f"meta.cal_step.{self.class_alias}"] = "SKIPPED"
                         except AttributeError as e:
                             self.log.info(
                                 "Could not record skip into DataModel header: %s",

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -988,7 +988,7 @@ class Step:
                     model.shelve(m, i)
             return output_paths
 
-        elif isinstance(model, Sequence):
+        elif isinstance(model, Sequence) and not isinstance(model, str):
             if not hasattr(model, "save"):
                 # list of datamodels, e.g. ModelContainer
                 output_paths = []

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -492,9 +492,11 @@ class Step:
                                     )
                                 library.shelve(model, i)
 
-                    elif isinstance(args[0], Sequence) and self.class_alias is not None:
+                    elif (isinstance(args[0], Sequence)) and \
+                         (not isinstance(args[0], str)) and \
+                         (self.class_alias is not None):
                         # handle ModelContainer or list of models
-                        if isinstance(args[0][0], AbstractDataModel):
+                        if args[0] and isinstance(args[0][0], AbstractDataModel):
                             for model in args[0]:
                                 try:
                                     setattr(
@@ -515,8 +517,7 @@ class Step:
                             ] = "SKIPPED"
                         except AttributeError as e:
                             self.log.info(
-                                "Could not record skip into DataModel"
-                                " header: %s",
+                                "Could not record skip into DataModel header: %s",
                                 e,
                             )
                     step_result = args[0]
@@ -560,7 +561,37 @@ class Step:
 
                 # Save the output file if one was specified
                 if not self.skip and self.save_results:
-                    self.save_model(step_result)
+                    # Setup the save list.
+                    if isinstance(step_result, Sequence):
+                        if hasattr(step_result, "save") or isinstance(step_result, str):
+                            results_to_save = [step_result]
+                        else:
+                            results_to_save = step_result
+                    else:
+                        results_to_save = [step_result]
+
+                    for idx, result in enumerate(results_to_save):
+                        if len(results_to_save) <= 1:
+                            idx = None
+                        if isinstance(
+                            result, (AbstractDataModel | AbstractModelLibrary)
+                        ):
+                            self.save_model(result, idx=idx)
+                        elif hasattr(result, "save"):
+                            try:
+                                output_path = self.make_output_path(idx=idx)
+                            except AttributeError:
+                                self.log.warning(
+                                    "`save_results` has been requested, but cannot"
+                                    " determine filename."
+                                )
+                                self.log.warning(
+                                    "Specify an output file with `--output_file` or set"
+                                    " `--save_results=false`"
+                                )
+                            else:
+                                self.log.info("Saving file %s", output_path)
+                                result.save(output_path, overwrite=True)
 
                 if not self.skip:
                     self.log.info("Step %s done", self.name)
@@ -988,39 +1019,18 @@ class Step:
                     model.shelve(m, i)
             return output_paths
 
-        elif isinstance(model, Sequence) and not isinstance(model, str):
-            if not hasattr(model, "save"):
-                # list of datamodels, e.g. JWST ModelContainer
-                output_paths = []
-                for i, m in enumerate(model):
-                    # ignore list of lists. individual steps should handle this
-                    if not isinstance(m, Sequence):
-                        idx = None if len(model) == 1 else i
-                        output_paths.append(
-                            self.save_model(
-                                m,
-                                idx=idx,
-                                suffix=suffix,
-                                force=force,
-                                **components,
-                            )
-                        )
-                return output_paths
-            else:
-                # JWST SourceModelContainer takes this path
-                save_model_func = partial(
-                    self.save_model,
-                    suffix=suffix,
-                    force=force,
-                    **components,
-                )
-                output_path = model.save(
-                    path=output_file,
-                    save_model_func=save_model_func,
-                )
-                return output_path
-
-        elif hasattr(model, "save"):
+        elif isinstance(model, Sequence):
+            save_model_func = partial(
+                self.save_model,
+                suffix=suffix,
+                force=force,
+                **components,
+            )
+            output_path = model.save(
+                path=output_file,
+                save_model_func=save_model_func,
+            )
+        else:
             # Search for an output file name.
             if self.output_use_model or (
                 output_file is None and not self.search_output_file
@@ -1036,10 +1046,8 @@ class Step:
                 )
             )
             self.log.info("Saved model in %s", output_path)
-            return output_path
 
-        else:
-            return
+        return output_path
 
     @property
     def make_output_path(self):

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -993,16 +993,18 @@ class Step:
                 # list of datamodels, e.g. ModelContainer
                 output_paths = []
                 for i, m in enumerate(model):
-                    idx = None if len(model) == 1 else i
-                    output_paths.append(
-                        self.save_model(
-                            m,
-                            idx=idx,
-                            suffix=suffix,
-                            force=force,
-                            **components,
+                    # ignore list of lists. individual steps should handle this
+                    if not isinstance(m, Sequence):
+                        idx = None if len(model) == 1 else i
+                        output_paths.append(
+                            self.save_model(
+                                m,
+                                idx=idx,
+                                suffix=suffix,
+                                force=force,
+                                **components,
+                            )
                         )
-                    )
                 return output_paths
             else:
                 # JWST SourceModelContainer takes this path

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -990,7 +990,7 @@ class Step:
 
         elif isinstance(model, Sequence) and not isinstance(model, str):
             if not hasattr(model, "save"):
-                # list of datamodels, e.g. ModelContainer
+                # list of datamodels, e.g. JWST ModelContainer
                 output_paths = []
                 for i, m in enumerate(model):
                     # ignore list of lists. individual steps should handle this

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -448,7 +448,7 @@ class SimpleDataModel(AbstractDataModel):
     def save(self, path, dir_path=None, *args, **kwargs):
         saveid = getattr(self, "saveid", None)
         if saveid is not None:
-            fname = saveid+"-saved.txt"
+            fname = saveid + "-saved.txt"
             with open(fname, "w") as f:
                 f.write(f"{path}")
             return fname

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -1,7 +1,9 @@
 """Test step.Step"""
 
+import copy
 import logging
 import re
+from collections.abc import Sequence
 from typing import ClassVar
 
 import asdf
@@ -9,6 +11,7 @@ import pytest
 
 import stpipe.config_parser as cp
 from stpipe import cmdline
+from stpipe.datamodel import AbstractDataModel
 from stpipe.pipeline import Pipeline
 from stpipe.step import Step
 
@@ -411,3 +414,123 @@ def test_log_records():
     pipeline.run()
 
     assert any(r == "This step has called out a warning." for r in pipeline.log_records)
+
+
+class StepWithModel(Step):
+    """A step that immediately saves the model it gets passed in"""
+
+    spec = """
+    output_ext = string(default='simplestep')
+    save_results = boolean(default=True)
+    """
+    # spec = """
+    #
+    # skip = bool(default=False)
+    # """
+
+    def process(self, input_model):
+        return input_model
+
+
+class SimpleDataModel(AbstractDataModel):
+    """A simple data model"""
+
+    @property
+    def crds_observatory(self):
+        return "jwst"
+
+    # @property
+    # def meta(self):
+    #     return {"filename": "test.fits"}
+
+    def get_crds_parameters(self):
+        return {"test": "none"}
+
+    def save(self, path, dir_path=None, *args, **kwargs):
+        saveid = getattr(self, "saveid", None)
+        if saveid is not None:
+            print(f"here {saveid}")
+            fname = saveid+"-saved.txt"
+            with open(fname, "w") as f:
+                f.write(f"{path}")
+            return fname
+        return None
+
+
+def test_save(tmp_cwd):
+
+    model = SimpleDataModel()
+    model.saveid = "test"
+    step = StepWithModel()
+    step.run(model)
+    assert (tmp_cwd / "test-saved.txt").exists()
+
+
+@pytest.fixture(scope="function")
+def model_list():
+    model = SimpleDataModel()
+    model_list = [copy.deepcopy(model) for _ in range(3)]
+    for i, model in enumerate(model_list):
+        model.saveid = f"test{i}"
+    return model_list
+
+
+def test_save_list(tmp_cwd, model_list):
+    step = StepWithModel()
+    step.run(model_list)
+    for i in range(3):
+        assert (tmp_cwd / f"test{i}-saved.txt").exists()
+
+
+class SimpleContainer(Sequence):
+
+    def __init__(self, models):
+        self._models = models
+
+    def __len__(self):
+        return len(self._models)
+
+    def __getitem__(self, idx):
+        return self._models[idx]
+
+    def __iter__(self):
+        yield from self._models
+
+    def insert(self, index, model):
+        self._models.insert(index, model)
+
+    def append(self, model):
+        self._models.append(model)
+
+    def extend(self, model):
+        self._models.extend(model)
+
+    def pop(self, index=-1):
+        self._models.pop(index)
+
+
+def test_save_container(tmp_cwd, model_list):
+    """ensure list-like save still works for non-list sequence"""
+    container = SimpleContainer(model_list)
+    step = StepWithModel()
+    step.run(container)
+    for i in range(3):
+        assert (tmp_cwd / f"test{i}-saved.txt").exists()
+
+
+def test_save_tuple_with_nested_list(tmp_cwd, model_list):
+    """
+    in rare cases, multiple outputs are returned from step as tuple.
+    One example is the jwst badpix_selfcal step, which returns one sci exposure
+    and a list containing an arbitrary number of background exposures.
+    Expected behavior in this case, at least at time of writing, is to save the
+    science exposure and ignore the list
+    """
+    single_model = SimpleDataModel()
+    single_model.saveid = "test"
+    container = (single_model, model_list)
+    step = StepWithModel()
+    step.run(container)
+    assert (tmp_cwd / "test-saved.txt").exists()
+    for i in range(3):
+        assert not (tmp_cwd / f"test{i}-saved.txt").exists()

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -509,6 +509,15 @@ class SimpleContainer(Sequence):
         self._models.pop(index)
 
 
+class SimpleContainerWithSave(SimpleContainer):
+
+    def save(self, path, dir_path=None, *args, **kwargs):
+        for model in self._models[1:]:
+            # skip the first model to test that the save method is called
+            # rather than just looping over all models like in the without-save case
+            model.save(path, dir_path, *args, **kwargs)
+
+
 def test_save_container(tmp_cwd, model_list):
     """ensure list-like save still works for non-list sequence"""
     container = SimpleContainer(model_list)
@@ -516,6 +525,16 @@ def test_save_container(tmp_cwd, model_list):
     step.run(container)
     for i in range(3):
         assert (tmp_cwd / f"test{i}-saved.txt").exists()
+
+
+def test_save_container_with_save_method(tmp_cwd, model_list):
+    """ensure list-like save still works for non-list sequence"""
+    container = SimpleContainerWithSave(model_list)
+    step = StepWithModel()
+    step.run(container)
+    assert not (tmp_cwd / "test0-saved.txt").exists()
+    assert (tmp_cwd / "test1-saved.txt").exists()
+    assert (tmp_cwd / "test2-saved.txt").exists()
 
 
 def test_save_tuple_with_nested_list(tmp_cwd, model_list):

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -427,7 +427,11 @@ class StepWithModel(Step):
     def process(self, input_model):
         # make a change to ensure step skip is working
         # without having to define SimpleDataModel.meta.stepname
-        input_model.stepstatus = "COMPLETED"
+        if isinstance(input_model, SimpleDataModel):
+            input_model.stepstatus = "COMPLETED"
+        elif isinstance(input_model, SimpleContainer):
+            for model in input_model:
+                model.stepstatus = "COMPLETED"
         return input_model
 
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Helps to resolve [JP-3721](https://jira.stsci.edu/browse/JP-3721)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Helps to close https://github.com/spacetelescope/jwst/issues/8738 

<!-- describe the changes comprising this PR here -->
This PR enables the JWST ModelContainer to no longer inherit from DataModel and to no longer require its own `save` method, as part of an effort to make ModelContainer's usage narrower and easier to understand.  This required two changes to the logic of step.py:

- Add handling for Sequence when setting `skip` attribute
- In save_model(), remove the assumption that a Sequence-type object will always have a `save` method

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stpipe@<branch>"`)
    - [x] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
