### PR TITLE
allow uris for member expnames

### DIFF
--- a/changes/305.feature.rst
+++ b/changes/305.feature.rst
@@ -1,0 +1,1 @@
+Support URIs in member expnames in ModelLibrary.

--- a/src/stpipe/library.py
+++ b/src/stpipe/library.py
@@ -7,6 +7,7 @@ import warnings
 from collections.abc import Iterable, MutableMapping
 from pathlib import Path
 from types import MappingProxyType
+from urllib.parse import urlparse
 
 import asdf
 
@@ -279,8 +280,9 @@ class AbstractModelLibrary(abc.ABC):
 
         for index, member in enumerate(self._members):
             if "group_id" not in member:
-                filename = os.path.join(self._asn_dir, member["expname"])
-                member["group_id"] = self._to_group_id(filename, index)
+                member["group_id"] = self._to_group_id(
+                    self._member_to_filename(member), index
+                )
 
         if not on_disk:
             # if models were provided as input, assign the members here
@@ -548,6 +550,27 @@ class AbstractModelLibrary(abc.ABC):
         if "asn_pool" in self.asn:
             model.meta.asn["pool_name"] = self.asn["asn_pool"]
 
+    def _member_to_filename(self, member):
+        """
+        Resolve a filename for the provided member.
+
+        Parameters
+        ----------
+        member : dict
+            Member definition (likely from an association).
+
+        Returns
+        -------
+        filename : str
+            Filename for the provided member.
+        """
+        member_filename = member["expname"]
+        if self._asn_dir is None:
+            return member_filename
+        if urlparse(member_filename).scheme:
+            return member_filename
+        return os.path.join(self._asn_dir, member["expname"])
+
     def _load_member(self, index):
         """
         Load a model for the association member at the provided index.
@@ -565,7 +588,7 @@ class AbstractModelLibrary(abc.ABC):
         model : DataModel
         """
         member = self._members[index]
-        filename = os.path.join(self._asn_dir, member["expname"])
+        filename = self._member_to_filename(member)
 
         model = self._datamodels_open(filename, **self._datamodels_open_kwargs)
 

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -23,6 +23,7 @@ _N_MODELS = len(_GROUP_IDS)
 _N_GROUPS = len(set(_GROUP_IDS))
 _PRODUCT_NAME = "foo_out"
 _INIT_TYPES = ("filename", "asn", "models")
+_TEST_URI_SCHEME = "file://"
 
 
 def _load_asn(filename):
@@ -84,6 +85,14 @@ class ModelLibrary(AbstractModelLibrary):
         raise NoGroupID(f"{model} missing group_id")
 
 
+class URIModelLibrary(ModelLibrary):
+    def _datamodels_open(self, filename, **kwargs):
+        return super()._datamodels_open(filename.removeprefix(_TEST_URI_SCHEME))
+
+    def _filename_to_group_id(self, filename):
+        return super()._filename_to_group_id(filename.removeprefix(_TEST_URI_SCHEME))
+
+
 def _library_to_models(library):
     """
     A few tests are easier to understand and write when
@@ -142,6 +151,17 @@ def example_asn_path(example_models, tmp_path):
     }
     asn_filename = tmp_path / (asn["asn_id"] + ".json")
     _write_asn(asn, asn_filename)
+    return asn_filename
+
+
+@pytest.fixture
+def example_uri_asn_path(example_asn_path):
+    asn_dir = example_asn_path.parent
+    asn_data = _load_asn(example_asn_path)
+    for member in asn_data["products"][0]["members"]:
+        member["expname"] = _TEST_URI_SCHEME + str(asn_dir / member["expname"])
+    asn_filename = asn_dir / "uri_asn.json"
+    _write_asn(asn_data, asn_filename)
     return asn_filename
 
 
@@ -801,3 +821,16 @@ def test_get_filename(table_name, filename):
     if table_name != "MISSING":
         lib._asn["table_name"] = table_name
     assert Step._get_filename(lib) == filename
+
+
+@pytest.mark.parametrize("loaded", [False, True])
+def test_uri_member_paths(example_uri_asn_path, loaded):
+    if loaded:
+        asn = _load_asn(example_uri_asn_path)
+    else:
+        asn = example_uri_asn_path
+    lib = URIModelLibrary(asn)
+    with lib:
+        for i, model in enumerate(lib):
+            assert model
+            lib.shelve(model, i, modify=False)


### PR DESCRIPTION
Add support for URIs in member expnames for ModelLibrary.

Although this doesn't close https://github.com/spacetelescope/romancal/issues/2238 (that ticket is being rescoped) it allows romancal to process associations with S3 URIs, silently accessing the remote files for the user.

Regtests all pass:
- roman: https://github.com/spacetelescope/RegressionTests/actions/runs/23542178125
- jwst: https://github.com/spacetelescope/RegressionTests/actions/runs/23542186937

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stpipe/blob/main/changes/README.rst) for instructions)
  - [ ] run regression tests with this branch installed (`stpipe@git+https://github.com/<fork>/stpipe.git@<branch>`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
