### PR TITLE
deprecate Step.__call__

### DIFF
--- a/changes/204.removal.rst
+++ b/changes/204.removal.rst
@@ -1,0 +1,1 @@
+Deprecate Step.__call__. For users that do not want to use CRDS parameters please use Step.run.

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -5,6 +5,7 @@ Step
 import gc
 import os
 import sys
+import warnings
 from collections.abc import Sequence
 from contextlib import contextmanager, suppress
 from functools import partial
@@ -593,7 +594,13 @@ class Step:
 
         return step_result
 
-    __call__ = run
+    def __call__(self, *args):
+        warnings.warn(
+            "Step.__call__ is deprecated. It is equivalent to Step.run "
+            "and is not recommended.",
+            UserWarning,
+        )
+        return self.run(*args)
 
     def finalize_result(self, result, reference_files_used):
         """

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -83,8 +83,8 @@ class MyPipeline(Pipeline):
         return init
 
     def process(self, input_data):
-        result = self.shovelpixels(input_data)
-        result = self.cancelnoise(result)
+        result = self.shovelpixels.run(input_data)
+        result = self.cancelnoise.run(result)
 
         return result  # noqa: RET504
 


### PR DESCRIPTION
This PR deprecates `Step.__call__`.

https://github.com/spacetelescope/romancal/pull/1499 and https://github.com/spacetelescope/jwst/pull/8945 removed all uses of `Step.__call__` in romancal and jwst.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stpipe@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
