### PR TITLE
DOC: Move changelog instructions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,16 +14,7 @@ This PR addresses ...
 - [ ] update or add relevant tests
 - [ ] update relevant docstrings and / or `docs/` page
 - [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
-  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
+  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stpipe/blob/main/changes/README.rst) for instructions)
   - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stpipe@<branch>"`)
     - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
     - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
-
-<details><summary>news fragment change types...</summary>
-
-- ``changes/<PR#>.feature.rst``: new feature
-- ``changes/<PR#>.bugfix.rst``: fixes an issue
-- ``changes/<PR#>.doc.rst``: documentation change
-- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
-- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
-</details>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,6 +15,6 @@ This PR addresses ...
 - [ ] update relevant docstrings and / or `docs/` page
 - [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
   - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stpipe/blob/main/changes/README.rst) for instructions)
-  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stpipe@<branch>"`)
+  - [ ] run regression tests with this branch installed (`stpipe@git+https://github.com/<fork>/stpipe.git@<branch>`)
     - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
     - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

--- a/changes/README.rst
+++ b/changes/README.rst
@@ -1,0 +1,16 @@
+Writing news fragments for the change log
+#########################################
+
+This ``changes/`` directory contains "news fragments": small reStructuredText (`.rst`) files describing a change in a few sentences.
+When making a release, run ``towncrier build --version <VERSION>`` to consume existing fragments in ``changes/`` and insert them as a full change log entry at the top of ``CHANGES.rst`` for the released version.
+
+News fragment filenames consist of the pull request number and the change log category (see below). A single change can have more than one news fragment.
+
+Change log categories
+*********************
+
+- ``<PR#>.feature.rst``: new feature
+- ``<PR#>.bugfix.rst``: fixes an issue
+- ``<PR#>.doc.rst``: documentation change
+- ``<PR#>.removal.rst``: deprecation or removal of public API
+- ``<PR#>.misc.rst``: infrastructure or miscellaneous change


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- describe the changes comprising this PR here -->
This PR moves change log instructions to dedicated readme like `jwst`. It is currently a little too hidden and clutters the PR template.

No need for change log (please help me apply label) nor RT.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see below for change types)
  - [ ] run regression tests with this branch installed (`"git+https://github.com/<fork>/stpipe@<branch>"`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)

<details><summary>news fragment change types...</summary>

- ``changes/<PR#>.feature.rst``: new feature
- ``changes/<PR#>.bugfix.rst``: fixes an issue
- ``changes/<PR#>.doc.rst``: documentation change
- ``changes/<PR#>.removal.rst``: deprecation or removal of public API
- ``changes/<PR#>.misc.rst``: infrastructure or miscellaneous change
</details>
