### PR TITLE
Deprecate logcfg

### DIFF
--- a/src/stpipe/cmdline.py
+++ b/src/stpipe/cmdline.py
@@ -2,11 +2,12 @@
 Various utilities to handle running Steps from the commandline.
 """
 
-import io
+import argparse
 import logging
 import os
 import os.path
 import textwrap
+import warnings
 
 from . import config_parser, log, utilities
 from .step import Step, get_disable_crds_steppars
@@ -15,6 +16,10 @@ built_in_configuration_parameters = [
     "debug",
     "logcfg",
     "verbose",
+    "log_level",
+    "log_format",
+    "log_file",
+    "log_stream",
 ]
 
 logger = logging.getLogger(__name__)
@@ -61,6 +66,81 @@ def _get_config_and_class(identifier):
     return step_class, config, name, config_file
 
 
+def _build_parent_arg_parser(cls=None, apply_log_cfg=False):
+    """Build a top-level argument parser for the command line interface."""
+    parser1 = argparse.ArgumentParser(
+        description="Run an stpipe Step or Pipeline",
+        add_help=False,
+    )
+    if cls is None:
+        parser1.add_argument(
+            "cfg_file_or_class",
+            type=str,
+            nargs=1,
+            help="The configuration file or Python class to run",
+        )
+    else:
+        parser1.add_argument(
+            "--config-file",
+            type=str,
+            help="A configuration file to load parameters from",
+        )
+    parser1.add_argument(
+        "--debug",
+        action="store_true",
+        help="When an exception occurs, invoke the Python debugger, pdb",
+    )
+    parser1.add_argument(
+        "--save-parameters",
+        type=str,
+        help="Save step parameters to specified file",
+    )
+    parser1.add_argument(
+        "--disable-crds-steppars",
+        action="store_true",
+        help="Disable retrieval of step parameter references files from CRDS",
+    )
+    if apply_log_cfg:
+        parser1.add_argument(
+            "--logcfg",
+            type=str,
+            help="DEPRECATED: The logging configuration file to load. "
+            "Ignored if verbose or other log arguments are set.",
+        )
+        parser1.add_argument(
+            "--verbose",
+            "-v",
+            action="store_true",
+            help="Turn on all logging messages",
+        )
+        parser1.add_argument(
+            "--log_level",
+            type=str,
+            default=None,
+            help="Log level (DEBUG, INFO, WARNING, ERROR, CRITICAL). "
+            "Ignored if 'verbose' is specified.",
+        )
+        parser1.add_argument(
+            "--log_format",
+            type=str,
+            default=None,
+            help="A format string for the logger",
+        )
+        parser1.add_argument(
+            "--log_file",
+            type=str,
+            default=None,
+            help="Full path to a file name to record log messages",
+        )
+        parser1.add_argument(
+            "--log_stream",
+            type=str,
+            default=None,
+            help="Log stream for terminal messages (stdout, stderr, or null).",
+        )
+    return parser1
+
+
 def _build_arg_parser_from_spec(spec, step_class, parent=None):
     """
     Given a configspec, sets up an argparse argument parser that
@@ -76,8 +156,6 @@ def _build_arg_parser_from_spec(spec, step_class, parent=None):
 
     The "baz" variable can be changed with ``--foo.bar.baz=42``.
     """
-    import argparse
-
     # It doesn't translate the configspec types -- it instead
     # will accept any string.  However, the types of the arguments will
     # later be verified by configobj itself.
@@ -163,13 +241,16 @@ def just_the_step_from_cmdline(args, cls=None, apply_log_cfg=False):
     """
     Create a step from a configuration file and return it.  Don't run it.
 
+    DOES NOT RUN THE STEP.
+
     Parameters
     ----------
     args : list of str
-        Commandline arguments
+        Command line arguments
 
-    cls : Step class
-        The step class to use.  If none is provided, the step
+    cls : Step class, optional
+        The step class to use.  If none is provided, the step is inferred
+        from the input arguments.
 
     apply_log_cfg : bool
         If True, apply the logging configuration. If False,
