### PR TITLE
JP-4129: Work around default CRDS log configuration to allow stpipe capture

### DIFF
--- a/changes/312.feature.rst
+++ b/changes/312.feature.rst
@@ -1,0 +1,1 @@
+Add special handling for the CRDS logger to allow its messages to be captured by stpipe steps.

--- a/src/stpipe/crds_client.py
+++ b/src/stpipe/crds_client.py
@@ -2,10 +2,6 @@
 This module defines functions that connect the core crds package
 to stpipe, tailoring it to provide results in the forms required
 by stpipe.
-
-WARNING:  stpipe and crds have circular dependencies.  Do not use crds imports
-directly in modules other than this crds_client so that dependency order and
-general integration can be managed here.
 """
 
 import re
@@ -24,16 +20,6 @@ __all__ = [
     "reference_uri_to_cache_path",
     "get_context_used",
 ]
-
-
-def remove_crds_log_handler():
-    """Remove the default stream handler for the CRDS logger."""
-    log.remove_console_handler()
-
-
-def restore_crds_log_handler():
-    """Restore the default stream handler for the CRDS logger."""
-    log.add_console_handler()
 
 
 def get_multiple_reference_paths(parameters, reference_file_types, observatory):

--- a/src/stpipe/crds_client.py
+++ b/src/stpipe/crds_client.py
@@ -26,6 +26,16 @@ __all__ = [
 ]
 
 
+def remove_crds_log_handler():
+    """Remove the default stream handler for the CRDS logger."""
+    log.remove_console_handler()
+
+
+def restore_crds_log_handler():
+    """Restore the default stream handler for the CRDS logger."""
+    log.add_console_handler()
+
+
 def get_multiple_reference_paths(parameters, reference_file_types, observatory):
     """Aligns stpipe requirements with CRDS library top level interfaces.
 

--- a/src/stpipe/log.py
+++ b/src/stpipe/log.py
@@ -131,6 +131,13 @@ class LogConfig:
         If a logger has already been configured and not undone,
         it will be skipped.
 
+        Special handling is applied for the following log names:
+
+        - "py.warnings": If provided, Python warnings are captured and
+          logged (``logging.captureWarnings(True)``).
+        - "CRDS": If provided, the default stream handler for the CRDS
+          logger is removed.
+
         Parameters
         ----------
         log_names : tuple of str, list of str, or None, optional
@@ -161,6 +168,13 @@ class LogConfig:
     def undo(self, log_names=None, close_handlers=True):
         """
         Removes the configuration from known loggers.
+
+        Special handling is applied for the following log names:
+
+        - "py.warnings": If provided, Python warnings are no longer captured
+          and logged (``logging.captureWarnings(False)``).
+        - "CRDS": If provided, the default stream handler for the CRDS
+          logger is restored.
 
         Parameters
         ----------

--- a/src/stpipe/log.py
+++ b/src/stpipe/log.py
@@ -12,8 +12,9 @@ from contextlib import contextmanager
 
 from astropy.extern.configobj import validate
 from astropy.extern.configobj.configobj import ConfigObj
+from crds.core import log as crds_log
 
-from . import config_parser, crds_client
+from . import config_parser
 
 STPIPE_ROOT_LOGGER = "stpipe"
 DEFAULT_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
@@ -102,6 +103,7 @@ class LogConfig:
             self.handlers.append(BreakHandler(self.break_level))
 
         self._previous_level = {}
+        self._previous_crds_console = False
 
     def get_handler(self, handler_str):
         """
@@ -136,7 +138,7 @@ class LogConfig:
         - "py.warnings": If provided, Python warnings are captured and
           logged (``logging.captureWarnings(True)``).
         - "CRDS": If provided, the default stream handler for the CRDS
-          logger is removed.
+          logger is removed if needed.
 
         Parameters
         ----------
@@ -149,7 +151,9 @@ class LogConfig:
         if "py.warnings" in log_names:
             logging.captureWarnings(True)
         if "CRDS" in log_names:
