### PR TITLE
JP-4129: Capture pre-pipeline CRDS checks in ASDF log

### DIFF
--- a/changes/304.bugfix.rst
+++ b/changes/304.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed some step log messages not getting saved to output model logs.

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -76,6 +76,8 @@ class Step:
     # log_records to be saved.
     _log_records_formatter = None
 
+    _prerun_logs = []
+
     @classmethod
     def get_config_reftype(cls):
         """
@@ -128,6 +130,7 @@ class Step:
         name : str, optional
             If provided, use that name for the returned instance.
             If not provided, the following are tried (in order):
+
             - The ``name`` parameter in the config file
             - The filename of the config file
             - The name of returned class
@@ -172,7 +175,7 @@ class Step:
         Parameters
         ----------
         args : list of str
-            Commandline arguments
+            Command line arguments
 
         Returns
         -------
@@ -239,15 +242,19 @@ class Step:
         config : configobj.Section instance
             The config file fragment containing parameters for this
             step only.
+
         parent : Step instance, optional
             The parent step of this step.  Used to determine a
             fully-qualified name for this step, and to determine
             the mode in which to run this step.
+
         name : str, optional
             If provided, use that name for the returned instance.
             If not provided, try the following (in order):
+
             - The ``name`` parameter in the config file fragment
             - The name of returned class
+
         config_file : str or pathlib.Path, optional
             The path to the config file that created this step, if
             any.  This is used to resolve relative file name
@@ -442,10 +449,7 @@ class Step:
         self._log = logging.getLogger(self.qualified_name)
 
         # Log the fact that we have been init-ed.
-        logger.info(
-            "%s instance created.",
-            self.__class__.__name__,
-        )
+        type(self)._prerun_logs.append((logging.INFO, f"{self.__class__.__name__} instance created."))
 
         # Store the config file path so config filenames can be resolved
         # against it.
@@ -496,6 +500,10 @@ class Step:
             self._log_records = log_records
 
             step_result = None
+
+            for loglevel, logmsg in self._prerun_logs:
+                logger.log(loglevel, logmsg)
+            type(self)._prerun_logs = []
 
             logger.info("Step %s running with args %s.", self.name, args)
             # log Step or Pipeline parameters from top level only
@@ -931,6 +939,7 @@ class Step:
         """
 
         reftype = cls.get_config_reftype()
+        reftype_upper = reftype.upper()
 
         if isinstance(dataset, dict):
             # crds_parameters was passed as input from pipeline.py
@@ -943,20 +952,18 @@ class Step:
             try:
                 crds_parameters, crds_observatory = cls._get_crds_parameters(dataset)
             except (OSError, TypeError, ValueError):
-                logger.warning("Input dataset is not an instance of AbstractDataModel.")
+                cls._prerun_logs.append((logging.WARNING, "Input dataset is not an instance of AbstractDataModel."))
                 disable = True
 
         # Check if retrieval should be attempted.
         if disable is None:
             disable = get_disable_crds_steppars()
         if disable:
-            logger.info(
-                "%s: CRDS parameter reference retrieval disabled.", reftype.upper()
-            )
+            cls._prerun_logs.append((logging.INFO, f"{reftype_upper}: CRDS parameter reference retrieval disabled."))
             return config_parser.ConfigObj()
 
         # Retrieve step parameters from CRDS
-        logger.debug("Retrieving step %s parameters from CRDS", reftype.upper())
+        cls._prerun_logs.append((logging.DEBUG, f"Retrieving step {reftype_upper} parameters from CRDS"))
         try:
             ref_file = crds_client.get_reference_file(
                 crds_parameters,
@@ -964,22 +971,20 @@ class Step:
                 crds_observatory,
             )
         except (AttributeError, crds_client.CrdsError):
-            logger.debug("%s: No parameters found", reftype.upper())
+            cls._prerun_logs.append((logging.DEBUG, f"{reftype_upper}: No parameters found"))
             return config_parser.ConfigObj()
         if ref_file != "N/A":
-            logger.info("%s parameters found: %s", reftype.upper(), ref_file)
+            cls._prerun_logs.append((logging.INFO, f"{reftype_upper} parameters found: {ref_file}"))
             ref = config_parser.load_config_file(ref_file)
 
             ref_pars = {
                 par: value for par, value in ref.items() if par not in ["class", "name"]
             }
-            logger.debug(
-                "%s parameters retrieved from CRDS: %s", reftype.upper(), ref_pars
-            )
+            cls._prerun_logs.append((logging.DEBUG, f"{reftype_upper} parameters retrieved from CRDS: {ref_pars}"))
 
             return ref
 
-        logger.debug("No %s reference files found.", reftype.upper())
+        cls._prerun_logs.append((logging.DEBUG, f"No {reftype_upper} reference files found."))
         return config_parser.ConfigObj()
 
     @staticmethod
@@ -1007,7 +1012,7 @@ class Step:
         # )
         # warnings.warn(msg, DeprecationWarning, stacklevel=2)
 
-        return ("root",)
+        return ("root", )
 
     def set_primary_input(self, obj, exclusive=True):
         """
@@ -1026,6 +1031,7 @@ class Step:
         """
         self._set_input_dir(obj, exclusive=exclusive)
 
+        # NOTE: This method is called from self.run() so logger is captured normally.
         err_message = f"Cannot set master input file name from object {obj}"
         parent_input_filename = self.search_attr("_input_filename")
         if not exclusive or parent_input_filename is None:
