### PR TITLE
add Step._get_crds_parameters

### DIFF
--- a/changes/229.feature.rst
+++ b/changes/229.feature.rst
@@ -1,0 +1,1 @@
+Add ``Step._get_crds_parameters`` to allow subclasses to override parameter determination.

--- a/src/stpipe/pipeline.py
+++ b/src/stpipe/pipeline.py
@@ -182,7 +182,7 @@ class Pipeline(Step):
         logger.debug("Retrieving all substep parameters from CRDS")
         #
         # Iterate over the steps in the pipeline
-        _, crds_parameters, crds_observatory = cls._get_crds_parameters(dataset)
+        crds_parameters, crds_observatory = cls._get_crds_parameters(dataset)
 
         for cal_step in cls.step_defs.keys():
             cal_step_class = cls.step_defs[cal_step]
@@ -252,9 +252,7 @@ class Pipeline(Step):
         None
         """
         try:
-            filename, crds_parameters, observatory = self._get_crds_parameters(
-                input_file
-            )
+            crds_parameters, observatory = self._get_crds_parameters(input_file)
         except (ValueError, TypeError, OSError):
             self.log.info("First argument %s does not appear to be a model", input_file)
             return
@@ -269,7 +267,7 @@ class Pipeline(Step):
 
         self.log.info(
             "Prefetching reference files for dataset: %r reftypes = %r",
-            filename,
+            self._get_filename(input_file),
             fetch_types,
         )
         crds_refs = crds_client.get_multiple_reference_paths(

--- a/src/stpipe/pipeline.py
+++ b/src/stpipe/pipeline.py
@@ -2,14 +2,12 @@
 Pipeline
 """
 
-from collections.abc import Sequence
 from os.path import dirname, join
 from typing import ClassVar
 
 from astropy.extern.configobj.configobj import ConfigObj, Section
 
 from . import config_parser, crds_client, log
-from .library import AbstractModelLibrary
 from .step import Step, get_disable_crds_steppars
 from .utilities import _not_set
 
@@ -184,13 +182,7 @@ class Pipeline(Step):
         logger.debug("Retrieving all substep parameters from CRDS")
         #
         # Iterate over the steps in the pipeline
-        with cls._datamodels_open(dataset, asn_n_members=1) as model:
-            if isinstance(model, Sequence):
-                crds_parameters = model._models[0].get_crds_parameters()
-                crds_observatory = model.crds_observatory
-            else:
-                crds_parameters = model.get_crds_parameters()
-                crds_observatory = model.crds_observatory
+        _, crds_parameters, crds_observatory = cls._get_crds_parameters(dataset)
 
         for cal_step in cls.step_defs.keys():
             cal_step_class = cls.step_defs[cal_step]