@@ -192,53 +273,10 @@ def just_the_step_from_cmdline(args, cls=None, apply_log_cfg=False):
     positional: list of strings
         Positional parameters after arg parsing
 
-    DOES NOT RUN THE STEP
+    debug_on_exception : bool
+        If True, the Python debugger will be invoked when an exception occurs.
     """
-    import argparse
-
-    parser1 = argparse.ArgumentParser(
-        description="Run an stpipe Step or Pipeline",
-        add_help=False,
-    )
-    if cls is None:
-        parser1.add_argument(
-            "cfg_file_or_class",
-            type=str,
-            nargs=1,
-            help="The configuration file or Python class to run",
-        )
-    else:
-        parser1.add_argument(
-            "--config-file",
-            type=str,
-            help="A configuration file to load parameters from",
-        )
-    parser1.add_argument(
-        "--logcfg",
-        type=str,
-        help="The logging configuration file to load",
-    )
-    parser1.add_argument(
-        "--verbose",
-        "-v",
-        action="store_true",
-        help="Turn on all logging messages",
-    )
-    parser1.add_argument(
-        "--debug",
-        action="store_true",
-        help="When an exception occurs, invoke the Python debugger, pdb",
-    )
-    parser1.add_argument(
-        "--save-parameters",
-        type=str,
-        help="Save step parameters to specified file.",
-    )
-    parser1.add_argument(
-        "--disable-crds-steppars",
-        action="store_true",
-        help="Disable retrieval of step parameter references files from CRDS",
-    )
+    parser1 = _build_parent_arg_parser(cls, apply_log_cfg=apply_log_cfg)
     known, _ = parser1.parse_known_args(args)
 
     try:
@@ -254,29 +292,52 @@ def just_the_step_from_cmdline(args, cls=None, apply_log_cfg=False):
             )
             step_class = cls
 
-        if known.verbose:
-            if known.logcfg is not None:
-                raise ValueError(
-                    "If --verbose is set, a logging configuration file may not be"
-                    " provided"
-                )
-            log_config = io.BytesIO(log.MAX_CONFIGURATION)
-        elif known.logcfg is not None:
-            if not os.path.exists(known.logcfg):
-                raise OSError(f"Logging config {known.logcfg!r} not found")
-            log_config = known.logcfg
-        else:
-            log_config = log._find_logging_config_file()
-
-        try:
-            log_cfg = log.load_configuration(log_config)
-        except Exception as e:
-            raise ValueError(
-                f"Error parsing logging config {log_config!r}:\n{e}"
-            ) from e
-        # globally apply the logging configuration since we're in cmdline mode
         if apply_log_cfg:
-            log_cfg.apply()
+            # Retrieve a log config file if specified
+            use_log_cfg = True
+            log_args = [
+                known.log_level,
+                known.log_format,
+                known.log_file,
+                known.log_stream,
+            ]
+            if known.verbose is True or any([arg is not None for arg in log_args]):
+                use_log_cfg = False
+
+            logcfg = None
+            if known.logcfg is not None:
+                msg = (
+                    "The logcfg configuration file is deprecated. "
+                    "Please use the log_* command line "
+                    "arguments to configure logging."
+                )
+                warnings.warn(msg, DeprecationWarning, stacklevel=2)
+                if use_log_cfg:
+                    if not os.path.exists(known.logcfg):
+                        raise OSError(f"Logging config {known.logcfg!r} not found")
+                    logcfg = known.logcfg
+            elif use_log_cfg:
+                logcfg = log._find_logging_config_file()
+
+            if known.verbose:
+                log_level = "DEBUG"
+            elif known.log_level is not None:
+                log_level = str(known.log_level).upper()
+            else:
+                log_level = None
+            try:
+                log_cfg = log.load_configuration(
+                    config_file=logcfg,
+                    log_level=log_level,
+                    log_format=known.log_format,
+                    log_file=known.log_file,
+                    log_stream=known.log_stream,
+                )
+            except Exception as e:
+                raise ValueError(f"Error parsing logging configuration:\n{e}") from e
+            # globally apply the logging configuration since we're in cmdline mode
+            if apply_log_cfg:
+                log_cfg.apply()
     except Exception as e:
         _print_important_message("ERROR PARSING CONFIGURATION:", str(e))
         parser1.print_help()
@@ -302,11 +363,16 @@ def just_the_step_from_cmdline(args, cls=None, apply_log_cfg=False):
         del args.cfg_file_or_class
     else:
         del args.config_file
-    del args.logcfg
-    del args.verbose
     del args.debug
     del args.save_parameters
     del args.disable_crds_steppars
+    if apply_log_cfg:
+        del args.logcfg
+        del args.verbose
+        del args.log_level
+        del args.log_format
+        del args.log_file
+        del args.log_stream
     positional = args.args
     del args.args
 
@@ -373,7 +439,9 @@ def step_from_cmdline(args, cls=None):
         Commandline arguments
 
     cls : Step class
-        The step class to use.  If none is provided, the step
+        The step class to use.  If none is provided, the step is inferred
+        from the input arguments.
+
 
     Returns
     -------

--- a/src/stpipe/log.py
+++ b/src/stpipe/log.py
@@ -117,6 +117,9 @@ class LogConfig:
         if handler_str == "stderr":
             return logging.StreamHandler(sys.stderr)
 
+        if handler_str == "null":
+            return logging.NullHandler()
+
         raise ValueError(f"Can't parse handler {handler_str!r}")
 
     def apply(self):
@@ -157,14 +160,29 @@ class LogConfig:
             self.undo()
 
 
-def load_configuration(config_file):
+def load_configuration(
+    config_file=None, log_level=None, log_format=None, log_file=None, log_stream=None
+):
     """
     Loads a logging configuration file.  The format of this file is
     defined in LogConfig.spec.
 
     Parameters
     ----------
