### PR TITLE
Allow downstream packages to specify known loggers

### DIFF
--- a/changes/247.feature.rst
+++ b/changes/247.feature.rst
@@ -1,0 +1,1 @@
+Allow downstream packages to whitelist known loggers, to ensure all desired logging messages are captured without adding configuration to the root logger.

--- a/src/stpipe/cmdline.py
+++ b/src/stpipe/cmdline.py
@@ -353,8 +353,8 @@ def just_the_step_from_cmdline(args, cls=None, apply_log_cfg=False):
 
     # Apply the log configuration to the step's known loggers
     if apply_log_cfg:
-        # Undo the initial configuration
-        log_cfg.undo()
+        # Undo the initial configuration without closing handlers
+        log_cfg.undo(close_handlers=False)
         # Apply configuration to specified loggers
         log_cfg.apply(step.get_known_loggers())
 

--- a/src/stpipe/cmdline.py
+++ b/src/stpipe/cmdline.py
@@ -274,7 +274,9 @@ def just_the_step_from_cmdline(args, cls=None, apply_log_cfg=False):
             raise ValueError(
                 f"Error parsing logging config {log_config!r}:\n{e}"
             ) from e
-        # globally apply the logging configuration since we're in cmdline mode
+
+        # Apply the logging configuration to the stpipe logger to
+        # capture start up messages
         if apply_log_cfg:
             log_cfg.apply()
     except Exception as e:
@@ -348,6 +350,13 @@ def just_the_step_from_cmdline(args, cls=None, apply_log_cfg=False):
         _print_important_message("ERROR PARSING CONFIGURATION:", str(e))
         parser2.print_help()
         raise ValueError(str(e)) from e
+
+    # Apply the log configuration to the step's known loggers
+    if apply_log_cfg:
+        # Undo the initial configuration
+        log_cfg.undo()
+        # Apply configuration to specified loggers
+        log_cfg.apply(step.get_known_loggers())
 
     # Define the primary input file.
     # Always have an output_file set on the outermost step

--- a/src/stpipe/log.py
+++ b/src/stpipe/log.py
@@ -150,7 +150,7 @@ class LogConfig:
             log.setLevel(self.level)
         LogConfig.applied = self
 
-    def undo(self, log_names=None):
+    def undo(self, log_names=None, close_handlers=True):
         """
         Removes the configuration from known loggers.
 
@@ -163,6 +163,9 @@ class LogConfig:
             This parameter is ignored if log configuration has been
             previously applied by this instance: in that case,
             only the previously affected logs are unconfigured.
+        close_handlers : bool, optional
+            If True, handlers will be closed as well as removed from
+            the named loggers.
         """
         if LogConfig.applied is self:
             log_names = list(self._previous_level.keys())
@@ -172,7 +175,8 @@ class LogConfig:
             log = logging.getLogger(log_name)
             for handler in self.handlers:
                 handler.flush()
-                handler.close()
+                if close_handlers:
+                    handler.close()
                 log.removeHandler(handler)
             if LogConfig.applied is self and log_name in self._previous_level:
                 log.setLevel(self._previous_level[log_name])

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -6,6 +6,7 @@ import gc
 import logging
 import os
 import sys
+import warnings
 from collections.abc import Sequence
 from contextlib import contextmanager, nullcontext, suppress
 from functools import partial
@@ -499,7 +500,9 @@ class Step:
         """
         gc.collect()
 
-        with log.record_logs(formatter=self._log_records_formatter) as log_records:
+        with log.record_logs(
+            log_names=self.get_known_loggers(), formatter=self._log_records_formatter
+        ) as log_records:
             self._log_records = log_records
 
             step_result = None
@@ -742,15 +745,16 @@ class Step:
             log_cfg = None
         ctx = nullcontext if log_cfg is None else log_cfg.context
 
-        with ctx():
+        log_names = cls.get_known_loggers()
+        with ctx(log_names):
             config, config_file = cls.build_config(filename, **kwargs)
 
             if "logcfg" in config:
                 # a logcfg is in the configuration file
                 if log_cfg is not None:
-                    log_cfg.undo()
+                    log_cfg.undo(log_names)
                 log_cfg = log.load_configuration(config["logcfg"])
-                log_cfg.apply()
+                log_cfg.apply(log_names)
 
             if "class" in config:
                 del config["class"]
@@ -972,6 +976,29 @@ class Step:
 
         logger.debug("No %s reference files found.", reftype.upper())
         return config_parser.ConfigObj()
+
+    @staticmethod
+    def get_known_loggers():
+        """
+        Get the names of loggers to configure.
+
+        For the base class, the root logger is currently returned,
+        to allow downstream classes time to transition to specifying
+        their loggers. In future builds, the base class logger will
+        default to "stpipe" only.
+
+        Returns
+        -------
+        loggers : list
+            List of log names to configure.
+        """
+        msg = (
+            "The default for `get_known_loggers` is currently the root logger. "
+            "This method should be overridden in downstream packages. "
+            "The default logger will change to 'stpipe' only in future builds."
+        )
+        warnings.warn(msg, DeprecationWarning, stacklevel=2)
+        return [""]
 
     def set_primary_input(self, obj, exclusive=True):
         """

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -35,6 +35,10 @@ class FakeStep(Step):
     def _datamodels_open(cls, init, **kwargs):
         return init
 
