### PR TITLE
support selecting steps by package name for strun

### DIFF
--- a/changes/202.feature.rst
+++ b/changes/202.feature.rst
@@ -1,0 +1,1 @@
+Allow class aliases (used during strun) to contain the package name (for example "jwst::resample").

--- a/src/stpipe/cli/strun.py
+++ b/src/stpipe/cli/strun.py
@@ -1,6 +1,6 @@
 import sys
 
-from stpipe import Step
+from stpipe import cmdline
 from stpipe.cli.main import _print_versions
 from stpipe.exceptions import StpipeExitException
 
@@ -21,7 +21,7 @@ def main():
         sys.exit(0)
 
     try:
-        Step.from_cmdline(sys.argv[1:])
+        cmdline.step_from_cmdline(sys.argv[1:])
     except StpipeExitException as e:
         sys.exit(e.exit_status)
     except Exception:

--- a/src/stpipe/entry_points.py
+++ b/src/stpipe/entry_points.py
@@ -1,7 +1,7 @@
 import warnings
 from collections import namedtuple
 
-from importlib_metadata import entry_points
+import importlib_metadata
 
 STEPS_GROUP = "stpipe.steps"
 
@@ -26,7 +26,7 @@ def get_steps():
     """
     steps = []
 
-    for entry_point in entry_points(group=STEPS_GROUP):
+    for entry_point in importlib_metadata.entry_points(group=STEPS_GROUP):
         package_name = entry_point.dist.name
         package_version = entry_point.dist.version
         package_steps = []

--- a/src/stpipe/utilities.py
+++ b/src/stpipe/utilities.py
@@ -33,13 +33,29 @@ def resolve_step_class_alias(name):
     else:
         scope, class_name = None, name
 
+    # track all found steps keyed by package name
+    found_class_names = {}
     for info in entry_points.get_steps():
         if scope and info.package_name != scope:
             continue
         if info.class_alias is not None and class_name == info.class_alias:
-            return info.class_name
+            found_class_names[info.package_name] = info
 
-    return name
+    if not found_class_names:
+        return name
+
+    if len(found_class_names) == 1:
+        return found_class_names.popitem()[1].class_name
+
+    # class alias resolved to several possible steps
+    scopes = list(found_class_names.keys())
+    msg = (
+        f"class alias {name} matched more than 1 step. Please provide "
+        "the package name along with the step name. One of:\n"
+    )
+    for scope in scopes:
+        msg += f"  {scope}::{name}\n"
+    raise ValueError(msg)
 
 
 def import_class(full_name, subclassof=object, config_file=None):

--- a/src/stpipe/utilities.py
+++ b/src/stpipe/utilities.py
@@ -19,13 +19,24 @@ def resolve_step_class_alias(name):
     Parameters
     ----------
     name : str
+        If name contains "::" only the package with
+        a name matching the characters before "::"
+        will be searched for the matching step.
 
     Returns
     -------
     str
     """
+    # check if the name contains a package name
+    if "::" in name:
+        scope, class_name = name.split("::", maxsplit=1)
+    else:
+        scope, class_name = None, name
+
     for info in entry_points.get_steps():
-        if info.class_alias is not None and name == info.class_alias:
+        if scope and info.package_name != scope:
+            continue
+        if info.class_alias is not None and class_name == info.class_alias:
             return info.class_name
 
     return name


### PR DESCRIPTION
If a user installs both romancal and jwst and runs the following:
```
strun resample some_file
```
strun will always find the resample step in jwst (even though romancal provides a resample step with the class alias "resample").

This PR adds the ability to filter steps found by strun by providing the package name as a "scope. With this PR a user could call:

```
strun romancal::resample some_file
```

to run resample from romancal or

```
strun jwst::resample some_file
```

to run resample from jwst.

Documentation in both packages will need to be updated minimally with a description that providing a package name may be required if multiple strun supported packages are provided.


<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stpipe@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
