### PR TITLE
fix pre_hooks

### DIFF
--- a/changes/214.bugfix.rst
+++ b/changes/214.bugfix.rst
@@ -1,0 +1,1 @@
+Fix pre-hooks by wrapping hook results in a tuple.

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -465,7 +465,7 @@ class Step:
                 for pre_hook in self._pre_hooks:
                     hook_results = pre_hook.run(*hook_args)
                     if hook_results is not None:
-                        hook_args = hook_results
+                        hook_args = (hook_results,)
                 args = hook_args
 
                 self._reference_files_used = []


### PR DESCRIPTION
<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #203

Fixes pre-hooks by packing pre-hook results as tuples so they can be unpacked for subsequent hooks and step.

JWST regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/12659199288
Romancal regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/12659196940

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stpipe@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
