### PR TITLE
Use full path if overriding a reference file

### DIFF
--- a/changes/234.bugfix.rst
+++ b/changes/234.bugfix.rst
@@ -1,0 +1,1 @@
+Record the full path to custom reference files

--- a/changes/235.bug.rst
+++ b/changes/235.bug.rst
@@ -1,1 +1,0 @@
-Record the full path to custom reference files

--- a/changes/235.bug.rst
+++ b/changes/235.bug.rst
@@ -1,0 +1,1 @@
+Record the full path to custom reference files

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -878,7 +878,7 @@ class Step:
 
             if override.strip() != "":
                 self._reference_files_used.append(
-                    (reference_file_type, basename(override))
+                    (reference_file_type, abspath(override))#basename(override))
                 )
                 reference_name = override
             else:

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -878,7 +878,7 @@ class Step:
 
             if override.strip() != "":
                 self._reference_files_used.append(
-                    (reference_file_type, abspath(override))#basename(override))
+                    (reference_file_type, abspath(override))
                 )
                 reference_name = override
             else:

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -676,3 +676,14 @@ def test_get_config_from_reference_dict(monkeypatch, klass, observatory, error):
 
     if not error:
         assert called
+
+
+@pytest.mark.parametrize("klass", (SimpleStep, SimplePipe, PipeWithPipe))
+def test_ref_file_override(klass, tmp_path):
+    override_path = tmp_path / "ref.asdf"
+    override_path.touch()
+    step = SimpleStep()
+    step.override_dark = override_path
+    ref_path = step.get_reference_file("foo.asdf", "dark")
+    assert ref_path == str(override_path)
+    assert ("dark", ref_path) in step._reference_files_used


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [AL-929](https://jira.stsci.edu/browse/AL-929)

<!-- If this PR closes a GitHub issue, reference it here by its number -->


<!-- describe the changes comprising this PR here -->
This PR addresses an issue with custom reference files passed to the pipelines with `override_reftype`. Only the basename of the file is recorded in `datamodel.meta.ref_file.name` and the path to it is dropped. However, there are steps which need to use the exact reference files used by another step. They look for reference file names and location in `meta.ref_file`. Since the absolute path is lost the step crashes. The fix here is to preserve the full path if custom files are used.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] run regression tests with this branch installed (`"git+https://github.com/<fork>/stpipe@<branch>"`)
    - [x] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    Seven failures in jwst look unrelated and exists on other PRs.
https://github.com/spacetelescope/RegressionTests/actions/runs/15170686795
    - [x] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
One expected failure in romancal, where the name of the file contains the full path.
https://github.com/spacetelescope/RegressionTests/actions/runs/15170866810

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
