### PR TITLE
fix downstream ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,5 +38,6 @@ jobs:
         CRDS_CLIENT_RETRY_COUNT: 3
         CRDS_CLIENT_RETRY_DELAY_SECONDS: 20
       envs: |
-        - linux: py311-jwst-xdist
-        - linux: py311-romancal-xdist
+        - linux: py311-jwst-cov-xdist
+        - linux: py311-romancal-cov-xdist
+      coverage: codecov

--- a/tox.ini
+++ b/tox.ini
@@ -41,13 +41,16 @@ description =
     warnings: treating warnings as errors
     cov: with coverage
     xdist: using parallel processing
+change_dir =
+    jwst,romancal: {env_tmp_dir}
+allowlist_externals =
+    git
+    jwst,romancal: bash
 extras =
     test
 deps =
     xdist: pytest-xdist
     cov: pytest-cov
-    jwst: jwst[test] @ git+https://github.com/spacetelescope/jwst.git
-    romancal: romancal[test] @ git+https://github.com/spacetelescope/romancal.git
     oldestdeps: minimum_dependencies
     devdeps: astropy>=0.0.dev0
     downstreamdeps: jwst
@@ -56,31 +59,39 @@ deps =
 pass_env =
     CRDS_*
     CI
+    romancal: WEBBPSF_PATH
 set_env =
     devdeps: PIP_EXTRA_INDEX_URL = https://pypi.anaconda.org/astropy/simple https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
-    jwst: CRDS_SERVER_URL=https://jwst-crds.stsci.edu
-    downstreamdeps: CRDS_SERVER_URL=https://jwst-crds.stsci.edu
+    jwst,downstreamdeps: CRDS_SERVER_URL=https://jwst-crds.stsci.edu
+    jwst: CRDS_SERVER_URL = https://jwst-crds.stsci.edu
+    jwst,romancal: CRDS_PATH = {package_root}/crds_cache
+    jwst,romancal: CRDS_CLIENT_RETRY_COUNT = 3
+    jwst,romancal: CRDS_CLIENT_RETRY_DELAY_SECONDS = 20
     romancal: CRDS_SERVER_URL=https://roman-crds.stsci.edu
 package =
     !cov: wheel
     cov: editable
-allowlist_externals =
-    echo
 commands_pre =
     oldestdeps: minimum_dependencies stpipe --filename requirements-min.txt
 # this package doesn't depend on numpy directly but the old versions of dependencies
 # will allow numpy 2.0 to be installed (and won't work with numpy 2.0). So we pin it.
     oldestdeps: pip install numpy<2.0
     oldestdeps: pip install -r requirements-min.txt
+    jwst,romancal: bash -c "pip freeze -q | grep 'stpipe @' > {env_tmp_dir}/requirements.txt"
+    jwst: git clone https://github.com/spacetelescope/jwst.git
+    romancal: git clone https://github.com/spacetelescope/romancal.git
+    jwst: pip install -e jwst[test]
+    romancal: pip install -e romancal[test]
+    jwst,romancal: pip install -r {env_tmp_dir}/requirements.txt
     pip freeze
 commands =
     pytest \
     warnings: -W error \
     nolegacypath: -p no:legacypath \
     xdist: -n auto \
-    jwst: --pyargs jwst --ignore-glob=timeconversion --ignore-glob=associations --ignore-glob=*/scripts/* \
-    romancal: --pyargs romancal \
-    cov: --cov=src/stpipe --cov-config=pyproject.toml --cov-report=term-missing --cov-report=xml \
+    jwst: jwst \
+    romancal: romancal \
+    cov: --cov={package_root} --cov-config={package_root}/pyproject.toml --cov-report=term-missing --cov-report=xml \
     {posargs}
 
 [testenv:build-docs]


### PR DESCRIPTION
See https://github.com/spacetelescope/stcal/pull/297
These are the same changes adapted to this package.

Currently downstream testing of jwst and romancal end up using the pyproject.toml in this repository for determining pytest configuration.
This ends up with pytest using options in these downstream tests that differ from the options used by the downstream packages in their tests (when run in their own CI). This in turn results in lots of false failures in our downstream testing.

This PR changes how the jwst and romancal downstream tests to use the pytest options defined in the respective repositories.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stpipe@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
