### PR TITLE
remove fits extension assumption for hooks

### DIFF
--- a/changes/217.bugfix.rst
+++ b/changes/217.bugfix.rst
@@ -1,0 +1,1 @@
+Allow hooks to save to non-fits files.

--- a/src/stpipe/function_wrapper.py
+++ b/src/stpipe/function_wrapper.py
@@ -11,7 +11,6 @@ class FunctionWrapper(Step):
     """
 
     spec = """
-    output_ext = string(default="fits")
     """
 
     def __init__(self, func, *args, **kwargs):

--- a/src/stpipe/subproc.py
+++ b/src/stpipe/subproc.py
@@ -22,7 +22,6 @@ class SystemCall(Step):
     log_stderr = boolean(default=True) # Do we want to log STDERR?
     exitcode_as_exception = boolean(default=True) # Should a non-zero exit code be converted into an exception?
     failure_as_exception = boolean(default=True) # If subprocess fails to run at all, should that be an exception?
-    output_ext = string(default="fits")
     """  # noqa: E501
 
     def process(self, *args):


### PR DESCRIPTION
This PR updates hooks to inherit `output_ext` from the hooked class.

Closes #216 

JWST regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/12938827091
Roman regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/12968661316

Regtests all passed

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stpipe@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
