### PR TITLE
STY: Remove UP038 ignore because it no longer has any effect

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,6 @@ extend-select = [
 ]
 ignore = [
     "ISC001",  # conflicts with ruff formatter
-    "UP038",  # results in slower code
 ]
 
 [tool.ruff.lint.extend-per-file-ignores]


### PR DESCRIPTION
I saw this warning locally:

```
warning: The following rules have been removed and ignoring them has no effect:
    - UP038
```

No need for change log nor RT.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stpipe/blob/main/changes/README.rst) for instructions)
  - [ ] run regression tests with this branch installed (`stpipe@git+https://github.com/<fork>/stpipe.git@<branch>`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
