### PR TITLE
capture pre-pipeline/step logs and cleanup cmdline

### DIFF
--- a/changes/317.feature.rst
+++ b/changes/317.feature.rst
@@ -1,0 +1,1 @@
+Record log messages before pipeline/step creation.

--- a/changes/317.misc.rst
+++ b/changes/317.misc.rst
@@ -1,0 +1,1 @@
+Minor restructuring of private cmdline submodule to simplify log handling and step class creation.

--- a/src/stpipe/cmdline.py
+++ b/src/stpipe/cmdline.py
@@ -289,7 +289,7 @@ def _determine_log_configuration(known):
 
     Returns
     -------
-    log_cfg : logging configuration object
+    log_cfg : LogConfig
         The loaded logging configuration ready for use.
     """
     if known.logcfg is not None:

--- a/src/stpipe/cmdline.py
+++ b/src/stpipe/cmdline.py
@@ -230,7 +230,7 @@ def _override_config_from_args(config, args):
             set_value(config, key, val)
 
 
-def just_the_step_from_cmdline(args, cls=None, apply_log_cfg=False):
+def just_the_step_from_cmdline(args, apply_log_cfg=False):
     """
     Create a step from a configuration file and return it.  Don't run it.
 
@@ -240,10 +240,6 @@ def just_the_step_from_cmdline(args, cls=None, apply_log_cfg=False):
     ----------
     args : list of str
         Command line arguments
-
-    cls : Step class, optional
-        The step class to use.  If none is provided, the step is inferred
-        from the input arguments.
 
     apply_log_cfg : bool
         If True, apply the logging configuration. If False,
@@ -261,7 +257,7 @@ def just_the_step_from_cmdline(args, cls=None, apply_log_cfg=False):
         instance.
 
     step_class: Step class
-        As defined by `cls` parameter or .cfg file.
+        As defined by .cfg file.
 
     positional: list of strings
         Positional parameters after arg parsing
@@ -269,21 +265,13 @@ def just_the_step_from_cmdline(args, cls=None, apply_log_cfg=False):
     debug_on_exception : bool
         If True, the Python debugger will be invoked when an exception occurs.
     """
-    parser1 = _build_parent_arg_parser(cls, apply_log_cfg=apply_log_cfg)
+    parser1 = _build_parent_arg_parser(None, apply_log_cfg=apply_log_cfg)
     known, _ = parser1.parse_known_args(args)
 
     try:
-        if cls is None:
-            step_class, config, name, config_file = _get_config_and_class(
-                known.cfg_file_or_class[0]
-            )
-        else:
-            config_file = known.config_file
-            config = config_parser.load_config_file(config_file)
-            step_class, name = Step._parse_class_and_name(
-                config, config_file=config_file
-            )
-            step_class = cls
+        step_class, config, name, config_file = _get_config_and_class(
+            known.cfg_file_or_class[0]
+        )
 
         if apply_log_cfg:
             # Retrieve a log config file if specified
@@ -352,10 +340,7 @@ def just_the_step_from_cmdline(args, cls=None, apply_log_cfg=False):
 
     args = parser2.parse_args(args)
 
-    if cls is None:
-        del args.cfg_file_or_class
-    else:
-        del args.config_file
+    del args.cfg_file_or_class
     del args.debug
     del args.save_parameters
     del args.disable_crds_steppars

--- a/src/stpipe/cmdline.py
+++ b/src/stpipe/cmdline.py
@@ -222,97 +222,66 @@ def _override_config_from_args(config, args):
             set_value(config, key, val)
 
 
-def _just_the_step_from_cmdline(args):
-    """
-    Create a step from a configuration file and return it.  Don't run it.
+def _print_parser_error(parser, error):
+    _print_important_message("ERROR PARSING CONFIGURATION:", str(error))
+    parser.print_help()
 
-    DOES NOT RUN THE STEP.
 
-    Parameters
-    ----------
-    args : list of str
-        Command line arguments
+def _config_and_class_from_cmdline(args):
+    parser = _build_parent_arg_parser()
+    known, _ = parser.parse_known_args(args)
+    try:
+        return (*_get_config_and_class(known.cfg_file_or_class[0]), parser, known)
+    except Exception as e:
+        _print_parser_error(parser, e)
+        raise e
 
-    Returns
-    -------
-    step : Step instance
-        If the config file has a `class` parameter, or the commandline
-        specifies a class, the return value will be as instance of
-        that class.
 
-        Any parameters found in the config file or on the commandline
-        will be set as member variables on the returned `Step`
-        instance.
+def _determine_log_configuration(known):
+    if known.logcfg is not None:
+        msg = (
+            "The logcfg configuration file is deprecated. "
+            "Please use the log_* command line "
+            "arguments to configure logging."
+        )
+        warnings.warn(msg, DeprecationWarning, stacklevel=2)
 
-    step_class: Step class
-        As defined by .cfg file.
+    # if verbose is enabled
+    # or log_level log_file or log_stream are set (not None)
+    # then don't try to use the log configuration file (or any passed in log_cfg)
+    if known.verbose is True or any(
+        getattr(known, attr) is not None
+        for attr in ("log_level", "log_file", "log_stream")
+    ):
+        cfgfile = None
+    elif known.logcfg:
+        if not os.path.exists(known.logcfg):
+            raise OSError(f"Logging config {known.logcfg!r} not found")
+        cfgfile = known.logcfg
+    else:
+        cfgfile = log._find_logging_config_file()
 
-    positional: list of strings
-        Positional parameters after arg parsing
-
-    debug_on_exception : bool
-        If True, the Python debugger will be invoked when an exception occurs.
-    """
-    parser1 = _build_parent_arg_parser()
-    known, _ = parser1.parse_known_args(args)
+    # determine level
+    if known.verbose:
+        log_level = "DEBUG"
+    elif known.log_level is not None:
+        log_level = str(known.log_level).upper()
+    else:
+        log_level = None
 
     try:
-        step_class, config, name, config_file = _get_config_and_class(
-            known.cfg_file_or_class[0]
+        log_cfg = log.load_configuration(
+            config_file=cfgfile,
+            log_level=log_level,
+            log_file=known.log_file,
+            log_stream=known.log_stream,
         )
-
-        # Retrieve a log config file if specified
-        use_log_cfg = True
-        log_args = [
-            known.log_level,
-            known.log_file,
-            known.log_stream,
-        ]
-        if known.verbose is True or any([arg is not None for arg in log_args]):
-            use_log_cfg = False
-
-        logcfg = None
-        if known.logcfg is not None:
-            msg = (
-                "The logcfg configuration file is deprecated. "
-                "Please use the log_* command line "
-                "arguments to configure logging."
-            )
-            warnings.warn(msg, DeprecationWarning, stacklevel=2)
-            if use_log_cfg:
-                if not os.path.exists(known.logcfg):
-                    raise OSError(f"Logging config {known.logcfg!r} not found")
-                logcfg = known.logcfg
-        elif use_log_cfg:
-            logcfg = log._find_logging_config_file()
-
-        if known.verbose:
-            log_level = "DEBUG"
-        elif known.log_level is not None:
-            log_level = str(known.log_level).upper()
-        else:
-            log_level = None
-        try:
-            log_cfg = log.load_configuration(
-                config_file=logcfg,
-                log_level=log_level,
-                log_file=known.log_file,
-                log_stream=known.log_stream,
-            )
-        except Exception as e:
-            raise ValueError(f"Error parsing logging configuration:\n{e}") from e
-
-        # Apply the logging configuration to the stpipe logger to
-        # capture start up messages
-        log_cfg.apply(step_class.get_stpipe_loggers())
-
     except Exception as e:
-        _print_important_message("ERROR PARSING CONFIGURATION:", str(e))
-        parser1.print_help()
-        raise
+        raise ValueError(f"Error parsing logging configuration:\n{e}") from e
+    return log_cfg
 
-    debug_on_exception = known.debug
 
+def _build_step_from_args(step_class, config, name, config_file, parser, known, args):
     # Determine whether CRDS should be queried for step parameters
     disable_crds_steppars = get_disable_crds_steppars(known.disable_crds_steppars)
 
@@ -323,9 +292,9 @@ def _just_the_step_from_cmdline(args):
     # load_spec_file is a method of both Step and Pipeline
     spec = step_class.load_spec_file()
 
-    parser2 = _build_arg_parser_from_spec(spec, step_class, parent=parser1)
+    step_arg_parser = _build_arg_parser_from_spec(spec, step_class, parent=parser)
 
-    args = parser2.parse_args(args)
+    args = step_arg_parser.parse_args(args)
 
     del args.cfg_file_or_class
     del args.debug
@@ -375,7 +344,7 @@ def _just_the_step_from_cmdline(args):
     except config_parser.ValidationError as e:
         # If the configobj validator failed, print usage information.
         _print_important_message("ERROR PARSING CONFIGURATION:", str(e))
-        parser2.print_help()
+        step_arg_parser.print_help()
         raise ValueError(str(e)) from e
 
     # Define the primary input file.
@@ -389,7 +358,7 @@ def _just_the_step_from_cmdline(args):
         step.export_config(known.save_parameters, include_metadata=True)
         logger.info(f"Step/Pipeline parameters saved to '{known.save_parameters}'")
 
-    return step, step_class, positional, debug_on_exception
+    return step, positional
 
 
 def step_from_cmdline(args):
@@ -413,30 +382,38 @@ def step_from_cmdline(args):
         will be set as member variables on the returned `Step`
         instance.
     """