+    @staticmethod
+    def get_known_loggers():
+        return ["stpipe"]
+
 
 class ShovelPixelsStep(FakeStep):
     class_alias = "shovelpixels"
@@ -82,6 +86,10 @@ class MyPipeline(Pipeline):
     @classmethod
     def _datamodels_open(cls, init, **kwargs):
         return init
+
+    @staticmethod
+    def get_known_loggers():
+        return ["stpipe"]
 
     def process(self, input_data):
         result = self.shovelpixels.run(input_data)
@@ -185,7 +193,8 @@ def test_hook_as_string_of_importable_function(
             ]
         }
     }
-    MyPipeline.call(model, steps=steps)
+    with pytest.warns(DeprecationWarning, match="root logger"):
+        MyPipeline.call(model, steps=steps)
 
     assert f"Running hook_function on data {data_id}" in caplog.text
 
@@ -203,7 +212,8 @@ def test_hook_as_systemcall(hook_type, caplog, tmp_cwd, disable_crds_steppars):
             ]
         }
     }
-    MyPipeline.call(model, steps=steps)
+    with pytest.warns(DeprecationWarning, match="root logger"):
+        MyPipeline.call(model, steps=steps)
 
     # Logs from fitsinfo
     assert "SystemCall instance created" in caplog.text

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -51,6 +51,10 @@ class LoggingStep(Step):
     def _datamodels_open(self, **kwargs):
         pass
 
+    @staticmethod
+    def get_known_loggers():
+        return ["stpipe", "external"]
+
 
 class LoggingPipeline(Pipeline):
     """A Pipeline that utilizes self.log
@@ -72,6 +76,10 @@ class LoggingPipeline(Pipeline):
 
     def _datamodels_open(self, **kwargs):
         pass
+
+    @staticmethod
+    def get_known_loggers():
+        return ["stpipe", "external"]
 
 
 def test_configuration(tmp_path):
@@ -110,6 +118,66 @@ format = '%(message)s'
     assert lines == ["Shown", "Breaking"]
 
 
+def test_configuration_apply(capsys):
+    log_cfg = stpipe_log.LogConfig(["stderr"], level="INFO")
+    stpipe_logger = logging.getLogger("stpipe")
+    other_logger = logging.getLogger("other")
+    stpipe_msg = "stpipe message"
+    other_msg = "other message"
+
+    # By default, only stpipe is configured
+    log_cfg.apply()
+    stpipe_logger.info(stpipe_msg)
+    other_logger.info(other_msg)
+    capt = capsys.readouterr()
+    assert capt.err.count(stpipe_msg) == 1
+    assert capt.err.count(other_msg) == 0
+
+    # Calling again does not attach a duplicate handler
+    log_cfg.apply()
+    stpipe_logger.info(stpipe_msg)
+    other_logger.info(other_msg)
+    capt = capsys.readouterr()
+    assert capt.err.count(stpipe_msg) == 1
+    assert capt.err.count(other_msg) == 0
+
+    # Other logger can be added to the configuration
+    log_cfg.apply(log_names=["other"])
+    stpipe_logger.info(stpipe_msg)
+    other_logger.info(other_msg)
+    capt = capsys.readouterr()
+    assert capt.err.count(stpipe_msg) == 1
+    assert capt.err.count(other_msg) == 1
+
+    # Calling undo removes configuration from both
+    log_cfg.undo()
+    stpipe_logger.info(stpipe_msg)
+    other_logger.info(other_msg)
+    capt = capsys.readouterr()
+    assert capt.err.count(stpipe_msg) == 0
+    assert capt.err.count(other_msg) == 0
+
+
+@pytest.mark.parametrize("log_names", [None, ["stpipe"]])
+def test_configuration_undo(capsys, log_names):
+    log_cfg = stpipe_log.LogConfig(["stderr"], level="INFO")
+    stpipe_logger = logging.getLogger("stpipe")
+    stpipe_msg = "stpipe message"
+
+    # If the log_cfg handler is attached to a logger without going
+    # through "apply", it can still be removed with undo.
+    stpipe_logger.addHandler(log_cfg.handlers[0])
+
+    stpipe_logger.info(stpipe_msg)
+    capt = capsys.readouterr()
+    assert capt.err.count(stpipe_msg) == 1
+
+    log_cfg.undo(log_names)
+    stpipe_logger.info(stpipe_msg)
+    capt = capsys.readouterr()
+    assert capt.err.count(stpipe_msg) == 0
+
+
 def test_record_logs():
     """
     Test that record_logs respects the default configuration
