### PR TITLE
add _model_to_exptype method to AbstractModelLibrary

### DIFF
--- a/changes/201.bugfix.rst
+++ b/changes/201.bugfix.rst
@@ -1,0 +1,1 @@
+Add hook to allow ModelLibrary subclasses to override exptype.

--- a/docs/source/model_library.rst
+++ b/docs/source/model_library.rst
@@ -393,6 +393,7 @@ Several methods are abstract and will need implementations:
 It's likely that a few other methods might require overriding:
 
 - ``_model_to_filename``
+- ``_model_to_exptype``
 - ``_assign_member_to_model``
 
 Consult the docstrings (and base implementations) for more details.

--- a/src/stpipe/library.py
+++ b/src/stpipe/library.py
@@ -782,6 +782,25 @@ class AbstractModelLibrary(abc.ABC):
             return f"exposure{index + 1:04d}"
 
     def _model_to_exptype(self, model):
+        """
+        Compute "exptype" from a model using the DataModel interface.
+
+        This will be called for every model in the library:
+            - when the library is created from a list of models
+            - when _save is called
+        In both cases the models are all in memory and this method
+        can use the in memory DataModel to determine the "exptype"
+        (likely ``model.meta.exptype``).
+
+        Parameters
+        ----------
+        model : DataModel
+
+        Returns
+        -------
+        exptype : str
+            Exposure type (for example "SCIENCE").
+        """
         return getattr(model.meta, "exptype", "SCIENCE")
 
     @property
@@ -854,10 +873,12 @@ class AbstractModelLibrary(abc.ABC):
         """
         Compute a "group_id" from a model using the DataModel interface.
 
-        This will be called for every model in the library ONLY when
-        the library is created from a list of models. In this case the
-        models are all in memory and this method can use the in memory
-        DataModel to determine the "group_id" (likely `model.meta.group_id`).
+        This will be called for every model in the library:
+            - when the library is created from a list of models
+            - when _save is called
+        In both cases the models are all in memory and this method
+        can use the in memory DataModel to determine the "group_id"
+        (likely ``model.meta.group_id``).
 
         If no "group_id" can be determined `NoGroupID` should be
         raised (to allow the library to assign a unique "group_id").

--- a/src/stpipe/library.py
+++ b/src/stpipe/library.py
@@ -231,7 +231,7 @@ class AbstractModelLibrary(abc.ABC):
                 else:
                     model = model_or_filename
 
-                exptype = getattr(model.meta, "exptype", "SCIENCE")
+                exptype = self._model_to_exptype(model)
 
                 if asn_exptypes is not None and exptype.lower() not in asn_exptypes:
                     continue
@@ -612,8 +612,8 @@ class AbstractModelLibrary(abc.ABC):
                 members.append(
                     {
                         "expname": str(mfn),
-                        "exptype": model.meta.exptype,
-                        "group_id": model.meta.group_id,
+                        "exptype": self._model_to_exptype(model),
+                        "group_id": self._model_to_group_id(model),
                     }
                 )
                 self.shelve(model, i, modify=False)
@@ -626,7 +626,7 @@ class AbstractModelLibrary(abc.ABC):
     def get_crds_parameters(self):
         """
         Get the "crds_parameters" from either:
-            - the first "science" member (based on model.meta.exptype)
+            - the first "science" member (based on exptype)
             - the first model (if no "science" member is found)
 
         If no "science" members are found in the library a ``UserWarning``
@@ -780,6 +780,9 @@ class AbstractModelLibrary(abc.ABC):
             return getter(model_or_filename)
         except NoGroupID:
             return f"exposure{index + 1:04d}"
+
+    def _model_to_exptype(self, model):
+        return getattr(model.meta, "exptype", "SCIENCE")
 
     @property
     @abc.abstractmethod


### PR DESCRIPTION
This PR adds a method `_model_to_exptype` to `AbstractModelLibrary` to allow jwst to control how `exptype` is determined when `ModelLibrary` is created from a list of models.

With https://github.com/spacetelescope/jwst/pull/8918 this will address JP-3787.

jwst regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/11487054306

Romancal regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/11487038188
show 1 unrelated failure matching main: https://github.com/spacetelescope/RegressionTests/actions/runs/11470564200/job/31920046203

Fixes https://github.com/spacetelescope/stpipe/issues/200

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stpipe@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
