### PR TITLE
add `pytest_crds` as an entrypoint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ tracker = "https://github.com/spacetelescope/stpipe/issues"
 [project.entry-points."asdf.resource_mappings"]
 stpipe = "stpipe.integration:get_resource_mappings"
 
+[project.entry-points.pytest11]
+report_crds_context = "stpipe.pytest_crds.plugin"
+
 [project.scripts]
 stpipe = "stpipe.cli.main:main"
 strun = "stpipe.cli.strun:main"

--- a/src/stpipe/pytest_crds/plugin.py
+++ b/src/stpipe/pytest_crds/plugin.py
@@ -1,0 +1,17 @@
+def pytest_addoption(parser):
+    parser.addoption(
+        "--report-crds-context",
+        action="store_true",
+        help="Report CRDS context in test suite header",
+    )
+
+
+def pytest_report_header(config):
+    """Add CRDS_CONTEXT to pytest report header"""
+
+    if config.getoption("report_crds_context"):
+        from stpipe.crds_client import get_context_used
+
+        return f"crds_context: {get_context_used('jwst')}"
+    else:
+        return []


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
moves `pytest_crds` plugin from `jwst` to here. `pytest_crds` is a PyTest plugin that reports the CRDS context in the `pytest` output if you add the `--report-crds-context` flag 

corresponding PR in `jwst`:
- https://github.com/spacetelescope/jwst/pull/9001

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stpipe@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
