### PR TITLE
remove hostname and os log messages

### DIFF
--- a/src/stpipe/cmdline.py
+++ b/src/stpipe/cmdline.py
@@ -347,9 +347,6 @@ def just_the_step_from_cmdline(args, cls=None):
         step.set_primary_input(positional[0])
         step.save_results = True
 
-    log.log.info(f"Hostname: {os.uname()[1]}")
-    log.log.info(f"OS: {os.uname()[0]}")
-
     # Save the step configuration
     if known.save_parameters:
         step.export_config(known.save_parameters, include_metadata=True)


### PR DESCRIPTION
This PR removes 2 log messages containing:
- the computer hostname
- the computer os

As logs are recorded in roman files (and will likely soon be recorded in jwst files) we don't want this information in the logs.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stpipe@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
