### PR TITLE
Fix bad exptype getattr in _model_to_exptype

### DIFF
--- a/src/stpipe/library.py
+++ b/src/stpipe/library.py
@@ -801,7 +801,9 @@ class AbstractModelLibrary(abc.ABC):
         exptype : str
             Exposure type (for example "SCIENCE").
         """
-        return getattr(model.meta, "exptype", "SCIENCE")
+        if getattr(model.meta, "exptype", None) is None:
+            return "SCIENCE"
+        return model.meta.exptype
 
     @property
     @abc.abstractmethod


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Relates to [JP-4228](https://jira.stsci.edu/browse/JP-4228)

<!-- describe the changes comprising this PR here -->
This PR addresses a usage of `getattr` that will stop working as expected for jwst datamodels if we move forward with https://github.com/spacetelescope/stdatamodels/pull/662.  The intention of the line is to set the exptype to "SCIENCE" if not found.  For jwst datamodels, this `getattr` call will never raise an `AttributeError` (neither on main nor the PR branch) so the fallback default value is never hit.

On main, if `model.meta.exptype` is not defined, `exptype` gets set here to its schema-defined default of "science".  On the PR branch though, `exptype` will get set to `None` and break downstream usages.

This PR allows the method to work as intended for both main and PR branches.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stpipe/blob/main/changes/README.rst) for instructions)
  - [ ] run regression tests with this branch installed (`stpipe@git+https://github.com/<fork>/stpipe.git@<branch>`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