-            crds_client.remove_crds_log_handler()
+            self._previous_crds_console = crds_log.THE_LOGGER.console is not None
+            if self._previous_crds_console:
+                crds_log.remove_console_handler()
         for log_name in log_names:
             # Don't reapply configuration, to avoid overwriting the
             # previously recorded level.
@@ -173,8 +177,9 @@ class LogConfig:
 
         - "py.warnings": If provided, Python warnings are no longer captured
           and logged (``logging.captureWarnings(False)``).
-        - "CRDS": If provided, the default stream handler for the CRDS
-          logger is restored.
+        - "CRDS": If provided and if the default stream handler for the CRDS
+          logger was present when configuration was applied, it will be
+          restored.
 
         Parameters
         ----------
@@ -207,8 +212,9 @@ class LogConfig:
             LogConfig.applied = None
         if "py.warnings" in log_names:
             logging.captureWarnings(False)
-        if "CRDS" in log_names:
-            crds_client.restore_crds_log_handler()
+        if "CRDS" in log_names and self._previous_crds_console:
+            self._previous_crds_console = False
+            crds_log.add_console_handler()
 
     @contextmanager
     def context(self, log_names=None):

--- a/src/stpipe/log.py
+++ b/src/stpipe/log.py
@@ -13,7 +13,7 @@ from contextlib import contextmanager
 from astropy.extern.configobj import validate
 from astropy.extern.configobj.configobj import ConfigObj
 
-from . import config_parser
+from . import config_parser, crds_client
 
 STPIPE_ROOT_LOGGER = "stpipe"
 DEFAULT_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
@@ -141,6 +141,8 @@ class LogConfig:
             log_names = [STPIPE_ROOT_LOGGER]
         if "py.warnings" in log_names:
             logging.captureWarnings(True)
+        if "CRDS" in log_names:
+            crds_client.remove_crds_log_handler()
         for log_name in log_names:
             # Don't reapply configuration, to avoid overwriting the
             # previously recorded level.
@@ -191,6 +193,8 @@ class LogConfig:
             LogConfig.applied = None
         if "py.warnings" in log_names:
             logging.captureWarnings(False)
+        if "CRDS" in log_names:
+            crds_client.restore_crds_log_handler()
 
     @contextmanager
     def context(self, log_names=None):

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -3,11 +3,11 @@ import logging
 import warnings
 
 import pytest
+from crds.core import log as crds_log
 
 import stpipe.cmdline
 from stpipe import Step
 from stpipe import log as stpipe_log
-from stpipe.crds_client import log as crds_log
 from stpipe.pipeline import Pipeline
 
 
@@ -592,7 +592,8 @@ def test_logging_capwarnings(caplog, recwarn):
     assert logging._warnings_showwarning is None
 
 
-def test_crds_log(capsys):
+@pytest.mark.parametrize("restore_console", [True, False])
+def test_crds_log(capsys, restore_console):
     class CRDSLoggingStep(LoggingStep):
         def process(self):
             logger.info(STEP_INFO)
@@ -606,12 +607,19 @@ def test_crds_log(capsys):
         def get_stpipe_loggers():
             return ("stpipe", "CRDS")
 
-    # Before the step call, the crds logger has a stream handler
     crds_logger = logging.getLogger("CRDS")
-    assert len(crds_logger.handlers) == 1
-    assert isinstance(crds_logger.handlers[0], logging.StreamHandler)
+    if restore_console:
+        # Before the step call, the crds logger has a stream handler
+        assert len(crds_logger.handlers) == 1
+        assert isinstance(crds_logger.handlers[0], logging.StreamHandler)
+    else:
+        # remove any current console handler
+        crds_log.remove_console_handler()
 
-    # During the step call, the CRDS handler is removed and
+        # Before the step call, the crds logger has no handlers
+        assert len(crds_logger.handlers) == 0
+
+    # During the step call, the CRDS handler is removed if necessary and
     # the stpipe handler is attached
     CRDSLoggingStep.call()
 