-    config_file : str, pathlib.Path instance or readable file-like object
+    config_file : str, pathlib.Path instance, file-like object, or None, optional
+        DEPRECATED. Log configuration file. Ignored if log_level, log_format,
+        or log_file are provided.
+    log_level : str, int, or None, optional
+        Logging level.  If None, and config_file is not provided, will default
+        to INFO level.
+    log_format : str or None, optional
+        Log format to apply.  If None, and config_file is not provided, will default
+        to DEFAULT_FORMAT.
+    log_file : str or None, optional
+        Full path to a file name to write log messages to, if desired.
+    log_stream : {"stdout", "stderr", "null", None}
+        Stream for terminal messages.  If "null", no stream handler is added.
+        If None, and config_file is not provided, will default to "stderr".
 
     Returns
     -------
@@ -184,13 +202,40 @@ def load_configuration(config_file):
             raise validate.VdtTypeError(value) from err
         return value
 
-    spec = config_parser.load_spec_file(LogConfig)
-    if isinstance(config_file, pathlib.Path):
-        config_file = str(config_file)
-    config = ConfigObj(config_file, raise_errors=True, interpolation=False)
-    val = validate.Validator()
-    val.functions["level"] = _level_check
-    config_parser.validate(config, spec, validator=val)
+    # Ignore config file if other arguments are provided
+    if log_level is not None or log_format is not None or log_file is not None:
+        config_file = None
+
+    if config_file is not None:
+        # Load the config file
+        spec = config_parser.load_spec_file(LogConfig)
+        if isinstance(config_file, pathlib.Path):
+            config_file = str(config_file)
+        config = ConfigObj(config_file, raise_errors=True, interpolation=False)
+        val = validate.Validator()
+        val.functions["level"] = _level_check
+        config_parser.validate(config, spec, validator=val)
+    else:
+        # Provide appropriate defaults for level and format
+        if log_level is None:
+            log_level = "INFO"
+        if log_format is None:
+            log_format = DEFAULT_FORMAT
+        if log_stream is None:
+            log_stream = "stderr"
+
+        # Add stream or log handlers
+        handlers = [log_stream]
+        if log_file is not None:
+            handlers.append(f"file:{log_file}")
+
+        config = {
+            "*": {
+                "handler": ",".join(handlers),
+                "level": _level_check(log_level),
+                "format": log_format,
+            }
+        }
 
     for key, val in config.items():
         if key in ("", ".", "root", "*"):
