### PR TITLE
TST: Fix spec documenter for sphinx 9

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,12 +6,18 @@
 version: 2
 
 build:
-  os: "ubuntu-22.04"
+  os: ubuntu-24.04
   tools:
-    python: "mambaforge-4.10"
+    python: mambaforge-latest
   jobs:
+    post_checkout:
+      - git fetch --unshallow || true
+      - git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*' || true
+      - git fetch --all --tags || true
+    pre_install:
+      - git update-index --assume-unchanged docs/rtd_environment.yaml docs/source/conf.py
     post_install:
-      - towncrier build --keep
+      - git describe --exact-match || towncrier build --keep
 
 conda:
   environment: docs/rtd_environment.yaml

--- a/docs/rtd_environment.yaml
+++ b/docs/rtd_environment.yaml
@@ -1,8 +1,7 @@
-name: rtd311
 channels:
   - conda-forge
 dependencies:
-  - python=3.11
+  - python=3.13
   - pip
   - graphviz
   - towncrier

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,7 +38,10 @@ class StepSpecDocumenter(AttributeDocumenter):
 
 def setup(app):
     # add a custom AttributeDocumenter subclass to handle Step.spec formatting
-    app.add_autodocumenter(StepSpecDocumenter, True)
+    def register_documenter(app, config):
+        app.add_autodocumenter(StepSpecDocumenter, True)
+    # register it with a high priority so it behaves with the built-in autodoc
+    app.connect("config-inited", register_documenter, priority=9000)
 
 
 REPO_ROOT = Path(__file__).parent.parent.parent
@@ -59,6 +62,7 @@ version = package.__version__.split("-", 1)[0]
 release = package.__version__
 
 extensions = [
+    "sphinx.ext.autodoc",
     "sphinx_automodapi.automodapi",
     "numpydoc",
     "sphinx.ext.intersphinx",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dynamic = [
 [project.optional-dependencies]
 docs = [
     "numpydoc",
-    "sphinx<9", # pin until spec formatter is updated for Sphinx 9 https://github.com/spacetelescope/jwst/issues/10151
+    "sphinx",
     "sphinx-automodapi",
     "sphinx-rtd-theme",
     "tomli; python_version <\"3.11\"",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dynamic = [
 [project.optional-dependencies]
 docs = [
     "numpydoc",
-    "sphinx",
+    "sphinx<9", # pin until spec formatter is updated for Sphinx 9 https://github.com/spacetelescope/jwst/issues/10151
     "sphinx-automodapi",
     "sphinx-rtd-theme",
     "tomli; python_version <\"3.11\"",


### PR DESCRIPTION
docs built with sphinx 9: https://app.readthedocs.org/projects/stpipe/builds/31107211/#302979907--1

step spec renders as expected: https://stpipe--295.org.readthedocs.build/en/295/api/stpipe.Step.html#stpipe.Step.spec

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stpipe/blob/main/changes/README.rst) for instructions)
  - [ ] run regression tests with this branch installed (`stpipe@git+https://github.com/<fork>/stpipe.git@<branch>`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