@@ -1127,6 +1133,7 @@ class Step:
                     **components,
                 )
             )
+            # NOTE: This method is called from self.run() so logger is captured normally.
             logger.info("Saved model in %s", output_path)
 
         return output_path
@@ -1398,6 +1405,7 @@ class Step:
                     for step_name, step_parameters in value.items():
                         getattr(self, step_name).update_pars(step_parameters)
             else:
+                # NOTE: This is called from utility function, so no need for cls._prerun_logs
                 logger.debug(
                     "Parameter %s is not valid for step %s. Ignoring.", parameter, self
                 )

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -1158,7 +1158,8 @@ class Step:
                     **components,
                 )
             )
-            # NOTE: This method is called from self.run() so logger is captured normally.
+            # NOTE: This method is called from self.run()
+            #       so logger is captured normally.
             logger.info("Saved model in %s", output_path)
 
         return output_path
@@ -1430,7 +1431,8 @@ class Step:
                     for step_name, step_parameters in value.items():
                         getattr(self, step_name).update_pars(step_parameters)
             else:
-                # NOTE: This is called from utility function, so no need for cls._prerun_logs
+                # NOTE: This is called from utility function,
+                #       so no need for cls._prerun_logs
                 logger.debug(
                     "Parameter %s is not valid for step %s. Ignoring.", parameter, self
                 )

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -449,7 +449,9 @@ class Step:
         self._log = logging.getLogger(self.qualified_name)
 
         # Log the fact that we have been init-ed.
-        type(self)._prerun_logs.append((logging.INFO, f"{self.__class__.__name__} instance created."))
+        type(self)._prerun_logs.append(
+            (logging.INFO, f"{self.__class__.__name__} instance created.")
+        )
 
         # Store the config file path so config filenames can be resolved
         # against it.
@@ -952,18 +954,30 @@ class Step:
             try:
                 crds_parameters, crds_observatory = cls._get_crds_parameters(dataset)
             except (OSError, TypeError, ValueError):
-                cls._prerun_logs.append((logging.WARNING, "Input dataset is not an instance of AbstractDataModel."))
+                cls._prerun_logs.append(
+                    (
+                        logging.WARNING,
+                        "Input dataset is not an instance of AbstractDataModel.",
+                    )
+                )
                 disable = True
 
         # Check if retrieval should be attempted.
         if disable is None:
             disable = get_disable_crds_steppars()
         if disable:
-            cls._prerun_logs.append((logging.INFO, f"{reftype_upper}: CRDS parameter reference retrieval disabled."))
+            cls._prerun_logs.append(
+                (
+                    logging.INFO,
+                    f"{reftype_upper}: CRDS parameter reference retrieval disabled.",
+                )
+            )
             return config_parser.ConfigObj()
 
         # Retrieve step parameters from CRDS
-        cls._prerun_logs.append((logging.DEBUG, f"Retrieving step {reftype_upper} parameters from CRDS"))
+        cls._prerun_logs.append(
+            (logging.DEBUG, f"Retrieving step {reftype_upper} parameters from CRDS")
+        )
         try:
             ref_file = crds_client.get_reference_file(
                 crds_parameters,
@@ -971,20 +985,31 @@ class Step:
                 crds_observatory,
             )
         except (AttributeError, crds_client.CrdsError):
-            cls._prerun_logs.append((logging.DEBUG, f"{reftype_upper}: No parameters found"))
+            cls._prerun_logs.append(
+                (logging.DEBUG, f"{reftype_upper}: No parameters found")
+            )
             return config_parser.ConfigObj()
         if ref_file != "N/A":
-            cls._prerun_logs.append((logging.INFO, f"{reftype_upper} parameters found: {ref_file}"))
+            cls._prerun_logs.append(
+                (logging.INFO, f"{reftype_upper} parameters found: {ref_file}")
+            )
             ref = config_parser.load_config_file(ref_file)
 
             ref_pars = {
                 par: value for par, value in ref.items() if par not in ["class", "name"]
             }
-            cls._prerun_logs.append((logging.DEBUG, f"{reftype_upper} parameters retrieved from CRDS: {ref_pars}"))
+            cls._prerun_logs.append(
+                (
+                    logging.DEBUG,
+                    f"{reftype_upper} parameters retrieved from CRDS: {ref_pars}",
+                )
+            )
 
             return ref
 
-        cls._prerun_logs.append((logging.DEBUG, f"No {reftype_upper} reference files found."))
+        cls._prerun_logs.append(
+            (logging.DEBUG, f"No {reftype_upper} reference files found.")
+        )
         return config_parser.ConfigObj()
 
     @staticmethod
@@ -1012,7 +1037,7 @@ class Step:
         # )
         # warnings.warn(msg, DeprecationWarning, stacklevel=2)
 
-        return ("root", )
+        return ("root",)
 
     def set_primary_input(self, obj, exclusive=True):
         """


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-4129](https://jira.stsci.edu/browse/JP-4129)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
This PR addresses https://github.com/spacetelescope/jwst/issues/9864

Close #309

Close https://github.com/spacetelescope/jwst/pull/10437

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stpipe/blob/main/changes/README.rst) for instructions)
  - [x] run regression tests with this branch installed (`stpipe@git+https://github.com/pllim/stpipe.git@log-all-the-things`)
    - [x] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml) https://github.com/spacetelescope/RegressionTests/actions/runs/23520602776 (passed)
    - [x] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml) https://github.com/spacetelescope/RegressionTests/actions/runs/23520609993 (passed)
