### PR TITLE
remove unused cmdline.step_script

### DIFF
--- a/changes/315.removal.rst
+++ b/changes/315.removal.rst
@@ -1,0 +1,1 @@
+Remove unused ``cmdline.step_script``.

--- a/src/stpipe/cmdline.py
+++ b/src/stpipe/cmdline.py
@@ -482,12 +482,3 @@ def step_from_cmdline(args, cls=None):
             log.LogConfig.applied.undo()
 
     return step
-
-
-def step_script(cls):
-    import sys
-
-    if not issubclass(cls, Step):
-        raise AssertionError("cls must be a subclass of Step")
-
-    return step_from_cmdline(sys.argv[1:], cls=cls)


### PR DESCRIPTION
Closes https://github.com/spacetelescope/stpipe/issues/178

Remove unused cmdline.step_script

Unused in jwst: https://github.com/search?q=repo%3Aspacetelescope%2Fjwst%20step_script&type=code
and unused in romancal: https://github.com/search?q=repo%3Aspacetelescope%2Fromancal+step_script&type=code

jwst regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/25672081673
romancal regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/25672114547

This removes the only use of the `cls` argument to `step_from_cmdline`:
https://github.com/spacetelescope/stpipe/blob/14c962784fcbcc58ad142918227ac530b313391b/src/stpipe/cmdline.py#L431
(FWIW `step_from_cmdline` is unused outside of stpipe). If we remove `cls` it would remove all non-test uses of the `cls` argument to `just_the_step_from_cmdline` (FWIW `just_the_step_from_cmdline` is unused outside of tests). I think we should simplify these functions by:
- removing the unused arguments
- replacing test usage of `just_the_step_from_cmdline` with `step_from_cmdline`
- making `just_the_step_from_cmdline` private (and perhaps removing it depending on how we want to address capturing the pre-pipeline jobs)

I didn't include the above changes in this PR but can do so if it's preferred to batch these changes into 1 "refactoring" PR.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stpipe/blob/main/changes/README.rst) for instructions)
  - [ ] run regression tests with this branch installed (`stpipe@git+https://github.com/<fork>/stpipe.git@<branch>`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
