### PR TITLE
Remove deprecated __call__ method

### DIFF
--- a/changes/239.removal.rst
+++ b/changes/239.removal.rst
@@ -1,0 +1,1 @@
+Remove the deprecated ``Step.__call__`` method.

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -5,7 +5,6 @@ Step
 import gc
 import os
 import sys
-import warnings
 from collections.abc import Sequence
 from contextlib import contextmanager, suppress
 from functools import partial

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -654,14 +654,6 @@ class Step:
 
         return step_result
 
-    def __call__(self, *args):
-        warnings.warn(
-            "Step.__call__ is deprecated. It is equivalent to Step.run "
-            "and is not recommended.",
-            UserWarning,
-        )
-        return self.run(*args)
-
     def finalize_result(self, result, reference_files_used):
         """
         Hook that allows subclasses to set mission-specific metadata on each


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3490](https://jira.stsci.edu/browse/JP-3490)
Resolves [RCAL-nnnn](https://jira.stsci.edu/browse/RCAL-nnnn)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
Remove the deprecated `__call__` method from stpipe steps.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stpipe@<branch>"`)
    - [x] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [x] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
