### PR TITLE
JP-3490: Allow run to check CRDS or user parameters for default overrides

### DIFF
--- a/changes/192.feature.rst
+++ b/changes/192.feature.rst
@@ -1,1 +1,1 @@
-Allow parameter updates from CRDS or user in `run` method.
+Allow parameter updates from CRDS or user in ``step.run`` method.

--- a/changes/192.feature.rst
+++ b/changes/192.feature.rst
@@ -1,0 +1,1 @@
+Allow parameter updates from CRDS or user in `run` method.

--- a/src/stpipe/pipeline.py
+++ b/src/stpipe/pipeline.py
@@ -37,6 +37,7 @@ class Pipeline(Step):
         Step.__init__(self, *args, **kwargs)
 
         # Configure all of the steps
+        step_parameters = kwargs.get('steps', {})
         for key, val in self.step_defs.items():
             cfg = self.steps.get(key)
             if cfg is not None:
@@ -44,7 +45,7 @@ class Pipeline(Step):
                     cfg,
                     parent=self,
                     name=key,
-                    config_file=self.config_file,
+                    config_file=self.config_file
                 )
             else:
                 new_step = val(
@@ -53,6 +54,13 @@ class Pipeline(Step):
                     config_file=self.config_file,
                     **kwargs.get(key, {}),
                 )
+
+            # Make sure explicitly passed parameters for sub-steps
+            # are marked as initialized
+            input_parameters = step_parameters.get(key, {})
+            for param in input_parameters:
+                if param in new_step._initialized:
+                    new_step._initialized[param] = True
 
             setattr(self, key, new_step)
 

--- a/src/stpipe/pipeline.py
+++ b/src/stpipe/pipeline.py
@@ -37,15 +37,12 @@ class Pipeline(Step):
         Step.__init__(self, *args, **kwargs)
 
         # Configure all of the steps
-        step_parameters = kwargs.get('steps', {})
+        step_parameters = kwargs.get("steps", {})
         for key, val in self.step_defs.items():
             cfg = self.steps.get(key)
             if cfg is not None:
                 new_step = val.from_config_section(
-                    cfg,
-                    parent=self,
-                    name=key,
-                    config_file=self.config_file
+                    cfg, parent=self, name=key, config_file=self.config_file
                 )
             else:
                 new_step = val(

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -477,7 +477,7 @@ class Step:
                 parameters = kwargs
 
             # Get parameters from CRDS
-            if self._validate_kwds:
+            if self._validate_kwds and not disable_crds_steppars:
                 # Get the first filename, if available
                 filename = None
                 if len(args) > 0:

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -485,15 +485,21 @@ class Step:
             self.log.info("Step %s running with args %s.", self.name, args)
 
             # Check for explicit disable for CRDS parameters
-            if 'disable_crds_steppars' in kwargs:
+            if "disable_crds_steppars" in kwargs:
                 disable_crds_steppars = kwargs.pop("disable_crds_steppars")
             else:
                 disable_crds_steppars = True
                 if self.parent is None and self._validate_kwds:
-                    self.log.warning("CRDS parameter checks are currently disabled by default.")
-                    self.log.warning("In future builds, they will be enabled by default.")
-                    self.log.warning("To turn them on now, set 'disable_crds_steppars' to False "
-                                     "in the arguments to 'run'.")
+                    self.log.warning(
+                        "CRDS parameter checks are currently disabled by default."
+                    )
+                    self.log.warning(
+                        "In future builds, they will be enabled by default."
+                    )
+                    self.log.warning(
+                        "To turn them on now, set 'disable_crds_steppars' to False "
+                        "in the arguments to 'run'."
+                    )
 
             # Get parameters from user
             parameters = None
@@ -520,8 +526,10 @@ class Step:
                     # Catch steps that cannot build a config
                     # (e.g. post hooks created from local functions,
                     # missing input files)
-                    raise ValueError(f"Cannot retrieve CRDS keywords for "
-                                     f"{self.name} with input {str(filename)}.")
+                    raise ValueError(
+                        f"Cannot retrieve CRDS keywords for "
+                        f"{self.name} with input {str(filename)}."
+                    )
 
             # Update parameters from the retrieved config + keywords
             if parameters:
@@ -631,7 +639,9 @@ class Step:
 
                 # Run the post hooks
                 for post_hook in self._post_hooks:
-                    hook_results = post_hook.run(step_result, disable_crds_steppars=True)
+                    hook_results = post_hook.run(
+                        step_result, disable_crds_steppars=True
+                    )
                     if hook_results is not None:
                         step_result = hook_results
 

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -1340,9 +1340,11 @@ class Step:
         for parameter, value in parameters.items():
             if parameter in existing:
                 if parameter != "steps":
-                    if (skip_initialized
-                            and parameter in self._initialized
-                            and self._initialized[parameter]):
+                    if (
+                        skip_initialized
+                        and parameter in self._initialized
+                        and self._initialized[parameter]
+                    ):
                         self.log.debug(f"Skipping initialized parameter {parameter}")
                     else:
                         self.log.debug(f"Setting parameter {parameter} to {value}")
@@ -1350,7 +1352,8 @@ class Step:
                 else:
                     for step_name, step_parameters in value.items():
                         getattr(self, step_name).update_pars(
-                            step_parameters, skip_initialized=skip_initialized)
+                            step_parameters, skip_initialized=skip_initialized
+                        )
             else:
                 self.log.debug(
                     "Parameter %s is not valid for step %s. Ignoring.", parameter, self

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -465,7 +465,7 @@ class Step:
             self.log.info("Step %s running with args %s.", self.name, args)
 
             # Check for explicit disable for CRDS parameters
-            disable_crds_steppars = kwargs.pop('disable_crds_steppars', None)
+            disable_crds_steppars = kwargs.pop("disable_crds_steppars", None)
 
             # Get parameters from user
             parameters = None
@@ -486,7 +486,8 @@ class Step:
                 # Build config from CRDS + user keywords
                 try:
                     parameters, _ = self.build_config(
-                        filename, disable=disable_crds_steppars, **kwargs)
+                        filename, disable=disable_crds_steppars, **kwargs
+                    )
                 except (NotImplementedError, FileNotFoundError):
                     # Catch steps that cannot build a config
                     # (e.g. post hooks created from local functions,

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -426,9 +426,26 @@ class Step:
 
     def run(self, *args, **kwargs):
         """
+        Set up and run a step process.
+
         Run handles the generic setup and teardown that happens with
         the running of each step.  The real work that is unique to
         each step type is done in the `process` method.
+
+        If this step was not created via a `call` or command line process,
+        default parameters from CRDS are retrieved if available.  Override
+        parameters can also be passed as keyword arguments if desired.
+
+        The order of parameter checking and overrides is:
+           1. spec default value for the step
+           2. keyword parameters or configuration set on step initialization
+           3. CRDS parameters if available
+           4. step attributes directly set by the user before calling run
+           5. keyword parameters passed directly to the run call
+
+        Only 1 and 2 are checked if the step was created via `call`
+        or the command line.
+
         """
         gc.collect()
 

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -1449,10 +1449,11 @@ class Step:
         def _format_new_keywords(config_dict, full_config, keys_to_strip):
             _strip_keys(config_dict, keys_to_strip)
             for key in config_dict:
-                if key == 'steps':
+                if key == "steps":
                     for step_name, step_parameters in config_dict[key].items():
                         _format_new_keywords(
-                            step_parameters, full_config[key][step_name], keys_to_strip)
+                            step_parameters, full_config[key][step_name], keys_to_strip
+                        )
                 else:
                     config_dict[key] = full_config[key]
 

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -411,7 +411,7 @@ class Step:
     def __setattr__(self, key, value):
         """Override setattr to track initialization status for step parameters."""
         super().__setattr__(key, value)
-        if not key.startswith('_'):
+        if not key.startswith("_"):
             self._initialized[key] = True
 
     @property
@@ -458,15 +458,20 @@ class Step:
 
             skip = {"class", "logcfg", "name", "config_file"}
             for key in config:
-                if key in kwargs or (key not in skip and key in self._initialized
-                                     and not self._initialized[key]):
-                    self.log.debug(f'Setting parameter {key} to {config[key]}')
+                if key in kwargs or (
+                    key not in skip
+                    and key in self._initialized
+                    and not self._initialized[key]
+                ):
+                    self.log.debug(f"Setting parameter {key} to {config[key]}")
                     setattr(self, key, config[key])
-                    if key == 'steps':
+                    if key == "steps":
                         for step, step_dict in config[key].items():
                             for step_key, step_value in step_dict.items():
-                                self.log.debug(f'Setting parameters {step}.{step_key} '
-                                               f'to {step_value}')
+                                self.log.debug(
+                                    f"Setting parameters {step}.{step_key} "
+                                    f"to {step_value}"
+                                )
                                 step_instance = getattr(self, step)
                                 setattr(step_instance, step_key, step_value)
 

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -449,11 +449,12 @@ class Step:
             if len(args) > 0:
                 filename = args[0]
 
+            # Catch steps that cannot build a config
+            # (e.g. post hooks created from local functions,
+            # missing input files)
             try:
                 config, config_file = self.build_config(filename, **kwargs)
-            except NotImplementedError:
-                # Catch steps that cannot build a config
-                # (i.e. post hooks created from local functions)
+            except (NotImplementedError, FileNotFoundError):
                 config = {}
 
             skip = {"class", "logcfg", "name", "config_file"}

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -638,7 +638,7 @@ def test_pipe_run_step_values_skip_initialized():
 
 
 @pytest.mark.usefixtures("_mock_crds_reffile")