@@ -207,9 +252,43 @@ def _find_logging_config_file():
     for file in files:
         file = os.path.expanduser(file)
         if os.path.exists(file):
+            msg = (
+                "The logcfg configuration file is deprecated. "
+                "In future releases, the configuration file at "
+                f"{os.path.abspath(file)} will be ignored."
+            )
+            warnings.warn(msg, DeprecationWarning, stacklevel=2)
             return os.path.abspath(file)
 
     return io.BytesIO(DEFAULT_CONFIGURATION)
+
+
+def is_configured(logger):
+    """
+    Quick check for likely user log configuration.
+
+    Since stpipe may attach handlers to the root logger,
+    we have to check for handlers commonly added by pytest.
+
+    Parameters
+    ----------
+    logger : logging.Logger
+        Logger to check
+    """
+    for handler in logger.handlers:
+        if handler.__class__.__name__ in (
+            "LogCaptureHandler",
+            "_LiveLoggingNullHandler",
+        ):
+            continue
+        elif (
+            isinstance(handler, logging.FileHandler)
+            and handler.baseFilename == "/dev/null"
+        ):
+            continue
+        else:
+            return True
+    return False
 
 
 class RecordingHandler(logging.Handler):

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -6,6 +6,7 @@ import gc
 import logging
 import os
 import sys
+import warnings
 from collections.abc import Sequence
 from contextlib import contextmanager, nullcontext, suppress
 from functools import partial
@@ -698,9 +699,14 @@ class Step:
     @classmethod
     def call(cls, *args, **kwargs):
         """
-        Creates and runs a new instance of the class.
+        Create and run a new instance of the class.
 
-        Gets a config file from CRDS if one is available
+        Gets a config file from CRDS if one is available.
+
+        By default, log handlers are added for the duration of the
+        run, if there are no handlers already present in the root
+        logger.  To avoid configuring the log, specify ``configure_log=False``
+        in the keyword arguments.
 
         To set configuration parameters, pass a ``config_file`` path or
         keyword arguments.  Keyword arguments override those in the
@@ -715,11 +721,6 @@ class Step:
         this ``call()`` method, it will ignore previously-set parameters, as
         it creates a new instance of the class with only the ``config_file``,
         ``*args`` and ``**kwargs`` passed to the ``call()`` method.
-
-        If not used with a ``config_file`` or specific ``*args`` and ``**kwargs``,
-        it would be better to use the `run` method, which does not create
-        a new instance but simply runs the existing instance of the `Step`
-        class.
         """
         filename = None
         if len(args) > 0:
@@ -728,7 +729,15 @@ class Step:
         # set up the log configuration here (although we might undo it
         # below) as log messages are generated before the config is
         # fully loaded
+        configure_log = kwargs.pop("configure_log", True)
+        deprecation_msg = (
+            "The 'logcfg' configuration option is deprecated. "
+            "In future releases, it will be ignored, and logging "
+            "should be directly configured via command line arguments "
+            "or the logging module."
+        )
         if "logcfg" in kwargs:
+            warnings.warn(deprecation_msg, DeprecationWarning, stacklevel=2)
             try:
                 log_cfg = log.load_configuration(kwargs["logcfg"])
             except Exception as e:
@@ -736,8 +745,20 @@ class Step:
                     f"Error parsing logging config {kwargs['logcfg']}"
                 ) from e
             del kwargs["logcfg"]
