### PR TITLE
JP-4129: Capture pre-pipeline CRDS checks in ASDF log (try 2)

### DIFF
--- a/changes/309.bugfix.rst
+++ b/changes/309.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed some step log messages not getting saved to output model logs.

--- a/src/stpipe/cmdline.py
+++ b/src/stpipe/cmdline.py
@@ -441,7 +441,6 @@ def step_from_cmdline(args, cls=None):
         The step class to use.  If none is provided, the step is inferred
         from the input arguments.
 
-
     Returns
     -------
     step : Step instance
@@ -466,7 +465,16 @@ def step_from_cmdline(args, cls=None):
         raise e
 
     try:
-        step.run(*positional)
+        with log.record_logs(
+            log_names=step_class.get_stpipe_loggers(),
+            formatter=step_class._log_records_formatter,
+        ) as log_records:
+            step, step_class, positional, debug_on_exception = (
+                just_the_step_from_cmdline(args, cls, apply_log_cfg=True)
+            )
+            step._external_log_context = log_records
+            step.run(*positional)
+            step._external_log_context = None
     except Exception as e:
         _print_important_message(f"ERROR RUNNING STEP {step_class.__name__!r}:", str(e))
 

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -487,7 +487,7 @@ class Step:
         """
         return self._log_records
 
-    def run(self, *args):
+    def run(self, *args, _external_log_context=None):
         """
         Run handles the generic setup and teardown that happens with
         the running of each step.  The real work that is unique to
@@ -495,10 +495,19 @@ class Step:
         """
         gc.collect()
 
-        with log.record_logs(
-            log_names=self.get_stpipe_loggers(), formatter=self._log_records_formatter
-        ) as log_records:
-            self._log_records = log_records
+        if _external_log_context is not None:
+            ctx = nullcontext()
+        else:
+            ctx = log.record_logs(
+                log_names=self.get_stpipe_loggers(),
+                formatter=self._log_records_formatter,
+            )
+
+        with ctx as log_records:
+            if _external_log_context is not None:
+                self._log_records = _external_log_context
+            else:
+                self._log_records = log_records
 
             step_result = None
 
@@ -537,7 +546,9 @@ class Step:
 
             hook_args = args
             for pre_hook in self._pre_hooks:
-                hook_results = pre_hook.run(*hook_args)
+                hook_results = pre_hook.run(
+                    *hook_args, _external_log_context=_external_log_context
+                )
                 if hook_results is not None:
                     hook_args = (hook_results,)
             args = hook_args
@@ -578,7 +589,9 @@ class Step:
 
             # Run the post hooks
             for post_hook in self._post_hooks:
-                hook_results = post_hook.run(step_result)
+                hook_results = post_hook.run(
+                    step_result, _external_log_context=_external_log_context
+                )
                 if hook_results is not None:
                     step_result = hook_results
 
@@ -744,7 +757,12 @@ class Step:
             log_cfg = None
         ctx = nullcontext if log_cfg is None else log_cfg.context
 
-        with ctx(log_names):
+        with (
+            ctx(log_names),
+            log.record_logs(
+                log_names=cls.get_stpipe_loggers(), formatter=cls._log_records_formatter
+            ) as log_records,
+        ):
             config, config_file = cls.build_config(filename, **kwargs)
 
             if "logcfg" in config:
@@ -764,7 +782,7 @@ class Step:
                 config, name=name, config_file=config_file
             )
 
-            return instance.run(*args)
+            return instance.run(*args, _external_log_context=log_records)
 
     @property
     def input_dir(self):

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -128,6 +128,7 @@ class Step:
         name : str, optional
             If provided, use that name for the returned instance.
             If not provided, the following are tried (in order):
+
             - The ``name`` parameter in the config file
             - The filename of the config file
             - The name of returned class
@@ -172,7 +173,7 @@ class Step:
         Parameters
         ----------
         args : list of str
-            Commandline arguments
+            Command line arguments
 
         Returns
         -------
@@ -239,15 +240,19 @@ class Step:
         config : configobj.Section instance
             The config file fragment containing parameters for this
             step only.
+
         parent : Step instance, optional
             The parent step of this step.  Used to determine a
             fully-qualified name for this step, and to determine
             the mode in which to run this step.
+
         name : str, optional
             If provided, use that name for the returned instance.
             If not provided, try the following (in order):
+
             - The ``name`` parameter in the config file fragment
             - The name of returned class
+
         config_file : str or pathlib.Path, optional
             The path to the config file that created this step, if
             any.  This is used to resolve relative file name
@@ -931,6 +936,7 @@ class Step:
         """
 
         reftype = cls.get_config_reftype()
+        reftype_upper = reftype.upper()
 
         if isinstance(dataset, dict):
             # crds_parameters was passed as input from pipeline.py
@@ -951,12 +957,12 @@ class Step:
             disable = get_disable_crds_steppars()
         if disable:
             logger.info(
-                "%s: CRDS parameter reference retrieval disabled.", reftype.upper()
+                "%s: CRDS parameter reference retrieval disabled.", reftype_upper
             )
             return config_parser.ConfigObj()
 
         # Retrieve step parameters from CRDS
-        logger.debug("Retrieving step %s parameters from CRDS", reftype.upper())
+        logger.debug("Retrieving step %s parameters from CRDS", reftype_upper)
         try:
             ref_file = crds_client.get_reference_file(
                 crds_parameters,
@@ -964,22 +970,22 @@ class Step:
                 crds_observatory,
             )
         except (AttributeError, crds_client.CrdsError):