@@ -122,7 +190,7 @@ def test_record_logs():
     )
 
     with stpipe_log.record_logs(
-        level=logging.ERROR, formatter=logging.Formatter("%(message)s")
+        log_names=[""], level=logging.ERROR, formatter=logging.Formatter("%(message)s")
     ) as log_records:
         stpipe_logger.warning("Warning from stpipe")
         stpipe_logger.error("Error from stpipe")
@@ -194,9 +262,6 @@ def root_logger_unchanged():
         raise AssertionError(f"Unexpected handler {h} in root logger")
 
 
-@pytest.mark.parametrize(
-    "logging_level",
-)
 @pytest.fixture(
     params=(
         logging.CRITICAL,
@@ -267,7 +332,41 @@ def test_logging_delegation(capsys, root_logger_unchanged):
         def _datamodels_open(self, **kwargs):
             pass
 
+        @staticmethod
+        def get_known_loggers():
+            return ["stpipe", "other_library"]
+
     StepThatLogs.call()
 
     captured = capsys.readouterr()
     assert MSG in captured.err
+
+
+def test_logging_unconfigured_external_package(capsys, root_logger_unchanged):
+    """Test that unexpected messages from external packages are not logged."""
+
+    # make a non-step-specific logger
+    other_library_logger = logging.getLogger("other_library.logger")
+    MSG = "warning from other logger"
+
+    class StepThatLogs(Step):
+        spec = """
+           output_ext = string(default='step')
+        """
+
+        def process(self):
+            other_library_logger.warning(MSG)
+
+        def _datamodels_open(self, **kwargs):
+            pass
+
+        @staticmethod
+        def get_known_loggers():
+            # "other_library" is not a known logger,
+            # so it will not be configured.
+            return ["stpipe"]
+
+    StepThatLogs.call()
+
+    captured = capsys.readouterr()
+    assert MSG not in captured.err

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -384,6 +384,10 @@ class StepWithModel(Step):
     save_results = boolean(default=True)
     """
 
+    @staticmethod
+    def get_known_loggers():
+        return ["stpipe"]
+
     def process(self, input_model):
         # make a change to ensure step skip is working
         # without having to define SimpleDataModel.meta.stepname


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Partially resolves [JP-1866](https://jira.stsci.edu/browse/JP-1866)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #245

<!-- describe the changes comprising this PR here -->
Allow downstream packages to specify known loggers, to ensure all desired logging messages are captured without adding configuration to the root logger.

For jwst and romancal, the specific loggers desired can be specified by overriding the `get_known_loggers` method in JwstStep and RomanStep, respectively.  

To allow downstream packages time to transition, the `get_known_loggers` method in the base class raises a DeprecationWarning and returns the root logger.   This should behave identically to the current method, which always attaches configuration to the root logger.  In the future, the base class should transition to returning only the "stpipe" logger; at that point, the DeprecationWarning can be removed.

No changes to downstream packages are required before merging, but JWST unit and regression tests will fail due to the DeprecationWarning until a PR is merged to override the `get_known_loggers` method.  PR is: https://github.com/spacetelescope/jwst/pull/9643.  It can be merged first, since it just adds a new method to the JwstStep class.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] run regression tests with this branch installed (`"git+https://github.com/<fork>/stpipe@<branch>"`)
    - [x] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [x] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