@@ -260,49 +252,13 @@ class Pipeline(Step):
         None
         """
         try:
-            with self.open_model(
-                input_file, asn_n_members=1, asn_exptypes=["science"]
-            ) as model:
-                self._precache_references_opened(model)
+            filename, crds_parameters, observatory = self._get_crds_parameters(
+                input_file
+            )
         except (ValueError, TypeError, OSError):
             self.log.info("First argument %s does not appear to be a model", input_file)
+            return
 
-    def _precache_references_opened(self, model_or_container):
-        """Pre-fetches references for `model_or_container`.
-
-        Handles recursive pre-fetches for any models inside a container,
-        or just a single model.
-
-        Assumes model_or_container is an open model or container object,
-        not a filename.
-
-        No garbage collection.
-        """
-        if isinstance(model_or_container, Sequence):
-            # recurse on each contained model
-            for contained_model in model_or_container:
-                self._precache_references_opened(contained_model)
-        elif isinstance(model_or_container, AbstractModelLibrary):
-            with model_or_container:
-                for i, model in enumerate(model_or_container):
-                    self._precache_references_impl(model)
-                    model_or_container.shelve(model, i, modify=False)
-        else:
-            # precache a single model object
-            self._precache_references_impl(model_or_container)
-
-    def _precache_references_impl(self, model):
-        """Given open data `model`,  determine and cache reference files for
-        any reference types which are not overridden on the command line.
-
-        Verify that all CRDS and overridden reference files are readable.
-
-        Parameters
-        ----------
-        model :  `DataModel`
-            Only a `DataModel` instance is allowed.
-            Cannot be a filename, Sequence, etc.
-        """
         ovr_refs = {
             reftype: self.get_ref_override(reftype)
             for reftype in self.reference_file_types
@@ -313,11 +269,11 @@ class Pipeline(Step):
 
         self.log.info(
             "Prefetching reference files for dataset: %r reftypes = %r",
-            model.meta.filename,
+            filename,
             fetch_types,
         )
         crds_refs = crds_client.get_multiple_reference_paths(
-            model.get_crds_parameters(), fetch_types, model.crds_observatory
+            crds_parameters, fetch_types, observatory
         )
 
         ref_path_map = dict(list(crds_refs.items()) + list(ovr_refs.items()))

--- a/src/stpipe/pipeline.py
+++ b/src/stpipe/pipeline.py
@@ -149,10 +149,10 @@ class Pipeline(Step):
             Either a class or instance of a class derived
             from `Step`.
 
-        dataset : `stpipe.datamodel.AbstractDataModel`
+        dataset : `stpipe.datamodel.AbstractDataModel` or dict
             A model of the input file.  Metadata on this input file will
             be used by the CRDS "bestref" algorithm to obtain a reference
-            file.
+            file. If  dict crds_observatory must be a non-None value.
 
         disable: bool or None
             Do not retrieve parameters from CRDS. If None, check global settings.
@@ -182,7 +182,13 @@ class Pipeline(Step):
         logger.debug("Retrieving all substep parameters from CRDS")
         #
         # Iterate over the steps in the pipeline
-        crds_parameters, crds_observatory = cls._get_crds_parameters(dataset)
+        if isinstance(dataset, dict):
+            # crds_parameters was passed as input from pipeline.py
+            crds_parameters = dataset
+            if crds_observatory is None:
+                raise ValueError("Need a valid name for crds_observatory.")
+        else:
+            crds_parameters, crds_observatory = cls._get_crds_parameters(dataset)
 
         for cal_step in cls.step_defs.keys():
             cal_step_class = cls.step_defs[cal_step]

--- a/src/stpipe/pipeline.py
+++ b/src/stpipe/pipeline.py
@@ -152,7 +152,7 @@ class Pipeline(Step):
         dataset : `stpipe.datamodel.AbstractDataModel` or dict
             A model of the input file.  Metadata on this input file will
             be used by the CRDS "bestref" algorithm to obtain a reference
-            file. If  dict crds_observatory must be a non-None value.
+            file. If dict, crds_observatory must be a non-None value.
 
         disable: bool or None
             Do not retrieve parameters from CRDS. If None, check global settings.

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -304,6 +304,33 @@ class Step:
             **kwargs,
         )
 
+    @classmethod
+    def _get_crds_parameters(cls, dataset):
+        if isinstance(dataset, AbstractDataModel):
+            return (
+                dataset.meta.filename,
+                dataset.get_crds_parameters(),
+                dataset.crds_observatory,
+            )
+
+        # TODO asn_exptypes breaks roman_datamodels
+        with cls._datamodels_open(dataset, asn_n_members=1) as model:
+            # ModelContainer is a Sequence, use the first model
+            if isinstance(model, Sequence):
+                model = model[0]
+
+            if isinstance(model, AbstractDataModel):
+                return cls._get_crds_parameters(model)
+
+            # TODO for ModelLibrary we lose a log message
+            # here for precache_references since this is
+            # a class method
+            return (
+                None,
+                model.get_crds_parameters(),
+                model.crds_observatory,
+            )
+
     def __init__(
         self,
         name=None,
@@ -806,12 +833,12 @@ class Step:
             else:
                 return ""
         else:
-            with self.open_model(input_file) as model:
-                reference_name = crds_client.get_reference_file(
-                    model.get_crds_parameters(),
-                    reference_file_type,
-                    model.crds_observatory,
-                )
+            _, parameters, observatory = self._get_crds_parameters(input_file)
+            reference_name = crds_client.get_reference_file(
+                parameters,
+                reference_file_type,
+                observatory,
+            )
             if reference_name != "N/A":
                 hdr_name = "crds://" + basename(reference_name)
             else:
@@ -859,12 +886,7 @@ class Step:
             # If the dataset is not an operable instance of AbstractDataModel,
             # log as such and return an empty config object
             try:
-                with cls._datamodels_open(dataset, asn_n_members=1) as model:
-                    if isinstance(model, Sequence):
-                        # Pull out first model in ModelContainer
-                        model = model[0]
-                    crds_parameters = model.get_crds_parameters()
-                    crds_observatory = model.crds_observatory
+                _, crds_parameters, crds_observatory = cls._get_crds_parameters(dataset)
             except (OSError, TypeError, ValueError):
                 logger.warning("Input dataset is not an instance of AbstractDataModel.")
                 disable = True

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -306,6 +306,19 @@ class Step:
 
     @classmethod
     def _get_filename(cls, dataset):
+        """
+        Class method to get a filename for a dataset.
+
+        Parameters
+        ----------
+        dataset : str, Path, DataModel, ModelLibrary, Sequence
+            Dataset to be inspected for a filename.
+
+        Returns
+        -------
+        filename : str or None
+            Filename as a string or None if no filename could be determined.
+        """
         if isinstance(dataset, str):
             dataset = Path(dataset)
 
@@ -313,18 +326,35 @@ class Step:
             return dataset.name
 
         if isinstance(dataset, Sequence):
+            if not len(dataset):
+                return None
             dataset = dataset[0]
 
         if isinstance(dataset, AbstractDataModel):
-            return dataset.meta.filename
+            return cls._get_filename(dataset.meta.filename)
 
         if isinstance(dataset, AbstractModelLibrary):
-            return dataset.asn.get("table_name", None)
+            return cls._get_filename(dataset.asn.get("table_name", None))
 
         return None
 
     @classmethod
     def _get_crds_parameters(cls, dataset):
+        """
+        Class method to get the CRDS parameters and observatory for a given dataset.
+
+        Parameters
+        ----------
+        dataset : str, Path, DataModel, ModelLibrary, Sequence
+            Dataset to use for determining CRDS parameters.
+
+        Returns
+        -------
+        parameters : dict
+            Dictionary of parameters to pass to CRDS.
+        observatory : str
+            Observatory to pass to CRDS.
+        """
         if isinstance(dataset, AbstractModelLibrary) or (
             isinstance(dataset, AbstractDataModel) and not isinstance(dataset, Sequence)
         ):

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -903,10 +903,10 @@ class Step:
         cls : stpipe.Step
             Either a class or instance of a class derived
             from `Step`.
-        dataset : A datamodel that is an instance of AbstractDataModel
+        dataset : AbstractDataModel or dict
             A model of the input file.  Metadata on this input file will
             be used by the CRDS "bestref" algorithm to obtain a reference
-            file.
+            file. If a dict crds_observatory must be a non-None value.
         disable: bool or None
             Do not retrieve parameters from CRDS. If None, check global settings.
         crds_observatory : str
@@ -927,7 +927,6 @@ class Step:
         if isinstance(dataset, dict):
             # crds_parameters was passed as input from pipeline.py
             crds_parameters = dataset
-            crds_observatory = crds_observatory
             if crds_observatory is None:
                 raise ValueError("Need a valid name for crds_observatory.")
         else:

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -906,7 +906,7 @@ class Step:
         dataset : AbstractDataModel or dict
             A model of the input file.  Metadata on this input file will
             be used by the CRDS "bestref" algorithm to obtain a reference
-            file. If a dict crds_observatory must be a non-None value.
+            file. If a dict, crds_observatory must be a non-None value.
         disable: bool or None
             Do not retrieve parameters from CRDS. If None, check global settings.
         crds_observatory : str

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -16,6 +16,7 @@ from stpipe.library import (
     NoGroupID,
     _Ledger,
 )
+from stpipe.step import Step
 
 _GROUP_IDS = ["1", "1", "2"]
 _N_MODELS = len(_GROUP_IDS)
@@ -785,3 +786,18 @@ def test_library_is_not_sequence():
     a Sequence (like is ModelContainer).
     """
     assert not issubclass(AbstractModelLibrary, Sequence)