-            logger.debug("%s: No parameters found", reftype.upper())
+            logger.debug("%s: No parameters found", reftype_upper)
             return config_parser.ConfigObj()
         if ref_file != "N/A":
-            logger.info("%s parameters found: %s", reftype.upper(), ref_file)
+            logger.info("%s parameters found: %s", reftype_upper, ref_file)
             ref = config_parser.load_config_file(ref_file)
 
             ref_pars = {
                 par: value for par, value in ref.items() if par not in ["class", "name"]
             }
             logger.debug(
-                "%s parameters retrieved from CRDS: %s", reftype.upper(), ref_pars
+                "%s parameters retrieved from CRDS: %s", reftype_upper, ref_pars
             )
 
             return ref
 
-        logger.debug("No %s reference files found.", reftype.upper())
+        logger.debug("No %s reference files found.", reftype_upper)
         return config_parser.ConfigObj()
 
     @staticmethod
@@ -1026,6 +1032,7 @@ class Step:
         """
         self._set_input_dir(obj, exclusive=exclusive)
 
+        # NOTE: This method is called from self.run() so logger is captured normally.
         err_message = f"Cannot set master input file name from object {obj}"
         parent_input_filename = self.search_attr("_input_filename")
         if not exclusive or parent_input_filename is None:
@@ -1127,6 +1134,8 @@ class Step:
                     **components,
                 )
             )
+            # NOTE: This method is called from self.run()
+            #       so logger is captured normally.
             logger.info("Saved model in %s", output_path)
 
         return output_path
@@ -1398,6 +1407,8 @@ class Step:
                     for step_name, step_parameters in value.items():
                         getattr(self, step_name).update_pars(step_parameters)
             else:
+                # NOTE: This method is called from self.run()
+                #       so logger is captured normally.
                 logger.debug(
                     "Parameter %s is not valid for step %s. Ignoring.", parameter, self
                 )

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -418,6 +418,7 @@ class Step:
         # A list of logging.LogRecord emitted to the stpipe root logger
         # during the most recent call to Step.run.
         self._log_records = []
+        self._external_log_context = None
         self._input_filename = None
         self._input_dir = None
         self._keywords = kws
@@ -487,7 +488,7 @@ class Step:
         """
         return self._log_records
 
-    def run(self, *args, _external_log_context=None):
+    def run(self, *args):
         """
         Run handles the generic setup and teardown that happens with
         the running of each step.  The real work that is unique to
@@ -495,7 +496,7 @@ class Step:
         """
         gc.collect()
 
-        if _external_log_context is not None:
+        if self._external_log_context is not None:
             ctx = nullcontext()
         else:
             ctx = log.record_logs(
@@ -504,8 +505,8 @@ class Step:
             )
 
         with ctx as log_records:
-            if _external_log_context is not None:
-                self._log_records = _external_log_context
+            if self._external_log_context is not None:
+                self._log_records = self._external_log_context
             else:
                 self._log_records = log_records
 
@@ -546,9 +547,9 @@ class Step:
 
             hook_args = args
             for pre_hook in self._pre_hooks:
-                hook_results = pre_hook.run(
-                    *hook_args, _external_log_context=_external_log_context
-                )
+                pre_hook._external_log_context = self._external_log_context
+                hook_results = pre_hook.run(*hook_args)
+                pre_hook._external_log_context = None
                 if hook_results is not None:
                     hook_args = (hook_results,)
             args = hook_args
@@ -589,9 +590,9 @@ class Step:
 
             # Run the post hooks
             for post_hook in self._post_hooks:
-                hook_results = post_hook.run(
-                    step_result, _external_log_context=_external_log_context
-                )
+                post_hook._external_log_context = self._external_log_context
+                hook_results = post_hook.run(step_result)
+                post_hook._external_log_context = None
                 if hook_results is not None:
                     step_result = hook_results
 
@@ -782,7 +783,10 @@ class Step:
                 config, name=name, config_file=config_file
             )
 
-            return instance.run(*args, _external_log_context=log_records)
+            instance._external_log_context = log_records
+            result = instance.run(*args)
+            instance._external_log_context = None
+            return result
 
     @property
     def input_dir(self):


### PR DESCRIPTION
Resolves [JP-4129](https://jira.stsci.edu/browse/JP-4129)

* This PR addresses https://github.com/spacetelescope/jwst/issues/9864
* Close https://github.com/spacetelescope/stpipe/pull/304

Blocked by:

* https://github.com/spacetelescope/stpipe/pull/312
* https://github.com/spacetelescope/jwst/pull/10523
* #315 
* #317 

TODO:

- [ ] Fix the problem in `strun`
- [ ] Write tests

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stpipe/blob/main/changes/README.rst) for instructions)
  - [x] run regression tests with this branch installed (`stpipe@git+https://github.com/pllim/stpipe.git@log-all-the-things-porque-no-los-dos`)
    - [x] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
      - https://github.com/spacetelescope/RegressionTests/actions/runs/24103349581 (passed with spacetelescope/jwst#10437)
      - https://github.com/spacetelescope/RegressionTests/actions/runs/25520758464
    - [x] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
      - https://github.com/spacetelescope/RegressionTests/actions/runs/24103582716 (passed)
      - https://github.com/spacetelescope/RegressionTests/actions/runs/25520810950