@@ -627,6 +635,11 @@ def test_crds_log(capsys):
             assert capt.err.count(msg) == 0
 
     # After the call is complete, the stpipe logger is removed and the CRDS
-    # stream logger is restored
-    assert len(crds_logger.handlers) == 1
-    assert isinstance(crds_logger.handlers[0], logging.StreamHandler)
+    # stream logger is restored if it was previously present
+    if restore_console:
+        assert len(crds_logger.handlers) == 1
+        assert isinstance(crds_logger.handlers[0], logging.StreamHandler)
+    else:
+        assert len(crds_logger.handlers) == 0
+        # Clean up: restore a console logger
+        crds_log.add_console_handler()

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -7,6 +7,7 @@ import pytest
 import stpipe.cmdline
 from stpipe import Step
 from stpipe import log as stpipe_log
+from stpipe.crds_client import log as crds_log
 from stpipe.pipeline import Pipeline
 
 
@@ -49,7 +50,7 @@ logger = logging.getLogger("stpipe.tests.test_logger")
 
 
 class LoggingStep(Step):
-    """A Step that utilizes a local logger to log a warning."""
+    """A Step that uses a local and external logger to log messages."""
 
     spec = """
         str1 = string(default='default')
@@ -74,7 +75,7 @@ class LoggingStep(Step):
 
 
 class LoggingPipeline(Pipeline):
-    """A Pipeline that utilizes a local logger to log a warning."""
+    """A Pipeline that uses a local and external logger to log messages."""
 
     spec = """
         str1 = string(default='default')
@@ -589,3 +590,43 @@ def test_logging_capwarnings(caplog, recwarn):
     assert len(recwarn) == 1  # Unchanged from above assert
     assert MSG in caplog.text
     assert logging._warnings_showwarning is None
+
+
+def test_crds_log(capsys):
+    class CRDSLoggingStep(LoggingStep):
+        def process(self):
+            logger.info(STEP_INFO)
+            logger.warning(STEP_WARNING)
+            logger.debug(STEP_DEBUG)
+            crds_log.info(EXTERNAL_INFO)
+            crds_log.warning(EXTERNAL_WARNING)
+            crds_log.debug(EXTERNAL_DEBUG)
+
+        @staticmethod
+        def get_stpipe_loggers():
+            return ("stpipe", "CRDS")
+
+    # Before the step call, the crds logger has a stream handler
+    crds_logger = logging.getLogger("CRDS")
+    assert len(crds_logger.handlers) == 1
+    assert isinstance(crds_logger.handlers[0], logging.StreamHandler)
+
+    # During the step call, the CRDS handler is removed and
+    # the stpipe handler is attached
+    CRDSLoggingStep.call()
+
+    # With default configuration, exactly one info and warning message is expected
+    # from each captured logger in the stderr stream
+    capt = capsys.readouterr()
+    for msg in ALL_MESSAGES:
+        assert capt.out == ""
+        if msg in [STEP_INFO, STEP_WARNING, EXTERNAL_INFO, EXTERNAL_WARNING]:
+            assert msg in capt.err
+            assert capt.err.count(msg) == 1
+        else:
+            assert capt.err.count(msg) == 0
+
+    # After the call is complete, the stpipe logger is removed and the CRDS
+    # stream logger is restored
+    assert len(crds_logger.handlers) == 1
+    assert isinstance(crds_logger.handlers[0], logging.StreamHandler)


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Toward [JP-4129](https://jira.stsci.edu/browse/JP-4129)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
Workaround for CRDS logging configuration, to allow stpipe to capture log messages from the "CRDS" logger.

The default console logger assigned by CRDS is removed when stpipe configures loggers, then is restored when the configuration is undone.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stpipe/blob/main/changes/README.rst) for instructions)
  - [x] run regression tests with this branch installed (`stpipe@git+https://github.com/<fork>/stpipe.git@<branch>`)
    - [x] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [x] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