-def test_pipe_run_step_values_skip_initialized():
+def test_pipe_run_step_values_skip_initialized_on_instantiation():
     """Test that initialized parameters are not overridden."""
     pipe = SimplePipe(steps={"step1": {"str1": "on instantiation"}})
     pipe.process = lambda *args: None

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -522,7 +522,7 @@ def test_step_run_crds_error(caplog, step_class):
 
     # Call run with an incomplete step implementation, on a file that does
     # not exist, without mocking the CRDS retrieval
-    with pytest.raises(ValueError, match='Cannot retrieve CRDS keywords'):
+    with pytest.raises(ValueError, match="Cannot retrieve CRDS keywords"):
         step.run("science.fits", disable_crds_steppars=False)
 
 
@@ -644,8 +644,11 @@ def test_pipe_run_step_values_from_keywords():
     assert pipe.step1._initialized["str1"] is False
 
     # Parameters are set by user
-    pipe.run("science.fits", steps={"step1": {"str1": "from keywords"}},
-             disable_crds_steppars=False)
+    pipe.run(
+        "science.fits",
+        steps={"step1": {"str1": "from keywords"}},
+        disable_crds_steppars=False,
+    )
     assert pipe.step1.str1 == "from keywords"
     assert pipe.step1._initialized["str1"] is True
 

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -487,7 +487,7 @@ def test_step_run_disable_crds_via_environment(monkeypatch, step_class):
     assert step.str1 == "default"
     assert step._initialized["str1"] is False
 
-    monkeypatch.setenv('STPIPE_DISABLE_CRDS_STEPPARS', 'True')
+    monkeypatch.setenv("STPIPE_DISABLE_CRDS_STEPPARS", "True")
 
     step.run("science.fits")
     assert step.str1 == "default"
@@ -516,7 +516,7 @@ def test_step_run_initialized_values(step_class):
 @pytest.mark.parametrize("step_class", [SimplePipe, SimpleStep])
 def test_step_run_initialized_values_on_instantiation(step_class):
     """Test that parameters pre-set are not overridden when run is called."""
-    step = step_class(str1='on instantiation')
+    step = step_class(str1="on instantiation")
     step.process = lambda *args: None
 
     assert step.str1 == "on instantiation"
@@ -640,7 +640,7 @@ def test_pipe_run_step_values_skip_initialized():
 @pytest.mark.usefixtures("_mock_crds_reffile")
 def test_pipe_run_step_values_skip_initialized():
     """Test that initialized parameters are not overridden."""
-    pipe = SimplePipe(steps={'step1': {'str1': 'on instantiation'}})
+    pipe = SimplePipe(steps={"step1": {"str1": "on instantiation"}})
     pipe.process = lambda *args: None
 
     assert pipe.step1.str1 == "on instantiation"

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -522,7 +522,7 @@ def test_step_run_invalid_parameter(step_class):
     step.process = lambda *args: None
 
     with pytest.raises(cp.ValidationError, match="Extra value"):
-        step.run("science.fits", bad_param='from keywords')
+        step.run("science.fits", bad_param="from keywords")
 
 
 @pytest.mark.usefixtures("_mock_crds_reffile")
@@ -532,7 +532,7 @@ def test_step_run_format_bool_parameters(step_class):
     step = step_class()
     step.process = lambda *args: None
 
-    step.run("science.fits", save_results='False')
+    step.run("science.fits", save_results="False")
     assert step.save_results is False
 
 

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -461,12 +461,12 @@ def test_step_run_crds_values(step_class):
     step = step_class()
     step.process = lambda *args: None
 
-    assert step.str1 == 'default'
-    assert step._initialized['str1'] is False
+    assert step.str1 == "default"
+    assert step._initialized["str1"] is False
 
     step.run("science.fits")
-    assert step.str1 == 'from config'
-    assert step._initialized['str1'] is True
+    assert step.str1 == "from config"
+    assert step._initialized["str1"] is True
 
 
 @pytest.mark.usefixtures("_mock_crds_reffile")
@@ -476,12 +476,12 @@ def test_step_run_keyword_values(step_class):
     step = step_class()
     step.process = lambda *args: None
 
-    assert step.str1 == 'default'
-    assert step._initialized['str1'] is False
+    assert step.str1 == "default"
+    assert step._initialized["str1"] is False
 
-    step.run("science.fits", str1='from keywords')
-    assert step.str1 == 'from keywords'
-    assert step._initialized['str1'] is True
+    step.run("science.fits", str1="from keywords")
+    assert step.str1 == "from keywords"
+    assert step._initialized["str1"] is True
 
 
 @pytest.mark.usefixtures("_mock_crds_reffile")
