### PR TITLE
JP-3530: Sort unused keys for deterministic order

### DIFF
--- a/src/stpipe/format_template.py
+++ b/src/stpipe/format_template.py
@@ -172,7 +172,7 @@ class FormatTemplate(Formatter):
         result = super().format(format_string, **formatted_kwargs)
 
         # Get any unused arguments and simply do the appending
-        unused_keys = set(formatted_kwargs).difference(self._used_keys)
+        unused_keys = sorted(set(formatted_kwargs).difference(self._used_keys))
         unused_values = [
             formatted_kwargs[unused]
             for unused in unused_keys


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3530](https://jira.stsci.edu/browse/JP-3530)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR addresses https://github.com/spacetelescope/jwst/issues/8257 . This change only fixes the edge case where user supplies a bad template, and only sometimes then. Does it need a change log?

Thanks to @melanieclarke and @stscieisenhamer for pointers.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stpipe@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
