### PR TITLE
standardize setattr use in skip

### DIFF
--- a/changes/195.bugfix.rst
+++ b/changes/195.bugfix.rst
@@ -1,0 +1,1 @@
+Fix cal_step setting when a step is skipped for roman datamodels.


### PR DESCRIPTION
Closes https://github.com/spacetelescope/roman_datamodels/issues/343

jwst regtests all pass: https://github.com/spacetelescope/RegressionTests/actions/runs/11804014366
romancal regtests all pass: https://github.com/spacetelescope/RegressionTests/actions/runs/11803229018
(it may be worthwhile to add a regression or unit test in romancal for the feature fixed in this PR in a follow-up romancal PR)

This PR standardizes how stpipe sets `meta.cal_step.<class_alias>` when a step is skipped. On main the behavior for a single roman datamodel (not a ModelLibrary) does not log the skip. Running the following on main:

```python
from romancal.pipeline import ExposurePipeline
elp = ExposurePipeline()
elp.saturation.skip = True
elp.refpix.skip = True
elp.linearity.skip = True
elp.dark_current.skip = True
elp.rampfit.skip = True
elp.assign_wcs.skip = True
elp.flatfield.skip = True
elp.photom.skip = True
elp.source_catalog.skip = True
elp.tweakreg.skip = True
result = elp.run("some_uncal.asdf")
print(result[0].meta.cal_step.saturation)
```
results in printing "INCOMPLETE" indicating that even though the saturation step was skipped stpipe failed to log this to the resulting datamodel.

With this PR the above example results in printing "SKIPPED".

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stpipe@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