@@ -491,10 +491,10 @@ def test_pipe_run_step_values():
     step.process = lambda *args: None
 
     # Step parameters are initialized when created via the pipeline
-    assert step.step1.str1 == 'default'
-    assert step.step1._initialized['str1'] is True
+    assert step.step1.str1 == "default"
+    assert step.step1._initialized["str1"] is True
 
     # Parameters in a step dictionary can still override them
-    step.run("science.fits", steps={'step1': {'str1': 'from steps'}})
-    assert step.step1.str1 == 'from steps'
-    assert step.step1._initialized['str1'] is True
+    step.run("science.fits", steps={"step1": {"str1": "from steps"}})
+    assert step.step1.str1 == "from steps"
+    assert step.step1._initialized["str1"] is True

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -472,7 +472,7 @@ def test_step_run_crds_values(step_class):
 @pytest.mark.usefixtures("_mock_crds_reffile")
 @pytest.mark.parametrize("step_class", [SimplePipe, SimpleStep])
 def test_step_run_initialized_values(step_class):
-    """Test that parameters pre-set are not overriden when run is called."""
+    """Test that parameters pre-set are not overridden when run is called."""
     step = step_class()
     step.process = lambda *args: None
 

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -215,13 +215,6 @@ def _mock_crds_reffile(monkeypatch, config_file_step, config_file_pipe):
     monkeypatch.setattr(SimpleStep, "_datamodels_open", SimpleStepModel)
     monkeypatch.setattr(SimplePipe, "_datamodels_open", SimplePipeModel)
 
-    small_spec = """
-    str1 = string(default='default')
-    output_ext = string(default='simplestep')
-    """
-    monkeypatch.setattr(SimpleStep, "spec", small_spec)
-    monkeypatch.setattr(SimplePipe, "spec", small_spec)
-
 
 # #####
 # Tests
@@ -519,6 +512,28 @@ def test_step_run_keyword_values_after_initialize(step_class):
     step.run("science.fits", str1="from keywords")
     assert step.str1 == "from keywords"
     assert step._initialized["str1"] is True
+
+
+@pytest.mark.usefixtures("_mock_crds_reffile")
+@pytest.mark.parametrize("step_class", [SimplePipe, SimpleStep])
+def test_step_run_invalid_parameter(step_class):
+    """Test that parameters are validated against spec."""
+    step = step_class()
+    step.process = lambda *args: None
+
+    with pytest.raises(cp.ValidationError, match="Extra value"):
+        step.run("science.fits", bad_param='from keywords')
+
+
+@pytest.mark.usefixtures("_mock_crds_reffile")
+@pytest.mark.parametrize("step_class", [SimplePipe, SimpleStep])
+def test_step_run_format_bool_parameters(step_class):
+    """Test that parameters are validated against spec."""
+    step = step_class()
+    step.process = lambda *args: None
+
+    step.run("science.fits", save_results='False')
+    assert step.save_results is False
 
 
 @pytest.mark.usefixtures("_mock_crds_reffile")


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3490](https://jira.stsci.edu/browse/JP-3490)
Resolves [RCAL-nnnn](https://jira.stsci.edu/browse/RCAL-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #

<!-- describe the changes comprising this PR here -->
This PR proposes a way to resolve the long-standing issue that calling pipeline or step via `run` retrieves different parameter defaults than calling it via the class method `call`.  The idea is to keep run and call as is, but allow run to check CRDS for parameter overrides when called.

To allow users to set parameters as attributes and not override them with defaults, we can track initialization status for all parameters.
- Override __setattr__ to set initialized = True whenever a parameter is set.
- In __init__, set initialized = False for all parameters set from software defaults in the spec

Inside run, check for CRDS defaults and use them.
- Use the provided input data to retrieve any param files from CRDS, and build a config in the same way `call` does.
- Set the parameters to the CRDS config defaults, for any that have not already been initialized.

This would be mostly invisible to users: both call and run would work in the same way they currently do, except that recommended defaults are retrieved from CRDS when run is called.

Additionally, since we are updating a config inside run, we can also allow it to accept `kwargs` in the same way call does, so users could directly set parameters for steps when calling run. Since run and call can use the same method to retrieve and merge CRDS and user parameters, this is straightforward to support.

If this PR is accepted, the JWST documentation will need to be updated, in [readthedocs](https://jwst-pipeline.readthedocs.io/en/stable/jwst/stpipe) and in [JDox](https://jwst-docs.stsci.edu/jwst-science-calibration-pipeline/running-the-jwst-science-calibration-pipeline#RunningtheJWSTScienceCalibrationPipeline-RunningfromwithinPython), to note the change to behavior for `run`.

The romancal documentation will also need updating, here: 
https://roman-pipeline.readthedocs.io/en/latest/roman/stpipe/call_via_run.html

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stpipe@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
