### PR TITLE
Remove import level warning capture in log configuration

### DIFF
--- a/changes/270.bugfix.rst
+++ b/changes/270.bugfix.rst
@@ -1,0 +1,1 @@
+Remove ``logging.captureWarnings`` setting from the ``stpipe.log`` module.

--- a/src/stpipe/log.py
+++ b/src/stpipe/log.py
@@ -337,6 +337,3 @@ def record_logs(log_names, level=logging.NOTSET, formatter=None):
             for log_name in log_names:
                 logger = logging.getLogger(log_name)
                 logger.removeHandler(handler)
-
-
-logging.captureWarnings(True)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Partially resolves [JP-4138](https://jira.stsci.edu/browse/JP-4138)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #269 

<!-- describe the changes comprising this PR here -->
The `stpipe.log` module currently contains an import-level setting to capture warning messages and direct them to the logging system.  If the `py.warnings` log is not configured, this will hide warning messages from the user.  This PR removes this import level behavior.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stpipe@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