-        elif log.LogConfig.applied is None:
-            log_cfg = log.load_configuration(log._find_logging_config_file())
+        elif configure_log and log.LogConfig.applied is None:
+            # Check for existing configuration on the root logger:
+            # if any handlers are present, don't add the default config
+            # Note: if we move to configuring known loggers instead
+            # of always configuring the root logger, we should
+            # check all known loggers here as well.
+            root_logger = logging.getLogger()
+            if not log.is_configured(root_logger):
+                # Load a default configuration
+                log_cfg = log.load_configuration(
+                    config_file=log._find_logging_config_file()
+                )
+            else:
+                log_cfg = None
         else:
             log_cfg = None
         ctx = nullcontext if log_cfg is None else log_cfg.context
@@ -747,6 +768,8 @@ class Step:
 
             if "logcfg" in config:
                 # a logcfg is in the configuration file
+                warnings.warn(deprecation_msg, DeprecationWarning, stacklevel=2)
+
                 if log_cfg is not None:
                     log_cfg.undo()
                 log_cfg = log.load_configuration(config["logcfg"])

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -18,6 +18,11 @@ def _clean_up_logging():
     logging.shutdown()
 
 
+STEP_DEBUG = "This step has called out a debug message."
+PIPELINE_DEBUG = "This pipeline has called out a debug message."
+EXTERNAL_DEBUG = "This external package has called out a debug message."
+ALL_DEBUG = [STEP_DEBUG, PIPELINE_DEBUG, EXTERNAL_DEBUG]
+
 STEP_INFO = "This step has called out an info message."
 PIPELINE_INFO = "This pipeline has called out an info message."
 EXTERNAL_INFO = "This external package has called out an info message."
@@ -28,7 +33,16 @@ PIPELINE_WARNING = "This pipeline has called out a warning."
 EXTERNAL_WARNING = "This external package has called out a warning."
 ALL_WARNINGS = [STEP_WARNING, PIPELINE_WARNING, EXTERNAL_WARNING]
 
-ALL_MESSAGES = ALL_INFO + ALL_WARNINGS
+ALL_MESSAGES = ALL_DEBUG + ALL_INFO + ALL_WARNINGS
+ALL_MESSAGES_EXCEPT_DEBUG = ALL_INFO + ALL_WARNINGS
+
+LOGLEVELS = (
+    logging.CRITICAL,
+    logging.ERROR,
+    logging.WARNING,
+    logging.INFO,
+    logging.DEBUG,
+)
 
 
 class LoggingStep(Step):
@@ -43,10 +57,12 @@ class LoggingStep(Step):
     _log_records_formatter = logging.Formatter("%(message)s")
 
     def process(self):
-        self.log.info(STEP_INFO)
         self.log.warning(STEP_WARNING)
+        self.log.info(STEP_INFO)
+        self.log.debug(STEP_DEBUG)
         logging.getLogger("external.logger").warning(EXTERNAL_WARNING)
         logging.getLogger("external.logger").info(EXTERNAL_INFO)
+        logging.getLogger("external.logger").debug(EXTERNAL_DEBUG)
 
     def _datamodels_open(self, **kwargs):
         pass
@@ -68,6 +84,7 @@ class LoggingPipeline(Pipeline):
     def process(self):
         self.log.warning(PIPELINE_WARNING)
         self.log.info(PIPELINE_INFO)
+        self.log.debug(PIPELINE_DEBUG)
         self.simplestep.run()
 
     def _datamodels_open(self, **kwargs):
@@ -144,7 +161,7 @@ def test_record_logs():
 @pytest.mark.parametrize(
     "level, expected",
     (
-        ("INFO", ALL_MESSAGES),
+        ("INFO", ALL_MESSAGES_EXCEPT_DEBUG),
         ("WARNING", ALL_WARNINGS),
     ),
 )
@@ -156,7 +173,8 @@ def test_logcfg_routing(tmp_path, level, expected):
     with open(logcfg_file, "w") as f:
         f.write(cfg)
 