+    # determine step class
+    step_class, config, name, config_file, parser, known = (
+        _config_and_class_from_cmdline(args)
+    )
+
+    # determine logging parameters
     try:
-        step, step_class, positional, debug_on_exception = _just_the_step_from_cmdline(
-            args
-        )
+        log_cfg = _determine_log_configuration(known)
     except Exception as e:
-        # since we applied a log config above, undo it
-        if log.LogConfig.applied is not None:
-            log.LogConfig.applied.undo()
+        _print_parser_error(parser, e)
         raise e
 
-    try:
-        step.run(*positional)
-    except Exception as e:
-        _print_important_message(f"ERROR RUNNING STEP {step_class.__name__!r}:", str(e))
+    # set up logging context
+    with log_cfg.context(step_class.get_stpipe_loggers()):
+        # finish parsing args, make class
+        step, positional = _build_step_from_args(
+            step_class, config, name, config_file, parser, known, args
+        )
 
-        if debug_on_exception:
-            import pdb  # noqa: T100
+        # run step
+        try:
+            step.run(*positional)
+        except Exception as e:
+            _print_important_message(
+                f"ERROR RUNNING STEP {step_class.__name__!r}:", str(e)
+            )
 
-            pdb.post_mortem()
-        else:
-            raise
-    finally:
-        # since we applied a log config above, undo it
-        if log.LogConfig.applied is not None:
-            log.LogConfig.applied.undo()
+            if known.debug:
+                import pdb  # noqa: T100
+
+                pdb.post_mortem()
+            else:
+                raise
 
     return step

--- a/src/stpipe/cmdline.py
+++ b/src/stpipe/cmdline.py
@@ -223,7 +223,7 @@ def _override_config_from_args(config, args):
             set_value(config, key, val)
 
 
-def just_the_step_from_cmdline(args, apply_log_cfg=False):
+def _just_the_step_from_cmdline(args, apply_log_cfg=False):
     """
     Create a step from a configuration file and return it.  Don't run it.
 
@@ -428,7 +428,7 @@ def step_from_cmdline(args):
         instance.
     """
     try:
