### PR TITLE
DOC: Fix ref in Step constructor

### DIFF
--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -390,23 +390,26 @@ class Step:
         **kws,
     ):
         """
-        Create a `Step` instance.
+        Create a `~stpipe.step.Step` instance.
 
         Parameters
         ----------
-        name : str, optional
+        name : str
             The name of the Step instance.  Used in logging messages
             and in cache filenames.  If not provided, one will be
             generated based on the class name.
 
-        parent : Step instance, optional
+        parent : `~stpipe.step.Step`
             The parent step of this step.  Used to determine a
             fully-qualified name for this step, and to determine
             the mode in which to run this step.
 
-        config_file : str or pathlib.Path, optional
+        config_file : str or pathlib.Path
             The path to the config file that this step was initialized
             with.  Use to determine relative path names of other config files.
+
+        _validate_kwds : bool
+            Validate given ``kws`` against specs/config.
 
         **kws : dict
             Additional parameters to set.  These will be set as member


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR aims to fix ref in Step constructor so it does not break when inherited by downstream API doc.

No need for change log but I cannot apply label here, please apply that label. Thanks.

No need for RT also.

Also see:

* https://github.com/spacetelescope/jwst/pull/9666
* https://github.com/spacetelescope/jwst/pull/9687
* https://github.com/spacetelescope/stpipe/issues/253

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stpipe@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