-    LoggingPipeline.call(logcfg=logcfg_file)
+    with pytest.warns(DeprecationWarning, match="'logcfg' configuration option"):
+        LoggingPipeline.call(logcfg=logcfg_file)
 
     with open(tmp_path / "myrun.log") as f:
         fulltext = "\n".join(list(f))
@@ -172,7 +190,7 @@ def test_log_records():
     pipeline = LoggingPipeline()
     pipeline.run()
 
-    for msg in ALL_MESSAGES:
+    for msg in ALL_MESSAGES_EXCEPT_DEBUG:
         assert msg in pipeline.log_records
 
 
@@ -185,27 +203,12 @@ def root_logger_unchanged():
     original_level = root_logger.level
     yield
     assert root_logger.level == original_level
-    for h in root_logger.handlers:
-        # these are added by pytest
-        if h.__class__.__name__ in ("LogCaptureHandler", "_LiveLoggingNullHandler"):
-            continue
-        if isinstance(h, logging.FileHandler) and h.baseFilename == "/dev/null":
-            continue
-        raise AssertionError(f"Unexpected handler {h} in root logger")
+    assert not stpipe_log.is_configured(
+        root_logger
+    ), "Unexpected handler in root logger"
 
 
-@pytest.mark.parametrize(
-    "logging_level",
-)
-@pytest.fixture(
-    params=(
-        logging.CRITICAL,
-        logging.ERROR,
-        logging.WARNING,
-        logging.INFO,
-        logging.DEBUG,
-    )
-)
+@pytest.fixture(params=LOGLEVELS)
 def log_cfg_path(request, tmp_path):
     config_level = logging.CRITICAL - request.param
     cfg = f"[*]\nlevel = {config_level}\nhandler = file:{tmp_path}/myrun.log, stderr"
@@ -219,26 +222,70 @@ def log_cfg_path(request, tmp_path):
 
 
 def test_call_no_root_logger_changes(log_cfg_path, root_logger_unchanged):
-    LoggingPipeline.call(logcfg=str(log_cfg_path))
+    with pytest.warns(DeprecationWarning, match="'logcfg' configuration option"):
+        LoggingPipeline.call(logcfg=str(log_cfg_path))
+
+
+def test_default_call(capsys, root_logger_unchanged):
+    LoggingPipeline.call()
+    capt = capsys.readouterr()
+    assert capt.out == ""
+    for msg in ALL_MESSAGES_EXCEPT_DEBUG:
+        assert msg in capt.err
+    for msg in ALL_DEBUG:
+        assert msg not in capt.err
+
+
+def test_default_cmdline(capsys, root_logger_unchanged):
+    LoggingPipeline.from_cmdline(["test_logger.LoggingPipeline"])
+    capt = capsys.readouterr()
+    assert capt.out == ""
+    for msg in ALL_MESSAGES_EXCEPT_DEBUG:
+        assert msg in capt.err
+    for msg in ALL_DEBUG:
+        assert msg not in capt.err
 
 
 def test_from_cmdline_no_root_logger_changes(log_cfg_path, root_logger_unchanged):
+    with pytest.warns(DeprecationWarning, match="logcfg configuration file"):
+        LoggingPipeline.from_cmdline(
+            ["test_logger.LoggingPipeline", f"--logcfg={log_cfg_path!s}"]
+        )
+
+
+@pytest.mark.parametrize("logging_level", LOGLEVELS)
+def test_from_cmdline_no_root_logger_changes_level_arg(
+    root_logger_unchanged, logging_level
+):
     LoggingPipeline.from_cmdline(
-        ["test_logger.LoggingPipeline", f"--logcfg={log_cfg_path!s}"]
+        ["test_logger.LoggingPipeline", f"--log_level={logging_level!s}"]
     )
 
 
 def test_step_from_cmdline_no_root_logger_changes(log_cfg_path, root_logger_unchanged):
