### PR TITLE
JP-3926: output_dir should be created before the pipeline is run

### DIFF
--- a/changes/289.bugfix.rst
+++ b/changes/289.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug where output_dir crashes pipeline if given directory does not exist. Now, the directory would be created silently instead.

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -1217,7 +1217,7 @@ class Step:
 
         output_dir = step.search_attr("output_dir", default="")
         output_dir = expandvars(expanduser(output_dir))
-        os.makedirs(outpath_dir, exist_ok=True)
+        os.makedirs(output_dir, exist_ok=True)
         return join(output_dir, basename)
 
     @classmethod

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -1157,7 +1157,8 @@ class Step:
 
         Returns
         -------
-        The fully qualified path name.
+        outpath : str
+            The fully qualified path name.
 
         Notes
         -----
@@ -1216,7 +1217,9 @@ class Step:
 
         output_dir = step.search_attr("output_dir", default="")
         output_dir = expandvars(expanduser(output_dir))
-        return join(output_dir, basename)
+        outpath = join(output_dir, basename)
+        os.makedirs(outpath, exist_ok=True)
+        return outpath
 
     @classmethod
     def _datamodels_open(cls, init, **kwargs):

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -1157,7 +1157,7 @@ class Step:
 
         Returns
         -------
-        outpath : str
+        str
             The fully qualified path name.
 
         Notes
@@ -1217,9 +1217,8 @@ class Step:
 
         output_dir = step.search_attr("output_dir", default="")
         output_dir = expandvars(expanduser(output_dir))
-        outpath = join(output_dir, basename)
-        os.makedirs(outpath, exist_ok=True)
-        return outpath
+        os.makedirs(outpath_dir, exist_ok=True)
+        return join(output_dir, basename)
 
     @classmethod
     def _datamodels_open(cls, init, **kwargs):

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -1217,7 +1217,8 @@ class Step:
 
         output_dir = step.search_attr("output_dir", default="")
         output_dir = expandvars(expanduser(output_dir))
-        os.makedirs(output_dir, exist_ok=True)
+        if output_dir:
+            os.makedirs(output_dir, exist_ok=True)
         return join(output_dir, basename)
 
     @classmethod

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -3,7 +3,6 @@
 import copy
 import os
 import re
-import sys
 from collections.abc import Sequence
 from contextlib import nullcontext
 from pathlib import Path
@@ -458,19 +457,10 @@ class SimpleDataModel(AbstractDataModel):
         return None
 
     def _stdm_save(self, path, dir_path=None, *args, **kwargs):
-        """Adapted from stdatamodels/model_base.py"""
-        path_head, path_tail = os.path.split(os.path.join(path, "test-saved.txt"))
-        ext = Path(path_tail).suffix
-        if isinstance(ext, bytes):
-            ext = ext.decode(sys.getfilesystemencoding())
-
-        if dir_path:
-            path_head = dir_path
-        output_path = os.path.join(path_head, path_tail)  # noqa: PTH118
-
+        """Adapted from stdatamodels/model_base.py but very simplified"""
+        output_path = os.path.join(path, "test-saved.txt")
         with open(output_path, "w") as f:
             f.write(f"{output_path}\n")
-
         return output_path
 
 
@@ -491,7 +481,7 @@ def test_save_with_output_dir(tmp_cwd):
     step = StepWithModel()
     step.output_dir = str(outpath)
     step.run(model)
-    assert (outpath / "test-saved.txt").exists()
+    assert (outpath / "foo_stepwithmodel.simplestep" / "test-saved.txt").exists()
 
 
 def test_skip():


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-3926](https://jira.stsci.edu/browse/JP-3926)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR addresses https://github.com/spacetelescope/jwst/issues/2763

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [x] run regression tests with this branch installed (`stpipe@git+https://github.com/pllim/stpipe.git@cli-outdir`)
    - [x] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) https://github.com/spacetelescope/RegressionTests/actions/runs/21044012706
    - [x] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) https://github.com/spacetelescope/RegressionTests/actions/runs/21044032322

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