+
+
+@pytest.mark.parametrize(
+    "table_name, filename",
+    [
+        ("foo.json", "foo.json"),
+        (None, None),
+        ("MISSING", None),  # special value for "missing" below"
+    ],
+)
+def test_get_filename(table_name, filename):
+    lib = ModelLibrary([])
+    if table_name != "MISSING":
+        lib._asn["table_name"] = table_name
+    assert Step._get_filename(lib) == filename

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -4,13 +4,14 @@ import copy
 import logging
 import re
 from collections.abc import Sequence
+from pathlib import Path
 from typing import ClassVar
 
 import asdf
 import pytest
 
 import stpipe.config_parser as cp
-from stpipe import cmdline
+from stpipe import cmdline, crds_client
 from stpipe.datamodel import AbstractDataModel
 from stpipe.pipeline import Pipeline
 from stpipe.step import Step
@@ -435,8 +436,41 @@ class StepWithModel(Step):
         return input_model
 
 
+class StepWithGetCRDSParameters(Step):
+    """A step that immediately saves the model it gets passed in"""
+
+    spec = """
+    output_ext = string(default='simplestep')
+    save_results = boolean(default=True)
+    """
+
+    _TEST_PARAMETERS = {"test_parameters": 123}
+
+    @classmethod
+    def _get_crds_parameters(cls, dataset):
+        return cls._TEST_PARAMETERS, "fake"
+
+    def process(self, input_model):
+        # make a change to ensure step skip is working
+        # without having to define SimpleDataModel.meta.stepname
+        if isinstance(input_model, SimpleDataModel):
+            input_model.stepstatus = "COMPLETED"
+        elif isinstance(input_model, SimpleContainer):
+            for model in input_model:
+                model.stepstatus = "COMPLETED"
+        return input_model
+
+
+class Meta:
+    pass
+
+
 class SimpleDataModel(AbstractDataModel):
     """A simple data model"""
