### PR TITLE
consistent `pre-commit` config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ ci:
 exclude: ".*\\.asdf$"
 
 repos:
+  # basic checks
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:
@@ -11,41 +12,66 @@ repos:
       - id: check-ast
       - id: check-case-conflict
       - id: check-yaml
-        args: ["--unsafe"]
+        args:
+          - --unsafe
       - id: check-toml
       - id: check-merge-conflict
       - id: check-symlinks
-      - id: debug-statements
-        exclude: "src/stpipe/cmdline.py"
+      # - id: debug-statements
       - id: detect-private-key
       - id: end-of-file-fixer
       - id: trailing-whitespace
-
+  # simple text searches for common issues
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
     hooks:
-      - id: python-check-blanket-noqa
-      - id: python-check-mock-methods
       - id: rst-directive-colons
       - id: rst-inline-touching-normal
       - id: text-unicode-replacement-char
-
+  # lint and format
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.9
+    hooks:
+      - id: ruff-check
+        args:
+          - --fix
+          - --show-fixes
+      # - id: ruff-format
+  # # type checking
+  # - repo: https://github.com/pre-commit/mirrors-mypy
+  #   rev: v1.17.0
+  #   hooks:
+  #     - id: mypy
+  # spell-checking
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.1
     hooks:
       - id: codespell
-        args: ["--write-changes"]
+        args:
+          - --write-changes
+          - --summary
         additional_dependencies:
           - tomli
-
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.12.9"
+  # validate change log and fragments in `changes/`
+  - repo: https://github.com/twisted/towncrier
+    rev: 24.8.0
     hooks:
-      - id: ruff
-        args: ["--fix", "--show-fixes"]
-        exclude: "scripts/strun"
-
-  - repo: https://github.com/psf/black
-    rev: 25.1.0
-    hooks:
-      - id: black
+      - id: towncrier-check
+  # # format YAML and Markdown
+  # - repo: https://github.com/rbubley/mirrors-prettier
+  #   rev: v3.6.2
+  #   hooks:
+  #     - id: prettier
+  #       types_or:
+  #         - yaml
+  #         - markdown
+  # # format TOML
+  # - repo: https://github.com/ComPWA/taplo-pre-commit
+  #   rev: v0.9.3
+  #   hooks:
+  #     - id: taplo-format
+  # # validate numpy-style docstrings
+  # - repo: https://github.com/numpy/numpydoc
+  #   rev: v1.9.0
+  #   hooks:
+  #     - id: numpydoc-validation

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
       - id: text-unicode-replacement-char
   # lint and format
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.9
+    rev: v0.12.10
     hooks:
       - id: ruff-check
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
         args:
           - --fix
           - --show-fixes
-      # - id: ruff-format
+      - id: ruff-format
   # # type checking
   # - repo: https://github.com/pre-commit/mirrors-mypy
   #   rev: v1.17.0

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -563,7 +563,7 @@ class Step:
                             setattr(model.meta.cal_step, self.class_alias, "SKIPPED")
                         except AttributeError as e:
                             self.log.info(
-                                "Could not record skip into DataModel " "header: %s",
+                                "Could not record skip into DataModel header: %s",
                                 e,
                             )
 

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -485,7 +485,6 @@ def test_save_list(tmp_cwd, model_list):
 
 
 class SimpleContainer(Sequence):
-
     def __init__(self, models):
         self._models = models
 
@@ -512,7 +511,6 @@ class SimpleContainer(Sequence):
 
 
 class SimpleContainerWithSave(SimpleContainer):
-
     def save(self, path, dir_path=None, *args, **kwargs):
         for model in self._models[1:]:
             # skip the first model to test that the save method is called


### PR DESCRIPTION
uses a common `.pre-commit-config.yaml` with other repositories in pipeline dependencies

As of the creation of this PR, checks that would change any files are commented out.

<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stpipe@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
