### PR TITLE
Check for N/A in override reference files

### DIFF
--- a/changes/301.bugfix.rst
+++ b/changes/301.bugfix.rst
@@ -1,0 +1,1 @@
+Check for the special value "N/A" for override reference files and store it as is. Any other non-empty string is recorded as an absolute path.

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -868,19 +868,29 @@ class Step:
         """
         override = self.get_ref_override(reference_file_type)
         if override is not None:
+            # Store a representative string for datamodels, then
+            # return the model without checking it.
             if isinstance(override, AbstractDataModel):
                 self._reference_files_used.append(
                     (reference_file_type, override.override_handle)
                 )
                 return override
 
-            if override.strip() != "":
+            # Return an empty string without storing or checking it.
+            if override.strip() == "":
+                return ""
+
+            # For either "N/A" or a file name, store the value and then
+            # check that it is a valid reference.
+            if override.strip() == "N/A":
+                # Special value: store it as is.
+                self._reference_files_used.append((reference_file_type, "N/A"))
+            else:
+                # Record the full path to the override file.
                 self._reference_files_used.append(
                     (reference_file_type, abspath(override))
                 )
-                reference_name = override
-            else:
-                return ""
+            reference_name = override
         else:
             parameters, observatory = self._get_crds_parameters(input_file)
             reference_name = crds_client.get_reference_file(

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -661,6 +661,7 @@ def test_get_config_from_reference_dict(monkeypatch, klass, observatory, error):
 
 @pytest.mark.parametrize("klass", (SimpleStep, SimplePipe, PipeWithPipe))
 def test_ref_file_override(klass, tmp_path):
+    """Test that override paths are stored as absolute paths."""
     override_path = tmp_path / "ref.asdf"
     override_path.touch()
     step = SimpleStep()
@@ -668,6 +669,28 @@ def test_ref_file_override(klass, tmp_path):
     ref_path = step.get_reference_file("foo.asdf", "dark")
     assert ref_path == str(override_path)
     assert ("dark", ref_path) in step._reference_files_used
+
+
+@pytest.mark.parametrize("klass", (SimpleStep, SimplePipe, PipeWithPipe))
+def test_ref_file_override_na(klass):
+    """Test that the special override value N/A is stored as is."""
+    override_path = "N/A"
+    step = SimpleStep()
+    step.override_dark = override_path
+    ref_path = step.get_reference_file("foo.asdf", "dark")
+    assert ref_path == override_path
+    assert ("dark", ref_path) in step._reference_files_used
+
+
+@pytest.mark.parametrize("klass", (SimpleStep, SimplePipe, PipeWithPipe))
+def test_ref_file_override_empty(klass):
+    """Test that an empty string passed as an override is not stored."""
+    override_path = ""
+    step = SimpleStep()
+    step.override_dark = override_path
+    ref_path = step.get_reference_file("foo.asdf", "dark")
+    assert ref_path == override_path
+    assert ("dark", ref_path) not in step._reference_files_used
 
 
 def test_get_stpipe_loggers():


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #299

<!-- describe the changes comprising this PR here -->
Check for the special value "N/A" before recording override reference files.  "N/A" should be stored as is; any other non-empty string should be recorded as an absolute path.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stpipe/blob/main/changes/README.rst) for instructions)
  - [x] run regression tests with this branch installed (`stpipe@git+https://github.com/<fork>/stpipe.git@<branch>`)
    - [x] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [x] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
