### PR TITLE
Deprecate Step.log

### DIFF
--- a/changes/249.removal.rst
+++ b/changes/249.removal.rst
@@ -1,0 +1,1 @@
+Deprecate the ``Step.log`` logger. Downstream packages should transition to logging to local loggers, retrieved via ``logging.getLogger``.

--- a/src/stpipe/pipeline.py
+++ b/src/stpipe/pipeline.py
@@ -8,12 +8,11 @@ from typing import ClassVar
 
 from astropy.extern.configobj.configobj import ConfigObj, Section
 
-from . import config_parser, crds_client, log
+from . import config_parser, crds_client
 from .step import Step, get_disable_crds_steppars
 from .utilities import _not_set
 
-# For classmethods, use the STPIPE_ROOT_LOGGER
-logger = logging.getLogger(log.STPIPE_ROOT_LOGGER)
+logger = logging.getLogger(__name__)
 
 
 class Pipeline(Step):
@@ -260,7 +259,7 @@ class Pipeline(Step):
         try:
             crds_parameters, observatory = self._get_crds_parameters(input_file)
         except (ValueError, TypeError, OSError):
-            self.log.info("First argument %s does not appear to be a model", input_file)
+            logger.info("First argument %s does not appear to be a model", input_file)
             return
 
         ovr_refs = {
@@ -271,7 +270,7 @@ class Pipeline(Step):
 
         fetch_types = sorted(set(self.reference_file_types) - set(ovr_refs.keys()))
 
-        self.log.info(
+        logger.info(
             "Prefetching reference files for dataset: %r reftypes = %r",
             self._get_filename(input_file),
             fetch_types,
@@ -284,7 +283,7 @@ class Pipeline(Step):
 
         for reftype, refpath in sorted(ref_path_map.items()):
             how = "Override" if reftype in ovr_refs else "Prefetch"
-            self.log.info(
+            logger.info(
                 "%s for %s reference file is '%s'.", how, reftype.upper(), refpath
             )
             crds_client.check_reference_open(refpath)

--- a/src/stpipe/subproc.py
+++ b/src/stpipe/subproc.py
@@ -1,8 +1,11 @@
+import logging
 import os
 import subprocess
 
 from .datamodel import AbstractDataModel
 from .step import Step
+
+logger = logging.getLogger(__name__)
 
 
 class SystemCall(Step):
@@ -42,7 +45,7 @@ class SystemCall(Step):
             env[var] = val or None
 
         # Start the process and wait for it to finish.
-        self.log.info("Spawning %r", cmd_str)
+        logger.info("Spawning %r", cmd_str)
         try:
             p = subprocess.Popen(
                 args=[cmd_str],
@@ -54,18 +57,18 @@ class SystemCall(Step):
             )
             err = p.wait()
         except Exception as e:
-            self.log.info("Failed with an exception: \n%s", e)
+            logger.info("Failed with an exception: \n%s", e)
 
             if self.failure_as_exception:
                 raise
         else:
-            self.log.info("Done with errorcode %s", err)
+            logger.info("Done with errorcode %s", err)
 
             # Log STDOUT/ERR if we are asked to do so.
             if self.log_stdout:
-                self.log.info("STDOUT: %s", p.stdout.read())
+                logger.info("STDOUT: %s", p.stdout.read())
             if self.log_stderr:
-                self.log.info("STDERR: %s", p.stderr.read())
+                logger.info("STDERR: %s", p.stderr.read())
 
             if self.exitcode_as_exception and err != 0:
                 raise OSError(f"{cmd_str!r} returned error code {err}")

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,8 +1,12 @@
+import logging
+
 import asdf
 import pytest
 
 from stpipe.pipeline import Pipeline
 from stpipe.step import Step
+
+logger = logging.getLogger(__name__)
 
 
 class FakeDataModel:
@@ -40,7 +44,7 @@ class ShovelPixelsStep(FakeStep):
     class_alias = "shovelpixels"
 
     def process(self, input_data):
-        self.log.info("Shoveling...")
+        logger.info("Shoveling...")
         return input_data
 
 
@@ -48,7 +52,7 @@ class CancelNoiseStep(FakeStep):
     class_alias = "cancelnoise"
 
     def process(self, input_data):
-        self.log.info("De-noising...")
+        logger.info("De-noising...")
         return input_data
 
 
@@ -62,7 +66,7 @@ class HookStep(FakeStep):
     """
 
     def process(self, input_data):
-        self.log.info("Running HookStep with %s and %s", self.param1, self.param2)
+        logger.info("Running HookStep with %s and %s", self.param1, self.param2)
 
         return input_data
 
@@ -114,7 +118,6 @@ def test_hook_as_step_class(hook_type, caplog, disable_crds_steppars):
     MyPipeline.call(model, steps=steps)
 
     assert "Running HookStep with bar and 1" in caplog.text
-    assert "cancelnoise.myhook" in caplog.text
 
 
 @pytest.mark.parametrize("hook_type", ["pre_hooks", "post_hooks"])


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Partially resolves [JP-1866](https://jira.stsci.edu/browse/JP-1866)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #246 

<!-- describe the changes comprising this PR here -->
Deprecate usage of the Step.log logger.  Downstream users should move to logging to local loggers instead, retrieved via `logging.getLogger`.

For the transition period, the Step.log logger will remain available, with the same name it currently has, but using it will raise a DeprecationWarning.  

Changes to downstream packages are not required before merge, but JWST unit and regression tests will fail due to the DeprecationWarning until https://github.com/spacetelescope/jwst/pull/9657 is merged to remove self.log usage in current steps and pipelines.  This PR can be merged prior to making any changes on stpipe, since stpipe already supports local logger use.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] run regression tests with this branch installed (`"git+https://github.com/<fork>/stpipe@<branch>"`)
    - [x] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [x] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