+
+    def __init__(self, filename="foo.asdf"):
+        self.meta = Meta()
+        self.meta.filename = filename
 
     @property
     def crds_observatory(self):
@@ -562,3 +596,39 @@ def test_save_tuple_with_nested_list(tmp_cwd, model_list):
     assert (tmp_cwd / "test-saved.txt").exists()
     for i in range(3):
         assert not (tmp_cwd / f"test{i}-saved.txt").exists()
+
+
+def test_subclass_get_crds_parameters(monkeypatch):
+    """Test that _get_crds_parameters for a subclass is called"""
+    step = StepWithGetCRDSParameters()
+
+    called = False
+
+    def get_reference_file(parameters, reference_file_type, observatory):
+        nonlocal called
+        called = True
+        return "N/A"
+
+    monkeypatch.setattr(crds_client, "get_reference_file", get_reference_file)
+    step.get_reference_file("foo", "bar")
+    assert called
+
+
+@pytest.mark.parametrize(
+    "dataset, filename",
+    [
+        (SimpleDataModel(filename="foo.asdf"), "foo.asdf"),
+        (SimpleDataModel(filename=Path("bar") / "foo.asdf"), "foo.asdf"),
+        ("bar/foo.asdf", "foo.asdf"),
+        (Path("bar") / "foo.asdf", "foo.asdf"),
+        ([SimpleDataModel(filename="foo.asdf")], "foo.asdf"),
+        ([SimpleDataModel(filename=Path("bar") / "foo.asdf")], "foo.asdf"),
+        (SimpleDataModel(filename=None), None),
+        ([SimpleDataModel(filename=None)], None),
+        ([SimpleDataModel(filename=None)], None),
+        ([], None),
+        (None, None),
+    ],
+)
+def test_get_filename(dataset, filename):
+    assert SimpleStep._get_filename(dataset) == filename


### PR DESCRIPTION
Closes #228
Partially resolves [JP-3949](https://jira.stsci.edu/browse/JP-3949)

This PR adds a class method `Step._get_crds_parameters` to allow subclasses to control how files/models are handled for determining crds parameters for fetching step configurations and reference files.

Combined with https://github.com/spacetelescope/stdatamodels/pull/445 this will allow jwst to more efficiently load models when only the metadata is needed (as is the case for crds).

Regtests all pass:
romancal regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/14038435767
jwst regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/14038446114

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stpipe@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