+    with pytest.warns(DeprecationWarning, match="logcfg configuration file"):
+        stpipe.cmdline.step_from_cmdline(
+            ["test_logger.LoggingPipeline", "--logcfg", str(log_cfg_path)]
+        )
+
+
+@pytest.mark.parametrize("logging_level", LOGLEVELS)
+def test_step_from_cmdline_no_root_logger_changes_level_arg(
+    root_logger_unchanged, logging_level
+):
     stpipe.cmdline.step_from_cmdline(
-        ["test_logger.LoggingPipeline", "--logcfg", str(log_cfg_path)]
+        ["test_logger.LoggingPipeline", f"--log_level={logging_level!s}"]
     )
 
 
 def test_just_the_step_from_cmdline_no_root_logger_changes(
     log_cfg_path, root_logger_unchanged
 ):
+    # By default, no log configuration is applied or available in the
+    # parameters.  If apply_log_cfg is True, it *will* modify the
+    # root logger.
     stpipe.cmdline.just_the_step_from_cmdline(
-        ["test_logger.LoggingPipeline", "--logcfg", str(log_cfg_path)]
+        ["test_logger.LoggingPipeline"], apply_log_cfg=False
     )
 
 
@@ -271,3 +318,53 @@ def test_logging_delegation(capsys, root_logger_unchanged):
 
     captured = capsys.readouterr()
     assert MSG in captured.err
+
+
+@pytest.mark.parametrize(
+    "level, expected",
+    zip(LOGLEVELS, [[], [], ALL_WARNINGS, ALL_MESSAGES_EXCEPT_DEBUG, ALL_MESSAGES]),
+)
+def test_configure_logging_directly(capsys, root_logger_unchanged, level, expected):
+    root_logger = logging.getLogger()
+    root_level = root_logger.level
+
+    # Allow all messages through
+    root_logger.setLevel(logging.DEBUG)
+
+    # Set up a stream handler at the specified level
+    handler = logging.StreamHandler()
+    handler.setLevel(level)
+    root_logger.addHandler(handler)
+
+    # Root logger is now configured
+    assert stpipe_log.is_configured(root_logger)
+
+    try:
+        LoggingPipeline.call()
+
+        # Stdout should be empty
+        capt = capsys.readouterr()
+        assert capt.out == ""
+
+        # Check stderr for expected messages
+        for msg in ALL_MESSAGES:
+            if msg in expected:
+                # Make sure there's exactly one copy of the message
+                assert capt.err.count(msg) == 1
+            else:
+                assert msg not in capt.err
+    finally:
+        # Clean up the root logger
+        handler.flush()
+        handler.close()
+        root_logger.removeHandler(handler)
+        root_logger.setLevel(root_level)
+
+
+def test_call_configure_log(capsys, root_logger_unchanged):
+    LoggingPipeline.call(configure_log=False)
+
+    # Nothing is logged
+    capt = capsys.readouterr()
+    assert capt.out == ""
+    assert capt.err == ""


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Partially resolves [JP-1866](https://jira.stsci.edu/browse/JP-1866)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #244 
Closes #132 
Closes #185 
Closes #241 

<!-- describe the changes comprising this PR here -->
Deprecate usage of log configuration via `logcfg`.  Users should move to using command line arguments for setting the log level or filename, or configure logging directly in their Python code.

For the transition period, logcfg-style configuration is still available, but it will raise a DeprecationWarning if it is used from the command line, in `call` function arguments, or implicitly via "stpipe-log.cfg" files.

Default configuration for the command line or the call function is still to log INFO and higher messages to stderr.  It is not applied in the call function if handlers have already been added to the root logger, or if `configure_log=False` is passed in the call function keyword arguments.

Changes to downstream packages are not required before merge, but JWST unit and regression tests will fail due to the Deprecation Warning until a PR is merged to avoid using logcfg.  That PR will require the changes here to support new log configuration arguments, so it should be coordinated with this PR.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stpipe@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