-        step, step_class, positional, debug_on_exception = just_the_step_from_cmdline(
+        step, step_class, positional, debug_on_exception = _just_the_step_from_cmdline(
             args,
             apply_log_cfg=True,
         )

--- a/src/stpipe/cmdline.py
+++ b/src/stpipe/cmdline.py
@@ -304,7 +304,7 @@ def _just_the_step_from_cmdline(args):
 
         # Apply the logging configuration to the stpipe logger to
         # capture start up messages
-        log_cfg.apply()
+        log_cfg.apply(step_class.get_stpipe_loggers())
 
     except Exception as e:
         _print_important_message("ERROR PARSING CONFIGURATION:", str(e))
@@ -377,12 +377,6 @@ def _just_the_step_from_cmdline(args):
         _print_important_message("ERROR PARSING CONFIGURATION:", str(e))
         parser2.print_help()
         raise ValueError(str(e)) from e
-
-    # Apply the log configuration to the step's known loggers
-    # Undo the initial configuration without closing handlers
-    log_cfg.undo(close_handlers=False)
-    # Apply configuration to specified loggers
-    log_cfg.apply(step.get_stpipe_loggers())
 
     # Define the primary input file.
     # Always have an output_file set on the outermost step

--- a/src/stpipe/cmdline.py
+++ b/src/stpipe/cmdline.py
@@ -428,7 +428,7 @@ def just_the_step_from_cmdline(args, cls=None, apply_log_cfg=False):
     return step, step_class, positional, debug_on_exception
 
 
-def step_from_cmdline(args, cls=None):
+def step_from_cmdline(args):
     """
     Create a step from a configuration file and run it.
 
@@ -436,10 +436,6 @@ def step_from_cmdline(args, cls=None):
     ----------
     args : list of str
         Commandline arguments
-
-    cls : Step class
-        The step class to use.  If none is provided, the step is inferred
-        from the input arguments.
 
 
     Returns
@@ -456,7 +452,6 @@ def step_from_cmdline(args, cls=None):
     try:
         step, step_class, positional, debug_on_exception = just_the_step_from_cmdline(
             args,
-            cls,
             apply_log_cfg=True,
         )
     except Exception as e:

--- a/src/stpipe/cmdline.py
+++ b/src/stpipe/cmdline.py
@@ -65,7 +65,7 @@ def _get_config_and_class(identifier):
     return step_class, config, name, config_file
 
 
-def _build_parent_arg_parser(apply_log_cfg=False):
+def _build_parent_arg_parser():
     """Build a top-level argument parser for the command line interface."""
     parser1 = argparse.ArgumentParser(
         description="Run an stpipe Step or Pipeline",
@@ -92,38 +92,37 @@ def _build_parent_arg_parser(apply_log_cfg=False):
         action="store_true",
         help="Disable retrieval of step parameter references files from CRDS",
     )
-    if apply_log_cfg:
-        parser1.add_argument(
-            "--logcfg",
-            type=str,
-            help="DEPRECATED: The logging configuration file to load. "
-            "Ignored if verbose or other log arguments are set.",
-        )
-        parser1.add_argument(
-            "--verbose",
-            "-v",
-            action="store_true",
-            help="Turn on all logging messages",
-        )
-        parser1.add_argument(
-            "--log-level",
-            type=str,
-            default=None,
-            help="Log level (DEBUG, INFO, WARNING, ERROR, CRITICAL). "
-            "Ignored if 'verbose' is specified.",
-        )
-        parser1.add_argument(
-            "--log-file",
-            type=str,
-            default=None,
-            help="Full path to a file name to record log messages",
-        )
-        parser1.add_argument(
-            "--log-stream",
-            type=str,
-            default=None,
-            help="Log stream for terminal messages (stdout, stderr, or null).",
-        )
+    parser1.add_argument(
+        "--logcfg",
+        type=str,
+        help="DEPRECATED: The logging configuration file to load. "
+        "Ignored if verbose or other log arguments are set.",
+    )
+    parser1.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Turn on all logging messages",
+    )
+    parser1.add_argument(
+        "--log-level",
+        type=str,
+        default=None,
+        help="Log level (DEBUG, INFO, WARNING, ERROR, CRITICAL). "
+        "Ignored if 'verbose' is specified.",
+    )
+    parser1.add_argument(
+        "--log-file",
+        type=str,
+        default=None,
+        help="Full path to a file name to record log messages",
+    )
+    parser1.add_argument(
+        "--log-stream",
+        type=str,
+        default=None,
+        help="Log stream for terminal messages (stdout, stderr, or null).",
+    )
     return parser1
 
 
@@ -223,7 +222,7 @@ def _override_config_from_args(config, args):
             set_value(config, key, val)
 
 
-def _just_the_step_from_cmdline(args, apply_log_cfg=False):
+def _just_the_step_from_cmdline(args):
     """
     Create a step from a configuration file and return it.  Don't run it.
 
@@ -233,10 +232,6 @@ def _just_the_step_from_cmdline(args, apply_log_cfg=False):
     ----------
     args : list of str
         Command line arguments
-
-    apply_log_cfg : bool
-        If True, apply the logging configuration. If False,
-        any provided log configuration will be ignored.
 
     Returns
     -------
@@ -258,7 +253,7 @@ def _just_the_step_from_cmdline(args, apply_log_cfg=False):
     debug_on_exception : bool
         If True, the Python debugger will be invoked when an exception occurs.
     """
-    parser1 = _build_parent_arg_parser(apply_log_cfg=apply_log_cfg)
+    parser1 = _build_parent_arg_parser()
     known, _ = parser1.parse_known_args(args)
 
     try:
@@ -266,51 +261,50 @@ def _just_the_step_from_cmdline(args, apply_log_cfg=False):
             known.cfg_file_or_class[0]
         )
 
-        if apply_log_cfg:
-            # Retrieve a log config file if specified
-            use_log_cfg = True
-            log_args = [
-                known.log_level,
-                known.log_file,
-                known.log_stream,
-            ]
-            if known.verbose is True or any([arg is not None for arg in log_args]):
-                use_log_cfg = False
+        # Retrieve a log config file if specified
+        use_log_cfg = True
+        log_args = [
+            known.log_level,
+            known.log_file,
+            known.log_stream,
+        ]
+        if known.verbose is True or any([arg is not None for arg in log_args]):
+            use_log_cfg = False
 
-            logcfg = None
-            if known.logcfg is not None:
-                msg = (
-                    "The logcfg configuration file is deprecated. "
-                    "Please use the log_* command line "
-                    "arguments to configure logging."
-                )
-                warnings.warn(msg, DeprecationWarning, stacklevel=2)
-                if use_log_cfg:
-                    if not os.path.exists(known.logcfg):
-                        raise OSError(f"Logging config {known.logcfg!r} not found")
-                    logcfg = known.logcfg
-            elif use_log_cfg:
-                logcfg = log._find_logging_config_file()
+        logcfg = None
+        if known.logcfg is not None:
+            msg = (
+                "The logcfg configuration file is deprecated. "
+                "Please use the log_* command line "
+                "arguments to configure logging."
+            )
+            warnings.warn(msg, DeprecationWarning, stacklevel=2)
+            if use_log_cfg:
+                if not os.path.exists(known.logcfg):
+                    raise OSError(f"Logging config {known.logcfg!r} not found")
+                logcfg = known.logcfg
+        elif use_log_cfg:
+            logcfg = log._find_logging_config_file()
 
-            if known.verbose:
-                log_level = "DEBUG"
-            elif known.log_level is not None:
-                log_level = str(known.log_level).upper()
-            else:
-                log_level = None
-            try:
-                log_cfg = log.load_configuration(
-                    config_file=logcfg,
-                    log_level=log_level,
-                    log_file=known.log_file,
-                    log_stream=known.log_stream,
-                )
-            except Exception as e:
-                raise ValueError(f"Error parsing logging configuration:\n{e}") from e
+        if known.verbose:
+            log_level = "DEBUG"
+        elif known.log_level is not None:
+            log_level = str(known.log_level).upper()
+        else:
+            log_level = None
+        try:
+            log_cfg = log.load_configuration(
+                config_file=logcfg,
+                log_level=log_level,
+                log_file=known.log_file,
+                log_stream=known.log_stream,
+            )
+        except Exception as e:
+            raise ValueError(f"Error parsing logging configuration:\n{e}") from e
 
-            # Apply the logging configuration to the stpipe logger to
-            # capture start up messages
-            log_cfg.apply()
+        # Apply the logging configuration to the stpipe logger to
+        # capture start up messages
+        log_cfg.apply()
 
     except Exception as e:
         _print_important_message("ERROR PARSING CONFIGURATION:", str(e))
@@ -337,12 +331,11 @@ def _just_the_step_from_cmdline(args, apply_log_cfg=False):
     del args.debug
     del args.save_parameters
     del args.disable_crds_steppars
-    if apply_log_cfg:
-        del args.logcfg
-        del args.verbose
-        del args.log_level
-        del args.log_file
-        del args.log_stream
+    del args.logcfg
+    del args.verbose
+    del args.log_level
+    del args.log_file
+    del args.log_stream
     positional = args.args
     del args.args
 
@@ -386,11 +379,10 @@ def _just_the_step_from_cmdline(args, apply_log_cfg=False):
         raise ValueError(str(e)) from e
 
     # Apply the log configuration to the step's known loggers
-    if apply_log_cfg:
-        # Undo the initial configuration without closing handlers
-        log_cfg.undo(close_handlers=False)
-        # Apply configuration to specified loggers
-        log_cfg.apply(step.get_stpipe_loggers())
+    # Undo the initial configuration without closing handlers
+    log_cfg.undo(close_handlers=False)
+    # Apply configuration to specified loggers
+    log_cfg.apply(step.get_stpipe_loggers())
 
     # Define the primary input file.
     # Always have an output_file set on the outermost step
@@ -429,8 +421,7 @@ def step_from_cmdline(args):
     """
     try:
         step, step_class, positional, debug_on_exception = _just_the_step_from_cmdline(
-            args,
-            apply_log_cfg=True,
+            args
         )
     except Exception as e:
         # since we applied a log config above, undo it

--- a/src/stpipe/cmdline.py
+++ b/src/stpipe/cmdline.py
@@ -223,11 +223,47 @@ def _override_config_from_args(config, args):
 
 
 def _print_parser_error(parser, error):
+    """
+    Print a formatted error message and parser help text.
+
+    Parameters
+    ----------
+    parser : argparse.ArgumentParser
+        The argument parser whose help text will be printed.
+    error : Exception
+        The error object whose message will be displayed.
+    """
     _print_important_message("ERROR PARSING CONFIGURATION:", str(error))
     parser.print_help()
 
 
 def _config_and_class_from_cmdline(args):
+    """
+    Parse command line arguments and retrieve step configuration and class.
+
+    Extracts the configuration file or class identifier from command line
+    arguments and retrieves the corresponding Step class and configuration.
+
+    Parameters
+    ----------
+    args : list of str
+        Command line arguments.
+
+    Returns
+    -------
+    step_class : type
+        The Step class to be instantiated.
+    config : ConfigObj
+        The configuration object for the step.
+    name : str or None
+        The step name from the configuration file, or None.
+    config_file : str or None
+        Path to the configuration file, or None.
+    parser : argparse.ArgumentParser
+        The parent argument parser used for parsing.
+    known : argparse.Namespace
+        The parsed command line arguments.
+    """
     parser = _build_parent_arg_parser()
     known, _ = parser.parse_known_args(args)
     try:
@@ -238,6 +274,24 @@ def _config_and_class_from_cmdline(args):
 
 
 def _determine_log_configuration(known):
+    """
+    Determine and load logging configuration from arguments.
+
+    Parameters
+    ----------
+    known : argparse.Namespace
+        Parsed command line arguments containing logging-related parameters:
+        - logcfg: Path to logging configuration file (deprecated)
+        - verbose: Enable all logging messages
+        - log_level: Specific log level to set
+        - log_file: Path to log file
+        - log_stream: Output stream for logs
+
+    Returns
+    -------
+    log_cfg : logging configuration object
+        The loaded logging configuration ready for use.
+    """
     if known.logcfg is not None:
         msg = (
             "The logcfg configuration file is deprecated. "
@@ -282,6 +336,37 @@ def _determine_log_configuration(known):
 
 
 def _build_step_from_args(step_class, config, name, config_file, parser, known, args):
+    """
+    Build and configure a Step instance from parsed arguments.
+
+    Creates a Step instance using the provided class and configuration,
+    merges in command line overrides, retrieves reference parameters from
+    CRDS if an input file is provided, and handles configuration validation.
+
+    Parameters
+    ----------
+    step_class : type
+        The Step class to instantiate.
+    config : ConfigObj
+        The base configuration object.
+    name : str or None
+        The step name from configuration.
+    config_file : str or None
+        Path to the configuration file.
+    parser : argparse.ArgumentParser
+        The parent argument parser.
+    known : argparse.Namespace
+        Parsed parent-level command line arguments.
+    args : list of str
+        Remaining unparsed command line arguments.
+
+    Returns
+    -------
+    step : Step instance
+        The instantiated and configured Step object.
+    positional : list of str
+        Positional arguments remaining after parsing.
+    """
     # Determine whether CRDS should be queried for step parameters
     disable_crds_steppars = get_disable_crds_steppars(known.disable_crds_steppars)
 

--- a/src/stpipe/cmdline.py
+++ b/src/stpipe/cmdline.py
@@ -395,7 +395,9 @@ def step_from_cmdline(args):
         raise e
 
     # set up logging context
-    with log_cfg.context(step_class.get_stpipe_loggers()):
+    with log_cfg.context(
+        step_class.get_stpipe_loggers(), step_class._log_records_formatter
+    ):
         # finish parsing args, make class
         step, positional = _build_step_from_args(
             step_class, config, name, config_file, parser, known, args

--- a/src/stpipe/cmdline.py
+++ b/src/stpipe/cmdline.py
@@ -394,10 +394,10 @@ def step_from_cmdline(args):
         _print_parser_error(parser, e)
         raise e
 
+    log_cfg.set_recording_formatter(step_class._log_records_formatter)
+
     # set up logging context
-    with log_cfg.context(
-        step_class.get_stpipe_loggers(), step_class._log_records_formatter
-    ):
+    with log_cfg.context(step_class.get_stpipe_loggers()):
         # finish parsing args, make class
         step, positional = _build_step_from_args(
             step_class, config, name, config_file, parser, known, args

--- a/src/stpipe/cmdline.py
+++ b/src/stpipe/cmdline.py
@@ -65,25 +65,18 @@ def _get_config_and_class(identifier):
     return step_class, config, name, config_file
 
 
-def _build_parent_arg_parser(cls=None, apply_log_cfg=False):
+def _build_parent_arg_parser(apply_log_cfg=False):
     """Build a top-level argument parser for the command line interface."""
     parser1 = argparse.ArgumentParser(
         description="Run an stpipe Step or Pipeline",
         add_help=False,
     )
-    if cls is None:
-        parser1.add_argument(
-            "cfg_file_or_class",
-            type=str,
-            nargs=1,
-            help="The configuration file or Python class to run",
-        )
-    else:
-        parser1.add_argument(
-            "--config-file",
-            type=str,
-            help="A configuration file to load parameters from",
-        )
+    parser1.add_argument(
+        "cfg_file_or_class",
+        type=str,
+        nargs=1,
+        help="The configuration file or Python class to run",
+    )
     parser1.add_argument(
         "--debug",
         action="store_true",
@@ -265,7 +258,7 @@ def just_the_step_from_cmdline(args, apply_log_cfg=False):
     debug_on_exception : bool
         If True, the Python debugger will be invoked when an exception occurs.
     """
-    parser1 = _build_parent_arg_parser(None, apply_log_cfg=apply_log_cfg)
+    parser1 = _build_parent_arg_parser(apply_log_cfg=apply_log_cfg)
     known, _ = parser1.parse_known_args(args)
 
     try:

--- a/src/stpipe/cmdline.py
+++ b/src/stpipe/cmdline.py
@@ -362,7 +362,7 @@ def _build_step_from_args(step_class, config, name, config_file, parser, known, 
 
     Returns
     -------
-    step : Step instance
+    step : Step
         The instantiated and configured Step object.
     positional : list of str
         Positional arguments remaining after parsing.

--- a/src/stpipe/log.py
+++ b/src/stpipe/log.py
@@ -177,13 +177,12 @@ class LogConfig:
                 log.addHandler(handler)
 
             # Set the log level
-            # we still track level since undo uses this to remove handlers
-            self._previous_level[log_name] = log.level
             if self.level is not logging.NOTSET:
+                self._previous_level[log_name] = log.level
                 log.setLevel(self.level)
         LogConfig.applied = self
 
-    def undo(self, log_names=None):
+    def undo(self, log_names):
         """
         Removes the configuration from known loggers.
 
@@ -197,18 +196,10 @@ class LogConfig:
 
         Parameters
         ----------
-        log_names : list of str or None, optional
-            If provided, handlers stored in this configuration
-            will be removed from each specified log name. If not
-            provided, they are removed from the STPIPE_ROOT_LOGGER.
-            This parameter is ignored if log configuration has been
-            previously applied by this instance: in that case,
-            only the previously affected logs are unconfigured.
+        log_names : list of str
+            The names of logs which will have any attached
+            handlers removed.
         """
-        if LogConfig.applied is self:
-            log_names = list(self._previous_level.keys())
-        elif log_names is None:
-            log_names = [STPIPE_ROOT_LOGGER]
         for log_name in log_names:
             log = logging.getLogger(log_name)
             for handler in self.handlers:
@@ -236,6 +227,7 @@ class LogConfig:
         log_names : list of str or None, optional
             Log names to pass to `apply` and `undo` methods.
         """
+        log_names = log_names or [STPIPE_ROOT_LOGGER]
         self.apply(log_names, recording_formatter)
         try:
             yield self.log_records

--- a/src/stpipe/log.py
+++ b/src/stpipe/log.py
@@ -136,7 +136,7 @@ class LogConfig:
 
         raise ValueError(f"Can't parse handler {handler_str!r}")
 
-    def apply(self, log_names=None, recording_formatter=None):
+    def apply(self, log_names, recording_formatter):
         """
         Applies the configuration to known loggers.
 
@@ -156,10 +156,7 @@ class LogConfig:
             Log names to configure.  If not provided, only the
             STPIPE_ROOT_LOGGER is configured.
         """
-        if recording_formatter is not None:
-            self._recording_handler.setFormatter(recording_formatter)
-        if log_names is None:
-            log_names = [STPIPE_ROOT_LOGGER]
+        self._recording_handler.setFormatter(recording_formatter)
         if "py.warnings" in log_names:
             logging.captureWarnings(True)
         if "CRDS" in log_names:
@@ -218,7 +215,7 @@ class LogConfig:
             crds_log.add_console_handler()
 
     @contextmanager
-    def context(self, log_names=None, recording_formatter=None):
+    def context(self, log_names, recording_formatter):
         """
         Context manager that applies the configuration to the known loggers.
 
@@ -227,7 +224,6 @@ class LogConfig:
         log_names : list of str or None, optional
             Log names to pass to `apply` and `undo` methods.
         """
-        log_names = log_names or [STPIPE_ROOT_LOGGER]
         self.apply(log_names, recording_formatter)
         try:
             yield self.log_records

--- a/src/stpipe/log.py
+++ b/src/stpipe/log.py
@@ -105,11 +105,14 @@ class LogConfig:
         # add recording handler
         self._recording_handler = RecordingHandler(level=recording_level)
         if recording_formatter is not None:
-            self._recording_handler.setFormatter(recording_formatter)
+            self.set_recording_formatter(recording_formatter)
         self.handlers.append(self._recording_handler)
 
         self._previous_level = {}
         self._previous_crds_console = False
+
+    def set_recording_formatter(self, formatter):
+        self._recording_handler.setFormatter(formatter)
 
     @property
     def log_records(self):
@@ -136,7 +139,7 @@ class LogConfig:
 
         raise ValueError(f"Can't parse handler {handler_str!r}")
 
-    def apply(self, log_names, recording_formatter):
+    def apply(self, log_names):
         """
         Applies the configuration to known loggers.
 
@@ -156,7 +159,6 @@ class LogConfig:
             Log names to configure.  If not provided, only the
             STPIPE_ROOT_LOGGER is configured.
         """
-        self._recording_handler.setFormatter(recording_formatter)
         if "py.warnings" in log_names:
             logging.captureWarnings(True)
         if "CRDS" in log_names:
@@ -215,7 +217,7 @@ class LogConfig:
             crds_log.add_console_handler()
 
     @contextmanager
-    def context(self, log_names, recording_formatter):
+    def context(self, log_names):
         """
         Context manager that applies the configuration to the known loggers.
 
@@ -224,7 +226,7 @@ class LogConfig:
         log_names : list of str or None, optional
             Log names to pass to `apply` and `undo` methods.
         """
-        self.apply(log_names, recording_formatter)
+        self.apply(log_names)
         try:
             yield self.log_records
         finally:

--- a/src/stpipe/log.py
+++ b/src/stpipe/log.py
@@ -55,8 +55,6 @@ class BreakHandler(logging.Handler):
     exceptions.
     """
 
-    _from_config = True
-
     def emit(self, record):
         raise LoggedException(record)
 

--- a/src/stpipe/log.py
+++ b/src/stpipe/log.py
@@ -169,7 +169,7 @@ class LogConfig:
             log.setLevel(self.level)
         LogConfig.applied = self
 
-    def undo(self, log_names=None, close_handlers=True):
+    def undo(self, log_names=None):
         """
         Removes the configuration from known loggers.
 
@@ -190,9 +190,6 @@ class LogConfig:
             This parameter is ignored if log configuration has been
             previously applied by this instance: in that case,
             only the previously affected logs are unconfigured.
-        close_handlers : bool, optional
-            If True, handlers will be closed as well as removed from
-            the named loggers.
         """
         if LogConfig.applied is self:
             log_names = list(self._previous_level.keys())
@@ -202,8 +199,7 @@ class LogConfig:
             log = logging.getLogger(log_name)
             for handler in self.handlers:
                 handler.flush()
-                if close_handlers:
-                    handler.close()
+                handler.close()
                 log.removeHandler(handler)
             if LogConfig.applied is self and log_name in self._previous_level:
                 log.setLevel(self._previous_level[log_name])

--- a/src/stpipe/log.py
+++ b/src/stpipe/log.py
@@ -177,8 +177,10 @@ class LogConfig:
                 log.addHandler(handler)
 
             # Set the log level
+            # we still track level since undo uses this to remove handlers
             self._previous_level[log_name] = log.level
-            log.setLevel(self.level)
+            if self.level is not logging.NOTSET:
+                log.setLevel(self.level)
         LogConfig.applied = self
 
     def undo(self, log_names=None):
@@ -236,7 +238,7 @@ class LogConfig:
         """
         self.apply(log_names, recording_formatter)
         try:
-            yield
+            yield self.log_records
         finally:
             self.undo(log_names)
 
@@ -355,21 +357,3 @@ class RecordingHandler(logging.Handler):
     def emit(self, record):
         if self.formatter is not None:
             self._log_records.append(self.formatter.format(record))
-
-
-@contextmanager
-def record_logs(log_names, level=logging.NOTSET, formatter=None):
-    if formatter is None:
-        yield []
-    else:
-        handler = RecordingHandler(level=level)
-        handler.setFormatter(formatter)
-        for log_name in log_names:
-            logger = logging.getLogger(log_name)
-            logger.addHandler(handler)
-        try:
-            yield handler.log_records
-        finally:
-            for log_name in log_names:
-                logger = logging.getLogger(log_name)
-                logger.removeHandler(handler)

--- a/src/stpipe/log.py
+++ b/src/stpipe/log.py
@@ -83,6 +83,8 @@ class LogConfig:
         handler,
         level=logging.INFO,
         break_level=logging.NOTSET,
+        recording_level=logging.NOTSET,
+        recording_formatter=None,
         format=None,  # noqa: A002
     ):
         if isinstance(handler, str):
@@ -100,8 +102,18 @@ class LogConfig:
         if self.break_level != logging.NOTSET:
             self.handlers.append(BreakHandler(self.break_level))
 
+        # add recording handler
+        self._recording_handler = RecordingHandler(level=recording_level)
+        if recording_formatter is not None:
+            self._recording_handler.setFormatter(recording_formatter)
+        self.handlers.append(self._recording_handler)
+
         self._previous_level = {}
         self._previous_crds_console = False
+
+    @property
+    def log_records(self):
+        return self._recording_handler.log_records
 
     def get_handler(self, handler_str):
         """
@@ -124,7 +136,7 @@ class LogConfig:
 
         raise ValueError(f"Can't parse handler {handler_str!r}")
 
-    def apply(self, log_names=None):
+    def apply(self, log_names=None, recording_formatter=None):
         """
         Applies the configuration to known loggers.
 
@@ -144,6 +156,8 @@ class LogConfig:
             Log names to configure.  If not provided, only the
             STPIPE_ROOT_LOGGER is configured.
         """
+        if recording_formatter is not None:
+            self._recording_handler.setFormatter(recording_formatter)
         if log_names is None:
             log_names = [STPIPE_ROOT_LOGGER]
         if "py.warnings" in log_names:
@@ -211,7 +225,7 @@ class LogConfig:
             crds_log.add_console_handler()
 
     @contextmanager
-    def context(self, log_names=None):
+    def context(self, log_names=None, recording_formatter=None):
         """
         Context manager that applies the configuration to the known loggers.
 
@@ -220,7 +234,7 @@ class LogConfig:
         log_names : list of str or None, optional
             Log names to pass to `apply` and `undo` methods.
         """
-        self.apply(log_names)
+        self.apply(log_names, recording_formatter)
         try:
             yield
         finally:

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -497,7 +497,12 @@ class Step:
                 level=logging.NOTSET,
                 recording_formatter=self._log_records_formatter,
             ).context(
-                log_names=self.get_stpipe_loggers(),
+                # skip applying py.warnings to reproduce the bug on stpipe main
+                # where warnings were not captured on logs when call
+                # is passed configure_log=False
+                log_names=[
+                    name for name in self.get_stpipe_loggers() if name != "py.warnings"
+                ],
             )
         else:
             ctx = nullcontext(log.LogConfig.applied.log_records)

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -492,9 +492,12 @@ class Step:
 
         # if run is called directly attach handlers to record logs
         if log.LogConfig.applied is None:
-            ctx = log.LogConfig([], level=logging.NOTSET).context(
-                log_names=self.get_stpipe_loggers(),
+            ctx = log.LogConfig(
+                [],
+                level=logging.NOTSET,
                 recording_formatter=self._log_records_formatter,
+            ).context(
+                log_names=self.get_stpipe_loggers(),
             )
         else:
             ctx = nullcontext(log.LogConfig.applied.log_records)
@@ -736,18 +739,16 @@ class Step:
                     f"Error parsing logging config {kwargs['logcfg']}"
                 ) from e
             del kwargs["logcfg"]
+            log_cfg.set_recording_formatter(cls._log_records_formatter)
         elif configure_log and log.LogConfig.applied is None:
             # Load a default configuration
             log_cfg = log.load_configuration(
                 config_file=log._find_logging_config_file()
             )
+            log_cfg.set_recording_formatter(cls._log_records_formatter)
         else:
             log_cfg = None
-        ctx = (
-            nullcontext
-            if log_cfg is None
-            else lambda: log_cfg.context(log_names, cls._log_records_formatter)
-        )
+        ctx = nullcontext if log_cfg is None else lambda: log_cfg.context(log_names)
 
         with ctx():
             config, config_file = cls.build_config(filename, **kwargs)
@@ -759,7 +760,8 @@ class Step:
                 if log_cfg is not None:
                     log_cfg.undo(log_names)
                 log_cfg = log.load_configuration(config["logcfg"])
-                log_cfg.apply(log_names, cls._log_records_formatter)
+                log_cfg.set_recording_formatter(cls._log_records_formatter)
+                log_cfg.apply(log_names)
 
             if "class" in config:
                 del config["class"]

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -492,9 +492,9 @@ class Step:
 
         # if run is called directly attach handlers to record logs
         if log.LogConfig.applied is None:
-            ctx = log.record_logs(
+            ctx = log.LogConfig([], level=logging.NOTSET).context(
                 log_names=self.get_stpipe_loggers(),
-                formatter=self._log_records_formatter,
+                recording_formatter=self._log_records_formatter,
             )
         else:
             ctx = nullcontext(log.LogConfig.applied.log_records)

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -490,9 +490,15 @@ class Step:
         """
         gc.collect()
 
-        with log.record_logs(
-            log_names=self.get_stpipe_loggers(), formatter=self._log_records_formatter
-        ) as log_records:
+        # if run is called directly attach handlers to record logs
+        if log.LogConfig.applied is None:
+            ctx = log.record_logs(
+                log_names=self.get_stpipe_loggers(),
+                formatter=self._log_records_formatter,
+            )
+        else:
+            ctx = nullcontext(log.LogConfig.applied.log_records)
+        with ctx as log_records:
             self._log_records = log_records
 
             step_result = None
@@ -737,9 +743,13 @@ class Step:
             )
         else:
             log_cfg = None
-        ctx = nullcontext if log_cfg is None else log_cfg.context
+        ctx = (
+            nullcontext
+            if log_cfg is None
+            else lambda: log_cfg.context(log_names, cls._log_records_formatter)
+        )
 
-        with ctx(log_names):
+        with ctx():
             config, config_file = cls.build_config(filename, **kwargs)
 
             if "logcfg" in config:
@@ -749,7 +759,7 @@ class Step:
                 if log_cfg is not None:
                     log_cfg.undo(log_names)
                 log_cfg = log.load_configuration(config["logcfg"])
-                log_cfg.apply(log_names)
+                log_cfg.apply(log_names, cls._log_records_formatter)
 
             if "class" in config:
                 del config["class"]

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -203,26 +203,6 @@ def test_configuration_apply(capsys):
     assert capt.err.count(other_msg) == 0
 
 
-@pytest.mark.parametrize("log_names", [None, ["stpipe"]])
-def test_configuration_undo(capsys, log_names):
-    log_cfg = stpipe_log.LogConfig(["stderr"], level="INFO")
-    stpipe_logger = logging.getLogger("stpipe")
-    stpipe_msg = "stpipe message"
-
-    # If the log_cfg handler is attached to a logger without going
-    # through "apply", it can still be removed with undo.
-    stpipe_logger.addHandler(log_cfg.handlers[0])
-
-    stpipe_logger.info(stpipe_msg)
-    capt = capsys.readouterr()
-    assert capt.err.count(stpipe_msg) == 1
-
-    log_cfg.undo(log_names)
-    stpipe_logger.info(stpipe_msg)
-    capt = capsys.readouterr()
-    assert capt.err.count(stpipe_msg) == 0
-
-
 @pytest.mark.parametrize(
     "level, expected",
     (

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -378,7 +378,7 @@ def test_just_the_step_from_cmdline_no_root_logger_changes(
     # By default, no log configuration is applied or available in the
     # parameters.  If apply_log_cfg is True, it *will* modify the
     # root logger.
-    stpipe.cmdline.just_the_step_from_cmdline(
+    stpipe.cmdline._just_the_step_from_cmdline(
         ["test_logger.LoggingPipeline"], apply_log_cfg=False
     )
 

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -146,7 +146,7 @@ format = '%(message)s'
         fd.seek(0)
         log_cfg = stpipe_log.load_configuration(fd)
 
-    with log_cfg.context(["stpipe"], ""):
+    with log_cfg.context(["stpipe"]):
         log = logging.getLogger(stpipe_log.STPIPE_ROOT_LOGGER)
 
         log.info("Hidden")
@@ -171,7 +171,7 @@ def test_configuration_apply(capsys):
     other_msg = "other message"
 
     # By default, only stpipe is configured
-    log_cfg.apply(["stpipe"], "")
+    log_cfg.apply(["stpipe"])
     stpipe_logger.info(stpipe_msg)
     other_logger.info(other_msg)
     capt = capsys.readouterr()
@@ -179,7 +179,7 @@ def test_configuration_apply(capsys):
     assert capt.err.count(other_msg) == 0
 
     # Calling again does not attach a duplicate handler
-    log_cfg.apply(["stpipe"], "")
+    log_cfg.apply(["stpipe"])
     stpipe_logger.info(stpipe_msg)
     other_logger.info(other_msg)
     capt = capsys.readouterr()
@@ -187,7 +187,7 @@ def test_configuration_apply(capsys):
     assert capt.err.count(other_msg) == 0
 
     # Other logger can be added to the configuration
-    log_cfg.apply(["other"], "")
+    log_cfg.apply(["other"])
     stpipe_logger.info(stpipe_msg)
     other_logger.info(other_msg)
     capt = capsys.readouterr()

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -372,17 +372,6 @@ def test_step_from_cmdline_no_root_logger_changes_level_arg(
     )
 
 
-def test_just_the_step_from_cmdline_no_root_logger_changes(
-    log_cfg_path, root_logger_unchanged
-):
-    # By default, no log configuration is applied or available in the
-    # parameters.  If apply_log_cfg is True, it *will* modify the
-    # root logger.
-    stpipe.cmdline._just_the_step_from_cmdline(
-        ["test_logger.LoggingPipeline"], apply_log_cfg=False
-    )
-
-
 def test_logging_delegation(capsys, root_logger_unchanged):
     """
     Python 3.13.3 and 3.13.4 have a bug where logging within a logger

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -195,7 +195,7 @@ def test_configuration_apply(capsys):
     assert capt.err.count(other_msg) == 1
 
     # Calling undo removes configuration from both
-    log_cfg.undo()
+    log_cfg.undo((*log_cfg._previous_level.keys(), "other"))
     stpipe_logger.info(stpipe_msg)
     other_logger.info(other_msg)
     capt = capsys.readouterr()
@@ -221,37 +221,6 @@ def test_configuration_undo(capsys, log_names):
     stpipe_logger.info(stpipe_msg)
     capt = capsys.readouterr()
     assert capt.err.count(stpipe_msg) == 0
-
-
-def test_record_logs():
-    """
-    Test that record_logs respects the default configuration
-    """
-    stpipe_logger = logging.getLogger(stpipe_log.STPIPE_ROOT_LOGGER)
-    root_logger = logging.getLogger()
-
-    assert not any(
-        isinstance(h, stpipe_log.RecordingHandler) for h in root_logger.handlers
-    )
-
-    with stpipe_log.record_logs(
-        log_names=[""], level=logging.ERROR, formatter=logging.Formatter("%(message)s")
-    ) as log_records:
-        stpipe_logger.warning("Warning from stpipe")
-        stpipe_logger.error("Error from stpipe")
-        root_logger.warning("Warning from root")
-        root_logger.error("Error from root")
-
-    assert not any(
-        isinstance(h, stpipe_log.RecordingHandler) for h in root_logger.handlers
-    )
-
-    stpipe_logger.error("Additional error from stpipe")
-    root_logger.error("Additional error from root")
-
-    assert len(log_records) == 2
-    assert log_records[0] == "Error from stpipe"
-    assert log_records[1] == "Error from root"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -146,7 +146,7 @@ format = '%(message)s'
         fd.seek(0)
         log_cfg = stpipe_log.load_configuration(fd)
 
-    with log_cfg.context():
+    with log_cfg.context(["stpipe"], ""):
         log = logging.getLogger(stpipe_log.STPIPE_ROOT_LOGGER)
 
         log.info("Hidden")
@@ -171,7 +171,7 @@ def test_configuration_apply(capsys):
     other_msg = "other message"
 
     # By default, only stpipe is configured
-    log_cfg.apply()
+    log_cfg.apply(["stpipe"], "")
     stpipe_logger.info(stpipe_msg)
     other_logger.info(other_msg)
     capt = capsys.readouterr()
@@ -179,7 +179,7 @@ def test_configuration_apply(capsys):
     assert capt.err.count(other_msg) == 0
 
     # Calling again does not attach a duplicate handler
-    log_cfg.apply()
+    log_cfg.apply(["stpipe"], "")
     stpipe_logger.info(stpipe_msg)
     other_logger.info(other_msg)
     capt = capsys.readouterr()
@@ -187,7 +187,7 @@ def test_configuration_apply(capsys):
     assert capt.err.count(other_msg) == 0
 
     # Other logger can be added to the configuration
-    log_cfg.apply(log_names=["other"])
+    log_cfg.apply(["other"], "")
     stpipe_logger.info(stpipe_msg)
     other_logger.info(other_msg)
     capt = capsys.readouterr()
@@ -195,7 +195,7 @@ def test_configuration_apply(capsys):
     assert capt.err.count(other_msg) == 1
 
     # Calling undo removes configuration from both
-    log_cfg.undo((*log_cfg._previous_level.keys(), "other"))
+    log_cfg.undo(["stpipe", "other"])
     stpipe_logger.info(stpipe_msg)
     other_logger.info(other_msg)
     capt = capsys.readouterr()

--- a/tests/test_record_logs.py
+++ b/tests/test_record_logs.py
@@ -1,0 +1,87 @@
+import logging
+
+import asdf
+
+from stpipe import Step, config_parser
+
+logger = logging.getLogger("stpipe.tests.test_test_record_logs")
+
+
+class DataModel:
+    crds_observatory = "jwst"
+
+    def __init__(self):
+        self.data = {}
+        self.filename = ""
+
+    def get_crds_parameters(self):
+        return self.data
+
+    @classmethod
+    def from_asdf(cls, init):
+        m = cls()
+        with asdf.open(init) as af:
+            m.data = af.tree
+        m.filename = init
+        return m
+
+    def save(self, fn, *args, **kwargs):
+        # ignore filename to make the from_cmdline test below simpler
+        if self.filename:
+            fn = self.filename
+        asdf.AsdfFile(self.data).write_to(fn)
+
+
+class LoggingStep(Step):
+    """A Step that utilizes a local logger to log a warning."""
+
+    spec = """
+        message = string(default='message')
+        output_ext = string(default='loggingstep')
+    """
+    _log_records_formatter = logging.Formatter("%(message)s")
+
+    def process(self, init):
+        if isinstance(init, str):
+            init = DataModel.from_asdf(init)
+        logger.warning(self.message)
+        return init
+
+    def _datamodels_open(self, init, *args, **kwargs):
+        if not isinstance(init, str):
+            return init
+        return DataModel.from_asdf(init)
+
+    @classmethod
+    def get_config_from_reference(cls, dataset, disable=None, crds_observatory=None):
+        logger.warning("get_config_from_reference")
+        return config_parser.ConfigObj()
+
+    def finalize_result(self, result, reference_files_used):
+        result.data["logs"] = self.log_records.copy()
+
+    @staticmethod
+    def get_stpipe_loggers():
+        return ("stpipe", "external")
+
+
+def test_run():
+    m = DataModel()
+    LoggingStep().run(m)
+    assert "message" in m.data["logs"]
+
+
+def test_call():
+    m = DataModel()
+    LoggingStep.call(m)
+    assert "message" in m.data["logs"]
+    assert "get_config_from_reference" in m.data["logs"]
+
+
+def test_from_cmdline(tmp_path):
+    fn = str(tmp_path / "test.asdf")
+    DataModel().save(fn)
+    Step.from_cmdline(["test_record_logs.LoggingStep", fn])
+    m = DataModel.from_asdf(fn)
+    assert "message" in m.data["logs"]
+    assert "get_config_from_reference" in m.data["logs"]

--- a/tests/test_record_logs.py
+++ b/tests/test_record_logs.py
@@ -2,6 +2,7 @@ import logging
 
 import asdf
 
+import stpipe
 from stpipe import Step, config_parser
 
 logger = logging.getLogger("stpipe.tests.test_test_record_logs")
@@ -85,3 +86,23 @@ def test_from_cmdline(tmp_path):
     m = DataModel.from_asdf(fn)
     assert "message" in m.data["logs"]
     assert "get_config_from_reference" in m.data["logs"]
+
+
+def test_record_logs():
+    stpipe_logger = logging.getLogger(stpipe.log.STPIPE_ROOT_LOGGER)
+    root_logger = logging.getLogger()
+
+    for logger in (stpipe_logger, root_logger):
+        assert not any(
+            isinstance(h, stpipe.log.RecordingHandler) for h in logger.handlers
+        )
+
+    m = DataModel()
+    LoggingStep().run(m)
+
+    for logger in (stpipe_logger, root_logger):
+        assert not any(
+            isinstance(h, stpipe.log.RecordingHandler) for h in logger.handlers
+        )
+
+    assert "message" in m.data["logs"]

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -293,15 +293,13 @@ def test_step_list_args(config_file_list_arg_step):
 
     c, *_ = cmdline.just_the_step_from_cmdline(
         [
+            returned_config_file,
             "filename.fits",
             "--output_shape",
             "1500,1300",
             "--crpix=123,456",
             "--pixel_scale=0.75",
-            "--config-file",
-            returned_config_file,
         ],
-        ListArgStep,
     )
     assert c.rotation is None
     assert c.pixel_scale == 0.75
@@ -317,15 +315,13 @@ def test_step_list_args(config_file_list_arg_step):
     with pytest.raises(ValueError, match=msg):
         cmdline.just_the_step_from_cmdline(
             [
+                returned_config_file,
                 "filename.fits",
                 "--output_shape",
                 "1500,1300,90",
                 "--crpix=123,456",
                 "--pixel_scale=0.75",
-                "--config-file",
-                returned_config_file,
             ],
-            ListArgStep,
         )
 
     msg = re.escape(
@@ -334,15 +330,13 @@ def test_step_list_args(config_file_list_arg_step):
     with pytest.raises(ValueError, match=msg):
         cmdline.just_the_step_from_cmdline(
             [
+                returned_config_file,
                 "filename.fits",
                 "--output_shape",
                 "1500,",
                 "--crpix=123,456",
                 "--pixel_scale=0.75",
-                "--config-file",
-                returned_config_file,
             ],
-            ListArgStep,
         )
 
     msg = re.escape(
@@ -351,15 +345,13 @@ def test_step_list_args(config_file_list_arg_step):
     with pytest.raises(ValueError, match=msg):
         cmdline.just_the_step_from_cmdline(
             [
+                returned_config_file,
                 "filename.fits",
                 "--output_shape",
                 "1500",
                 "--crpix=123,456",
                 "--pixel_scale=0.75",
-                "--config-file",
-                returned_config_file,
             ],
-            ListArgStep,
         )
 
     msg = re.escape(
@@ -368,15 +360,13 @@ def test_step_list_args(config_file_list_arg_step):
     with pytest.raises(ValueError, match=msg):
         cmdline.just_the_step_from_cmdline(
             [
+                returned_config_file,
                 "filename.fits",
                 "--output_shape",
                 "1500.5,1300.2",
                 "--crpix=123,456",
                 "--pixel_scale=0.75",
-                "--config-file",
-                returned_config_file,
             ],
-            ListArgStep,
         )
 
 

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -74,6 +74,9 @@ class ListArgStep(Step):
         output_ext = string(default='listargstep')
     """
 
+    def process(self, *args, **kwargs):
+        pass
+
 
 @pytest.fixture()
 def config_file_pipe(tmp_path):
@@ -291,7 +294,7 @@ def test_step_list_args(config_file_list_arg_step):
     # Command line tests below need the config file path to be a string
     returned_config_file = str(returned_config_file)
 
-    c, *_ = cmdline.just_the_step_from_cmdline(
+    c = cmdline.step_from_cmdline(
         [
             returned_config_file,
             "filename.fits",
@@ -313,7 +316,7 @@ def test_step_list_args(config_file_list_arg_step):
         "is too long."
     )
     with pytest.raises(ValueError, match=msg):
-        cmdline.just_the_step_from_cmdline(
+        cmdline.step_from_cmdline(
             [
                 returned_config_file,
                 "filename.fits",
@@ -328,7 +331,7 @@ def test_step_list_args(config_file_list_arg_step):
         "Config parameter 'output_shape': the value \"['1500']\" is too short."
     )
     with pytest.raises(ValueError, match=msg):
-        cmdline.just_the_step_from_cmdline(
+        cmdline.step_from_cmdline(
             [
                 returned_config_file,
                 "filename.fits",
@@ -343,7 +346,7 @@ def test_step_list_args(config_file_list_arg_step):
         "Config parameter 'output_shape': the value \"1500\" is of the wrong type."
     )
     with pytest.raises(ValueError, match=msg):
-        cmdline.just_the_step_from_cmdline(
+        cmdline.step_from_cmdline(
             [
                 returned_config_file,
                 "filename.fits",
@@ -358,7 +361,7 @@ def test_step_list_args(config_file_list_arg_step):
         "Config parameter 'output_shape': the value \"1500.5\" is of the wrong type."
     )
     with pytest.raises(ValueError, match=msg):
-        cmdline.just_the_step_from_cmdline(
+        cmdline.step_from_cmdline(
             [
                 returned_config_file,
                 "filename.fits",


### PR DESCRIPTION
https://github.com/spacetelescope/stpipe/pull/315 removed the unused `step_script` method from `cmdline`. It's removal allows for some cleanup in cmdline including:
- removal of the now un-used `cls` method from `just_the_step_from_cmdline` (more on this below) which allows removal of `cls` from `_build_parent_arg_parser`
- `just_the_step_from_cmdline` is only (directly) used in stpipe unit tests, there is no romancal or jwst usage, at the moment this PR removes it (and replaces the usage in the unit tests with the used `step_from_cmdline`)
- the above allows some cleanup of the argparsers in cmdline including
  - removal of `apply_log_config` arguments (also removed in all cmdline methods)
  - split parsing of logs/class (to allow easier integration of logging to capture pre-pipeline logs)
- the above changes (mainly the easier logging integration) allowed some cleanup of the logging
  - removal of `record_logs` (this is now handled by `LogConfig`)
  - require `log_names` for `apply` and `undo`
  - removal of `close_handlers` argument to `undo`

These changes also allow attaching the log recording handler earlier in the step/pipeline execution process allowing pre-pipeline logs to be captured for strun and call usage.

On main running `Step.call(configure_log=False)` fails to capture warnings in the recorded logs (following https://github.com/spacetelescope/stpipe/pull/271). This PR retains that behavior (see https://github.com/spacetelescope/stpipe/pull/317/commits/28aeeb11ce436aac438112677217339804286ccc). If we want to fix that issue, we'll need to update one jwst test:
https://github.com/spacetelescope/jwst/blob/4728a31f536c3339b33f2ef694d41d9616644d37/jwst/emicorr/tests/test_emicorr.py#L353
since the captured deprecation warning won't get captured by pytest.warns (due to a poor interaction between pytest and logging). If we revert the above commit and remove the `pytest.warns` (which will need to be replaced by a filterwarnings for the message to avoid the uncaught warnings turning into an error) the warning will correctly appear twice in the log (since jwst emits identical warning and a log.warning messages). On main (and with this PR with the above commit) the warning message appears only once in the cal_logs due to only the log.warning message being captured.

regtests
romancal: https://github.com/spacetelescope/RegressionTests/actions/runs/26038917156
jwst: https://github.com/spacetelescope/RegressionTests/actions/runs/26038956800

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [x] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stpipe/blob/main/changes/README.rst) for instructions)
  - [x] run regression tests with this branch installed (`stpipe@git+https://github.com/<fork>/stpipe.git@<branch>`)
    - [x] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [x] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
