### PR TITLE
DOC: Fix autodirective warning

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -82,6 +82,8 @@ html_use_index = True
 nitpicky = True
 nitpick_ignore = []
 
+suppress_warnings = ["app.add_directive"]
+
 # Set the default role for all single backtick annotations
 default_role = "obj"
 


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- describe the changes comprising this PR here -->
This PR addresses failing RTD build, probably caused by Sphinx 9. We will just ignore the new warning. No need for change log nor RT. 

`WARNING: directive 'autoattribute' is already registered and will not be overridden [app.add_directive]`

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stpipe@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
