### PR TITLE
support python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
         - linux: py311-downstreamdeps-cov-xdist
           coverage: 'codecov'
         - linux: py312-xdist-nolegacypath
+        - linux: py313-xdist
   test_downstream:
     uses: OpenAstronomy/github-actions-workflows/.github/workflows/tox.yml@v1
     with:

--- a/changes/193.feature.rst
+++ b/changes/193.feature.rst
@@ -1,1 +1,1 @@
-Add python 3.13 support.
+test with Python 3.13

--- a/changes/193.feature.rst
+++ b/changes/193.feature.rst
@@ -1,0 +1,1 @@
+Add python 3.13 support.


### PR DESCRIPTION
Update CI to test with python 3.13.

jwst downstream failure is unrelated see https://github.com/spacetelescope/stpipe/pull/191

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stpipe@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
