### PR TITLE
Move unit tests from jwst

### DIFF
--- a/tests/steps/__init__.py
+++ b/tests/steps/__init__.py
@@ -2,11 +2,6 @@ import logging
 
 from stpipe import Pipeline, Step
 
-# from stdatamodels.jwst import datamodels
-# from stdatamodels.jwst.datamodels import ImageModel
-# from jwst.datamodels import ModelContainer
-
-
 log = logging.getLogger("stpipe.tests.steps")
 
 
@@ -21,55 +16,6 @@ class BaseStep(Step):
 
 class BasePipeline(Pipeline, BaseStep):
     pass
-
-
-# class StepWithReference(Step):
-#     """Step that refers to a reference file."""
-#
-#     reference_file_types = ["flat"]
-#
-#     def process(self, data):  # noqa: D102
-#         return data
-#
-#
-# class PipeWithReference(Pipeline):
-#     """Pipeline calling step with reference."""
-#
-#     spec = """
-#     """
-#
-#     step_defs = {"step_with_reference": StepWithReference}
-#
-#     def process(self, data):  # noqa: D102
-#         result = self.step_with_reference.run(data)
-#
-#         return result
-#
-#
-# class AnotherDummyStep(Step):
-#     """Do-nothing step that demonstrates configuration argument parsing."""
-#
-#     spec = """
-#     par1 = float() # Control the frobulization
-#
-#     par2 = string() # Reticulate the splines
-#
-#     par3 = boolean(default=False) # Does it blend?
-#
-#     [foo]
-#
-#     """
-#     class_alias = "stpipe_dummy"
-#
-#     reference_file_types = ["flat_field"]
-#
-#     def process(self, a=0, b=0):  # noqa: D102
-#         log.info(f"Found a: {a}, b: {b}")
-#         log.info(f"par1: {self.par1}")
-#         log.info(f"par2: {self.par2}")
-#         log.info(f"par3: {self.par3}")
-#
-#         return a + b
 
 
 class WithDefaultsStep(BaseStep):
@@ -117,108 +63,6 @@ class MakeListStep(BaseStep):
         return result
 
 
-# class OptionalRefTypeStep(Step):
-#     """Do-nothing step that demonstrates optionally omitting a reference file."""
-#
-#     reference_file_types = ["to_be_ignored_ref_type"]
-#
-#     def process(self):  # noqa: D102
-#         ref_file = self.get_reference_file(
-#              datamodels.JwstDataModel(), "to_be_ignored_ref_type")
-#         assert ref_file == ""  # noqa: S101
-#
-#
-# class PostHookStep(Step):
-#     """A step to try out hooks."""
-#
-#     spec = """
-#     """
-#
-#     def process(self, *args):  # noqa: D102
-#         log.info(f'Received args: "{args}"')
-#         log.info(f'Self.parent = "{self.parent}"')
-#
-#         args[0].post_hook_run = True
-#         self.parent.post_hook_run = True
-#
-#
-# class PostHookWithReturnStep(Step):
-#     """A step to try out hooks."""
-#
-#     spec = """
-#     """
-#
-#     def process(self, *args):  # noqa: D102
-#         log.info(f'Received args: "{args}"')
-#         log.info(f'Self.parent = "{self.parent}"')
-#
-#         self.parent.post_hook_run = True
-#         return "PostHookWithReturnStep executed"
-#
-#
-# class PreHookStep(Step):
-#     """A step to try out hooks."""
-#
-#     spec = """
-#     """
-#
-#     def process(self, *args):  # noqa: D102
-#         log.info(f'Received args: "{args}"')
-#         log.info(f'Self.parent = "{self.parent}"')
-#
-#         args[0].pre_hook_run = True
-#         self.parent.pre_hook_run = True
-#
-#
-# class SaveStep(Step):
-#     """Step with explicit save."""
-#
-#     spec = """
-#     """
-#
-#     def process(self, *args):  # noqa: D102
-#         model = ImageModel(args[0])
-#
-#         log.info('Saving model as "processed"')
-#         self.save_model(model, "processed")
-#
-#         return model
-#
-#
-# class StepWithContainer(Step):
-#     """A step with a model."""
-#
-#     spec = """
-#     """
-#
-#     def process(self, *args):  # noqa: D102
-#         container = []
-#         if isinstance(args[0], ModelContainer):
-#             model = args[0][0]
-#         else:
-#             model = args[0]
-#         model1 = ImageModel(model).copy()
-#         model2 = ImageModel(model).copy()
-#         model1.meta.filename = "swc_model1.fits"
-#         model2.meta.filename = "swc_model2.fits"
-#         container.append(model1)
-#         container.append(model2)
-#
-#         return container
-#
-#
-# class StepWithModel(Step):
-#     """A step with a model."""
-#
-#     spec = """
-#     """
-#
-#     def process(self, *args):  # noqa: D102
-#         model = self.open_model(args[0])
-#         model = ImageModel(model)
-#         return model
-#
-#
 class EmptyPipeline(BasePipeline):
     """A pipeline that has no substeps."""
 
@@ -228,53 +72,6 @@ class EmptyPipeline(BasePipeline):
 
     def process(self, *args):  # noqa: D102
         return args
-
-
-# class ProperPipeline(Pipeline):
-#     """Pipeline with proper output setup."""
-#
-#     spec = """
-#     """
-#
-#     step_defs = {
-#         "stepwithmodel": StepWithModel,
-#         "another_stepwithmodel": StepWithModel,
-#         "stepwithcontainer": StepWithContainer,
-#         "withdefaultsstep": WithDefaultsStep,
-#     }
-#
-#     def process(self, *args):  # noqa: D102
-#         self.suffix = "pp"
-#
-#         model = ImageModel(args[0])
-#
-#         self.stepwithmodel.suffix = "swm"
-#         r = self.stepwithmodel.run(model)
-#         self.another_stepwithmodel.suffix = "aswm"
-#         r = self.another_stepwithmodel.run(r)
-#         self.stepwithcontainer.suffix = "swc"
-#         r = self.stepwithcontainer.run(r)
-#         self.withdefaultsstep.suffix = "wds"
-#         r = self.withdefaultsstep.run(r)
-#
-#         return r
-#
-#
-# class SavePipeline(Pipeline):
-#     """Save model in pipeline."""
-#
-#     spec = """
-#     """
-#
-#     step_defs = {"stepwithmodel": StepWithModel, "savestep": SaveStep}
-#
-#     def process(self, *args):  # noqa: D102
-#         model = ImageModel(args[0])
-#
-#         r = self.stepwithmodel.run(model)
-#         r = self.savestep.run(r)
-#
-#         return r
 
 
 class MakeListPipeline(BasePipeline):
@@ -290,29 +87,3 @@ class MakeListPipeline(BasePipeline):
 
     def process(self, *args):  # noqa: D102
         return self.make_list.run(*args)
-
-
-# class CalLogsStep(Step):
-#     """Step for testing cal_logs."""
-#
-#     class_alias = "cal_logs_step"
-#
-#     def process(self, msg):  # noqa: D102
-#         from stdatamodels.jwst.datamodels import ImageModel
-#
-#         log.info(msg)
-#         return ImageModel()
-#
-#
-# class CalLogsPipeline(Pipeline):
-#     """Pipeline for testing cal_logs."""
-#
-#     class_alias = "cal_logs_pipeline"
-#
-#     step_defs = {
-#         "a_step": CalLogsStep,
-#     }
-#
-#     def process(self, msg):  # noqa: D102
-#         log.info(msg)
-#         return self.a_step.run(msg)

--- a/tests/steps/__init__.py
+++ b/tests/steps/__init__.py
@@ -12,7 +12,7 @@ log = logging.getLogger("stpipe.tests.steps")
 
 class BaseStep(Step):
     spec = """
-        output_ext = string(default='asdf')
+        output_ext = string(default='.asdf')
     """
 
     def _datamodels_open(self, **kwargs):
@@ -219,17 +219,17 @@ class MakeListStep(BaseStep):
 #         return model
 #
 #
-# class EmptyPipeline(Pipeline):
-#     """A pipeline that has no substeps."""
-#
-#     spec = """
-#     par1 = string(default='Name the atomizer') # Control the frobulization
-#     """
-#
-#     def process(self, *args):  # noqa: D102
-#         return args
-#
-#
+class EmptyPipeline(BasePipeline):
+    """A pipeline that has no substeps."""
+
+    spec = """
+    par1 = string(default='Name the atomizer') # Control the frobulization
+    """
+
+    def process(self, *args):  # noqa: D102
+        return args
+
+
 # class ProperPipeline(Pipeline):
 #     """Pipeline with proper output setup."""
 #
@@ -282,7 +282,6 @@ class MakeListPipeline(BasePipeline):
 
     spec = """
     par1 = string(default='Name the atomizer') # Control the frobulization
-    output_ext = string(default='asdf')
     """
 
     step_defs = {

--- a/tests/steps/__init__.py
+++ b/tests/steps/__init__.py
@@ -1,0 +1,312 @@
+import logging
+
+from stpipe import Pipeline, Step
+
+# from stdatamodels.jwst import datamodels
+# from stdatamodels.jwst.datamodels import ImageModel
+# from jwst.datamodels import ModelContainer
+
+
+log = logging.getLogger("stpipe.tests.steps")
+
+
+class BaseStep(Step):
+    spec = """
+        output_ext = string(default='asdf')
+    """
+
+
+# class StepWithReference(Step):
+#     """Step that refers to a reference file."""
+#
+#     reference_file_types = ["flat"]
+#
+#     def process(self, data):  # noqa: D102
+#         return data
+#
+#
+# class PipeWithReference(Pipeline):
+#     """Pipeline calling step with reference."""
+#
+#     spec = """
+#     """
+#
+#     step_defs = {"step_with_reference": StepWithReference}
+#
+#     def process(self, data):  # noqa: D102
+#         result = self.step_with_reference.run(data)
+#
+#         return result
+#
+#
+# class AnotherDummyStep(Step):
+#     """Do-nothing step that demonstrates configuration argument parsing."""
+#
+#     spec = """
+#     par1 = float() # Control the frobulization
+#
+#     par2 = string() # Reticulate the splines
+#
+#     par3 = boolean(default=False) # Does it blend?
+#
+#     [foo]
+#
+#     """
+#     class_alias = "stpipe_dummy"
+#
+#     reference_file_types = ["flat_field"]
+#
+#     def process(self, a=0, b=0):  # noqa: D102
+#         log.info(f"Found a: {a}, b: {b}")
+#         log.info(f"par1: {self.par1}")
+#         log.info(f"par2: {self.par2}")
+#         log.info(f"par3: {self.par3}")
+#
+#         return a + b
+
+
+class WithDefaultsStep(BaseStep):
+    """A step that contains defaults for each of its pars."""
+
+    spec = """
+    par1 = string(default='default par1 value')
+    par2 = string(default='default par2 value')
+    par3 = string(default='default par3 value')
+    par4 = string(default='default par4 value')
+    """
+
+    def process(self, input_data):  # noqa: D102
+        log.info(
+            "Parameters par1=%s, par2=%s, par3=%s, par4=%s",
+            self.par1,
+            self.par2,
+            self.par3,
+            self.par3,
+        )
+
+        return input_data
+
+
+class MakeListStep(BaseStep):
+    """Make a list of all arguments and parameters."""
+
+    spec = """
+    par1 = float() # Control the frobulization
+    par2 = string() # Reticulate the splines
+    par3 = boolean(default=False) # Does it blend?
+    """
+
+    def process(self, a=None, b=None):  # noqa: D102
+        log.info("Arguments a=%s b=%s", a, b)
+        log.info(
+            "Parameters par1=%s, par2=%s, par3=%s", self.par1, self.par2, self.par3
+        )
+
+        result = [
+            item for item in [a, b, self.par1, self.par2, self.par3] if item is not None
+        ]
+
+        log.info("The list is %s", result)
+        return result
+
+
+# class OptionalRefTypeStep(Step):
+#     """Do-nothing step that demonstrates optionally omitting a reference file."""
+#
+#     reference_file_types = ["to_be_ignored_ref_type"]
+#
+#     def process(self):  # noqa: D102
+#         ref_file = self.get_reference_file(
+#              datamodels.JwstDataModel(), "to_be_ignored_ref_type")
+#         assert ref_file == ""  # noqa: S101
+#
+#
+# class PostHookStep(Step):
+#     """A step to try out hooks."""
+#
+#     spec = """
+#     """
+#
+#     def process(self, *args):  # noqa: D102
+#         log.info(f'Received args: "{args}"')
+#         log.info(f'Self.parent = "{self.parent}"')
+#
+#         args[0].post_hook_run = True
+#         self.parent.post_hook_run = True
+#
+#
+# class PostHookWithReturnStep(Step):
+#     """A step to try out hooks."""
+#
+#     spec = """
+#     """
+#
+#     def process(self, *args):  # noqa: D102
+#         log.info(f'Received args: "{args}"')
+#         log.info(f'Self.parent = "{self.parent}"')
+#
+#         self.parent.post_hook_run = True
+#         return "PostHookWithReturnStep executed"
+#
+#
+# class PreHookStep(Step):
+#     """A step to try out hooks."""
+#
+#     spec = """
+#     """
+#
+#     def process(self, *args):  # noqa: D102
+#         log.info(f'Received args: "{args}"')
+#         log.info(f'Self.parent = "{self.parent}"')
+#
+#         args[0].pre_hook_run = True
+#         self.parent.pre_hook_run = True
+#
+#
+# class SaveStep(Step):
+#     """Step with explicit save."""
+#
+#     spec = """
+#     """
+#
+#     def process(self, *args):  # noqa: D102
+#         model = ImageModel(args[0])
+#
+#         log.info('Saving model as "processed"')
+#         self.save_model(model, "processed")
+#
+#         return model
+#
+#
+# class StepWithContainer(Step):
+#     """A step with a model."""
+#
+#     spec = """
+#     """
+#
+#     def process(self, *args):  # noqa: D102
+#         container = []
+#         if isinstance(args[0], ModelContainer):
+#             model = args[0][0]
+#         else:
+#             model = args[0]
+#         model1 = ImageModel(model).copy()
+#         model2 = ImageModel(model).copy()
+#         model1.meta.filename = "swc_model1.fits"
+#         model2.meta.filename = "swc_model2.fits"
+#         container.append(model1)
+#         container.append(model2)
+#
+#         return container
+#
+#
+# class StepWithModel(Step):
+#     """A step with a model."""
+#
+#     spec = """
+#     """
+#
+#     def process(self, *args):  # noqa: D102
+#         model = self.open_model(args[0])
+#         model = ImageModel(model)
+#         return model
+#
+#
+# class EmptyPipeline(Pipeline):
+#     """A pipeline that has no substeps."""
+#
+#     spec = """
+#     par1 = string(default='Name the atomizer') # Control the frobulization
+#     """
+#
+#     def process(self, *args):  # noqa: D102
+#         return args
+#
+#
+# class ProperPipeline(Pipeline):
+#     """Pipeline with proper output setup."""
+#
+#     spec = """
+#     """
+#
+#     step_defs = {
+#         "stepwithmodel": StepWithModel,
+#         "another_stepwithmodel": StepWithModel,
+#         "stepwithcontainer": StepWithContainer,
+#         "withdefaultsstep": WithDefaultsStep,
+#     }
+#
+#     def process(self, *args):  # noqa: D102
+#         self.suffix = "pp"
+#
+#         model = ImageModel(args[0])
+#
+#         self.stepwithmodel.suffix = "swm"
+#         r = self.stepwithmodel.run(model)
+#         self.another_stepwithmodel.suffix = "aswm"
+#         r = self.another_stepwithmodel.run(r)
+#         self.stepwithcontainer.suffix = "swc"
+#         r = self.stepwithcontainer.run(r)
+#         self.withdefaultsstep.suffix = "wds"
+#         r = self.withdefaultsstep.run(r)
+#
+#         return r
+#
+#
+# class SavePipeline(Pipeline):
+#     """Save model in pipeline."""
+#
+#     spec = """
+#     """
+#
+#     step_defs = {"stepwithmodel": StepWithModel, "savestep": SaveStep}
+#
+#     def process(self, *args):  # noqa: D102
+#         model = ImageModel(args[0])
+#
+#         r = self.stepwithmodel.run(model)
+#         r = self.savestep.run(r)
+#
+#         return r
+
+
+class MakeListPipeline(Pipeline):
+    """A pipeline that calls MakeListStep."""
+
+    spec = """
+    par1 = string(default='Name the atomizer') # Control the frobulization
+    output_ext = string(default='asdf')
+    """
+
+    step_defs = {
+        "make_list": MakeListStep,
+    }
+
+    def process(self, *args):  # noqa: D102
+        return self.make_list.run(*args)
+
+
+# class CalLogsStep(Step):
+#     """Step for testing cal_logs."""
+#
+#     class_alias = "cal_logs_step"
+#
+#     def process(self, msg):  # noqa: D102
+#         from stdatamodels.jwst.datamodels import ImageModel
+#
+#         log.info(msg)
+#         return ImageModel()
+#
+#
+# class CalLogsPipeline(Pipeline):
+#     """Pipeline for testing cal_logs."""
+#
+#     class_alias = "cal_logs_pipeline"
+#
+#     step_defs = {
+#         "a_step": CalLogsStep,
+#     }
+#
+#     def process(self, msg):  # noqa: D102
+#         log.info(msg)
+#         return self.a_step.run(msg)

--- a/tests/steps/__init__.py
+++ b/tests/steps/__init__.py
@@ -15,6 +15,13 @@ class BaseStep(Step):
         output_ext = string(default='asdf')
     """
 
+    def _datamodels_open(self, **kwargs):
+        pass
+
+
+class BasePipeline(Pipeline, BaseStep):
+    pass
+
 
 # class StepWithReference(Step):
 #     """Step that refers to a reference file."""
@@ -270,7 +277,7 @@ class MakeListStep(BaseStep):
 #         return r
 
 
-class MakeListPipeline(Pipeline):
+class MakeListPipeline(BasePipeline):
     """A pipeline that calls MakeListStep."""
 
     spec = """

--- a/tests/steps/jwst_generic_pars-makeliststep_0001.asdf
+++ b/tests/steps/jwst_generic_pars-makeliststep_0001.asdf
@@ -1,0 +1,31 @@
+#ASDF 1.0.0
+#ASDF_STANDARD 1.3.0
+%YAML 1.1
+%TAG ! tag:stsci.edu:asdf/
+--- !core/asdf-1.1.0
+asdf_library: !core/software-1.0.0 {author: Space Telescope Science Institute, homepage: 'http://github.com/spacetelescope/asdf',
+  name: asdf, version: 2.3.3}
+history:
+  entries:
+  - !core/history_entry-1.0.0 {description: Baseline configuration file., time: !!timestamp '2019-07-18
+      20:01:09'}
+  extensions:
+  - !core/extension_metadata-1.0.0
+    extension_class: asdf.extension.BuiltinExtension
+    software: {name: asdf, version: 2.3.3}
+meta:
+  author: Alfred E. Neuman
+  date: '2019-07-17T10:56:23.456'
+  description: MakeListStep parameters
+  instrument: {name: GENERIC}
+  pedigree: GROUND
+  reftype: pars-makeliststep
+  telescope: JWST
+  title: MakeListStep default parameters
+  useafter: '1990-04-24T00:00:00'
+parameters:
+  class: steps.MakeListStep
+  name: make_list
+  par1: 42.0
+  par2: 'Yes, a string'
+...

--- a/tests/steps/jwst_generic_pars-makeliststep_0002.asdf
+++ b/tests/steps/jwst_generic_pars-makeliststep_0002.asdf
@@ -1,0 +1,44 @@
+#ASDF 1.0.0
+#ASDF_STANDARD 1.3.0
+%YAML 1.1
+%TAG ! tag:stsci.edu:asdf/
+--- !core/asdf-1.1.0
+asdf_library: !core/software-1.0.0 {author: Space Telescope Science Institute, homepage: 'http://github.com/spacetelescope/asdf',
+  name: asdf, version: 2.3.3}
+history:
+  entries:
+  - !core/history_entry-1.0.0 {description: Baseline configuration file., time: !!timestamp '2019-07-18
+      20:01:09'}
+  extensions:
+  - !core/extension_metadata-1.0.0
+    extension_class: asdf.extension.BuiltinExtension
+    software: {name: asdf, version: 2.3.3}
+meta:
+  author: Alfred E. Neuman
+  date: '2019-07-17T10:56:23.456'
+  description: MakeListStep parameters
+  instrument: {name: GENERIC}
+  pedigree: GROUND
+  reftype: pars-makeliststep
+  telescope: JWST
+  title: MakeListStep default parameters
+  useafter: '1990-04-24T00:00:00'
+parameters:
+  class: steps.MakeListStep
+  name: jwst_generic_pars-makeliststep_0002
+  input_dir: ''
+  output_dir: null
+  output_ext: .fits
+  output_file: null
+  output_use_index: true
+  output_use_model: false
+  par1: 42.0
+  par2: Yes, a string
+  par3: false
+  post_hooks: []
+  pre_hooks: []
+  save_results: false
+  search_output_file: true
+  skip: false
+  suffix: null
+...

--- a/tests/steps/local_class.cfg
+++ b/tests/steps/local_class.cfg
@@ -1,0 +1,4 @@
+class = 'steps.WithDefaultsStep'
+name = 'TestLocallyInstalledStepClass'
+
+par2 = "bar"

--- a/tests/steps/makelist.cfg
+++ b/tests/steps/makelist.cfg
@@ -1,0 +1,5 @@
+name = make_list
+class = steps.MakeListStep
+
+par1 = 43.0
+par2 = "My hovercraft is full of eels."

--- a/tests/steps/makelist_pipeline.cfg
+++ b/tests/steps/makelist_pipeline.cfg
@@ -1,0 +1,6 @@
+name = "foo_pipeline"
+class = "steps.FooPipeline"
+
+[steps]
+  [[make_list]]
+  config_file = makelist.cfg

--- a/tests/test_asdf_parameters.py
+++ b/tests/test_asdf_parameters.py
@@ -1,0 +1,149 @@
+"""Test initializing steps using ASDF and CRDS"""
+
+import pathlib
+
+import pytest
+
+from steps import MakeListPipeline, MakeListStep
+from stpipe import Step
+from stpipe.config_parser import ValidationError
+
+DEFAULT_PAR1 = 42.0
+DEFAULT_PAR2 = "Yes, a string"
+DEFAULT_RESULT = [DEFAULT_PAR1, DEFAULT_PAR2, False]
+
+_dir = pathlib.Path(__file__).parent
+
+
+def get_pkg_data_filename(fn):
+    return str(_dir / fn)
+
+
+def test_asdf_roundtrip_pipeline(tmp_cwd, disable_crds_steppars):
+    """Save a Pipeline pars and re-instantiate with the save parameters"""
+
+    # Save the parameters
+    par_path = "mkp_pars.asdf"
+    args = [
+        "steps.MakeListPipeline",
+        "a.fits",
+        "b",
+        "--steps.make_list.par1",
+        "10.",
+        "--steps.make_list.par2",
+        "par2",
+        "--save-parameters",
+        par_path,
+    ]
+    Step.from_cmdline(args)
+
+    # Rerun with the parameter file
+    # Initial condition is that `Step.from_cmdline`
+    # succeeds.
+    args = [par_path, "a.fits", "b"]
+    step = Step.from_cmdline(args)
+
+    # As a secondary condition, ensure the required parameter
+    # `par2` is set.
+    assert step.make_list.par2 == "par2"
+
+
+def test_asdf_from_call():
+    """Test using an ASDF file from call"""
+    config_file = get_pkg_data_filename(
+        "steps/jwst_generic_pars-makeliststep_0001.asdf"
+    )
+    results = MakeListStep.call(config_file=config_file)
+
+    assert results == DEFAULT_RESULT
+
+
+def test_from_command_line():
+    """Test creating Step from command line using ASDF"""
+    config_file = get_pkg_data_filename(
+        "steps/jwst_generic_pars-makeliststep_0001.asdf"
+    )
+    args = [config_file]
+    step = Step.from_cmdline(args)
+    assert isinstance(step, MakeListStep)
+    assert step.par1 == 42.0
+    assert step.par2 == "Yes, a string"
+
+    results = step.run()
+    assert results == DEFAULT_RESULT
+
+
+def test_from_command_line_override():
+    """Test creating Step from command line using ASDF"""
+    config_file = get_pkg_data_filename(
+        "steps/jwst_generic_pars-makeliststep_0001.asdf"
+    )
+    args = [config_file, "--par1=0."]
+    step = Step.from_cmdline(args)
+    assert isinstance(step, MakeListStep)
+    assert step.par1 == 0.0
+    assert step.par2 == "Yes, a string"
+
+    results = step.run()
+    assert results == [0.0, DEFAULT_PAR2, False]
+
+
+def test_makeliststep_missingpars():
+    """Test the testing step class when given insufficient information"""
+    with pytest.raises(ValidationError):
+        MakeListStep.call()
+
+
+def test_makeliststep_test():
+    """Test the testing step class for basic operation"""
+    result = MakeListStep.call(par1=DEFAULT_PAR1, par2=DEFAULT_PAR2)
+
+    assert result == DEFAULT_RESULT
+
+
+def test_step_from_asdf():
+    """Test initializing step completely from config"""
+    config_file = get_pkg_data_filename(
+        "steps/jwst_generic_pars-makeliststep_0001.asdf"
+    )
+    step = Step.from_config_file(config_file)
+    assert isinstance(step, MakeListStep)
+    assert step.name == "make_list"
+
+    results = step.run()
+    assert results == DEFAULT_RESULT
+
+
+def test_step_from_asdf_api_override():
+    """Test initializing step completely from config"""
+    config_file = get_pkg_data_filename(
+        "steps/jwst_generic_pars-makeliststep_0001.asdf"
+    )
+    results = MakeListStep.call(config_file=config_file, par1=0.0)
+    assert results == [0.0, DEFAULT_PAR2, False]
+
+
+def test_makeliststep_call_config_file():
+    """Test override step asdf with .cfg"""
+    config_file = get_pkg_data_filename("steps/makelist.cfg")
+    results = MakeListStep.call(config_file=config_file)
+    assert results == [43.0, "My hovercraft is full of eels.", False]
+
+
+def test_makeliststep_call_from_within_pipeline():
+    """Test override step asdf with .cfg"""
+    config_file = get_pkg_data_filename("steps/makelist_pipeline.cfg")
+    results = MakeListPipeline.call(config_file=config_file)
+    assert results == [43.0, "My hovercraft is full of eels.", False]
+
+
+def test_step_from_asdf_noname():
+    """Test initializing step completely from config without a name specified"""
+    root = "jwst_generic_pars-makeliststep_0002"
+    config_file = get_pkg_data_filename(f"steps/{root}.asdf")
+    step = Step.from_config_file(config_file)
+    assert isinstance(step, MakeListStep)
+    assert step.name == root
+
+    results = step.run()
+    assert results == DEFAULT_RESULT

--- a/tests/test_asdf_parameters.py
+++ b/tests/test_asdf_parameters.py
@@ -232,3 +232,9 @@ def test_reftype(cfg_file, expected_reftype):
     step = Step.from_config_file(get_pkg_data_filename(f"steps/{cfg_file}"))
     assert step.__class__.get_config_reftype() == expected_reftype
     assert step.get_config_reftype() == expected_reftype
+
+
+def test_step_with_local_class():
+    step_fn = get_pkg_data_filename("steps/local_class.cfg")
+    step = Step.from_config_file(step_fn)
+    assert isinstance(step, Step)

--- a/tests/test_asdf_parameters.py
+++ b/tests/test_asdf_parameters.py
@@ -167,3 +167,54 @@ def test_saving_pars(tmp_path):
     with asdf.open(str(saved_path)) as af:
         config = StepConfig.from_asdf(af)
         assert config.parameters == original_config.parameters
+
+
+@pytest.mark.parametrize(
+    "step_obj, expected",
+    [
+        (
+            MakeListStep(par1=0.0, par2="from args"),
+            StepConfig(
+                "steps.MakeListStep",
+                "MakeListStep",
+                {
+                    "pre_hooks": [],
+                    "post_hooks": [],
+                    "output_ext": "asdf",
+                    "output_use_model": False,
+                    "output_use_index": True,
+                    "save_results": False,
+                    "skip": False,
+                    "search_output_file": True,
+                    "input_dir": "",
+                    "par1": 0.0,
+                    "par2": "from args",
+                    "par3": False,
+                },
+                [],
+            ),
+        ),
+    ],
+)
+def test_export_config(step_obj, expected, tmp_path):
+    """Test retrieving of configuration parameters"""
+    config_path = tmp_path / "config.asdf"
+    step_obj.export_config(config_path)
+
+    with asdf.open(config_path) as af:
+        # StepConfig has an __eq__ implementation but we can't use it
+        # due to differences between asdf 2.7 and 2.8 in serializing None
+        # values.  This can be simplified once the minimum asdf requirement
+        # is changed to >= 2.8.
+        # assert StepConfig.from_asdf(af) == expected
+        config = StepConfig.from_asdf(af)
+        assert config.class_name == expected.class_name
+        assert config.name == expected.name
+        assert config.steps == expected.steps
+        parameters = set(expected.parameters.keys()).union(
+            set(config.parameters.keys())
+        )
+        for parameter in parameters:
+            assert config.parameters.get(parameter) == expected.parameters.get(
+                parameter
+            )

--- a/tests/test_asdf_parameters.py
+++ b/tests/test_asdf_parameters.py
@@ -218,3 +218,17 @@ def test_export_config(step_obj, expected, tmp_path):
             assert config.parameters.get(parameter) == expected.parameters.get(
                 parameter
             )
+
+
+@pytest.mark.parametrize(
+    "cfg_file, expected_reftype",
+    [
+        ("local_class.cfg", "pars-withdefaultsstep"),
+        ("jwst_generic_pars-makeliststep_0002.asdf", "pars-makeliststep"),
+    ],
+)
+def test_reftype(cfg_file, expected_reftype):
+    """Test that reftype is produced as expected"""
+    step = Step.from_config_file(get_pkg_data_filename(f"steps/{cfg_file}"))
+    assert step.__class__.get_config_reftype() == expected_reftype
+    assert step.get_config_reftype() == expected_reftype

--- a/tests/test_asdf_parameters.py
+++ b/tests/test_asdf_parameters.py
@@ -180,7 +180,7 @@ def test_saving_pars(tmp_path):
                 {
                     "pre_hooks": [],
                     "post_hooks": [],
-                    "output_ext": "asdf",
+                    "output_ext": ".asdf",
                     "output_use_model": False,
                     "output_use_index": True,
                     "save_results": False,

--- a/tests/test_asdf_parameters.py
+++ b/tests/test_asdf_parameters.py
@@ -2,10 +2,12 @@
 
 import pathlib
 
+import asdf
 import pytest
 
 from steps import MakeListPipeline, MakeListStep
 from stpipe import Step
+from stpipe.config import StepConfig
 from stpipe.config_parser import ValidationError
 
 DEFAULT_PAR1 = 42.0
@@ -147,3 +149,21 @@ def test_step_from_asdf_noname():
 
     results = step.run()
     assert results == DEFAULT_RESULT
+
+
+def test_saving_pars(tmp_path):
+    """Save the step parameters from the commandline"""
+    cfg_path = get_pkg_data_filename("steps/jwst_generic_pars-makeliststep_0002.asdf")
+    saved_path = tmp_path / "savepars.asdf"
+    Step.from_cmdline([cfg_path, "--save-parameters", str(saved_path)])
+    assert saved_path.exists()
+
+    with asdf.open(
+        get_pkg_data_filename("steps/jwst_generic_pars-makeliststep_0002.asdf")
+    ) as af:
+        original_config = StepConfig.from_asdf(af)
+        original_config.parameters["par3"] = False
+
+    with asdf.open(str(saved_path)) as af:
+        config = StepConfig.from_asdf(af)
+        assert config.parameters == original_config.parameters

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,192 @@
+from datetime import datetime, timedelta, timezone
+
+import asdf
+import pytest
+
+from steps import MakeListPipeline, WithDefaultsStep
+from stpipe.config import StepConfig, _validate_asdf, export_config
+
+
+@pytest.fixture
+def config():
+    s1 = StepConfig("some.StepClass", "Step1", {"woo": "hoo"}, [])
+    s2 = StepConfig("some.other.StepClass", "Step2", {"yee": "haw"}, [])
+
+    return StepConfig(
+        "some.PipelineClass", "Pipeline", {"foo": "bar", "baz": 42}, [s1, s2]
+    )
+
+
+def test_step_config_equality(config):
+    other = StepConfig(config.class_name, config.name, config.parameters, config.steps)
+    assert config == other
+
+    other = StepConfig(
+        "some.other.pipeline.Name", config.name, config.parameters, config.steps
+    )
+    assert config != other
+
+    other = StepConfig(config.class_name, "Hildegaard", config.parameters, config.steps)
+    assert config != other
+
+    other = StepConfig(config.class_name, config.name, {"foo": "foz"}, config.steps)
+    assert config != other
+
+    other = StepConfig(
+        config.class_name, config.name, config.parameters, [config.steps[0]]
+    )
+    assert config != other
+
+    assert config != object()
+
+
+def test_step_config_to_asdf(config):
+    # Without metadata
+    asdf_file = config.to_asdf()
+    assert isinstance(asdf_file, asdf.AsdfFile)
+    assert asdf_file["class"] == config.class_name
+    assert asdf_file["name"] == config.name
+    assert asdf_file["parameters"] == config.parameters
+    assert asdf_file["steps"] == [s.to_asdf().tree for s in config.steps]
+    assert "meta" not in asdf_file
+    # No validation errors:
+    with asdf.AsdfFile(asdf_file.tree) as af:
+        _validate_asdf(af, "http://stsci.edu/schemas/stpipe/step_config-1.0.0")
+
+    # With metadata
+    asdf_file = config.to_asdf(include_metadata=True)
+    assert isinstance(asdf_file, asdf.AsdfFile)
+    assert asdf_file["class"] == config.class_name
+    assert asdf_file["name"] == config.name
+    assert asdf_file["parameters"] == config.parameters
+    assert asdf_file["steps"] == [s.to_asdf().tree for s in config.steps]
+    assert asdf_file["meta"]["author"] == "<SPECIFY>"
+    current_time = datetime.now(timezone.utc).replace(tzinfo=None)
+    assert (
+        current_time - datetime.fromisoformat(asdf_file["meta"]["date"])
+    ) < timedelta(seconds=10)
+    assert (
+        asdf_file["meta"]["description"]
+        == "Parameters for calibration step some.PipelineClass"
+    )
+    assert asdf_file["meta"]["instrument"]["name"] == "<SPECIFY>"
+    assert asdf_file["meta"]["origin"] == "<SPECIFY>"
+    assert asdf_file["meta"]["pedigree"] == "<SPECIFY>"
+    assert asdf_file["meta"]["reftype"] == "<SPECIFY>"
+    assert asdf_file["meta"]["telescope"] == "<SPECIFY>"
+    assert asdf_file["meta"]["useafter"] == "<SPECIFY>"
+    # No validation errors against the simple schema:
+    with asdf.AsdfFile(asdf_file.tree) as af:
+        _validate_asdf(af, "http://stsci.edu/schemas/stpipe/step_config-1.0.0")
+
+    # Expect failures from the metadata schema while <SPECIFY>
+    # is still present:
+    with pytest.raises(asdf.ValidationError):
+        with asdf.AsdfFile(asdf_file.tree) as af:
+            _validate_asdf(
+                af, "http://stsci.edu/schemas/stpipe/step_config_with_metadata-1.0.0"
+            )
+
+    asdf_file["meta"]["author"] = "Yours Truly"
+    asdf_file["meta"]["instrument"]["name"] = "EYEBALLS"
+    asdf_file["meta"]["origin"] = "The depths"
+    asdf_file["meta"]["pedigree"] = "GROUND"
+    asdf_file["meta"]["reftype"] = "pars-pipelineclass"
+    asdf_file["meta"]["telescope"] = "BINOCULARS"
+    asdf_file["meta"]["useafter"] = "2020-11-20T00:00:00"
+    # No validation errors now:
+    with asdf.AsdfFile(asdf_file.tree) as af:
+        _validate_asdf(
+            af, "http://stsci.edu/schemas/stpipe/step_config_with_metadata-1.0.0"
+        )
+
+
+def test_step_config_from_asdf(config):
+    asdf_file = config.to_asdf()
+    assert StepConfig.from_asdf(asdf_file) == config
+
+    with pytest.raises(asdf.ValidationError):
+        StepConfig.from_asdf(asdf.AsdfFile())
+
+
+def test_step_config_from_legacy_asdf(config):
+    parameters = {
+        "class": config.class_name,
+        "name": config.name,
+    }
+    parameters.update(config.parameters)
+
+    steps = {}
+    for step in config.steps:
+        # The older config files don't include "name" or "class"
+        # for the child steps.
+        steps[step.name] = step.parameters
+
+    parameters["steps"] = steps
+
+    asdf_file = asdf.AsdfFile(
+        {"parameters": parameters},
+        custom_schema="http://stsci.edu/schemas/stpipe/step_config-0.1.0",
+    )
+
+    # We lose the step class names so the configs won't be equal:
+    legacy_config = StepConfig.from_asdf(asdf_file)
+    assert legacy_config.name == config.name
+    assert legacy_config.class_name == config.class_name
+    assert legacy_config.parameters == config.parameters
+    assert len(legacy_config.steps) == len(config.steps)
+    for legacy_step, step in zip(legacy_config.steps, config.steps):
+        assert legacy_step.name == step.name
+        assert legacy_step.class_name is None
+        assert legacy_step.parameters == step.parameters
+        assert legacy_step.steps == step.steps
+
+
+def test_export_config_step():
+    step = WithDefaultsStep(name="Ronald", par1="override par1 value")
+    config = export_config(step)
+
+    assert config.class_name == "steps.WithDefaultsStep"
+    assert config.name == "Ronald"
+
+    assert config.parameters["par1"] == "override par1 value"
+    assert config.parameters["par2"] == "default par2 value"
+    assert config.parameters["par3"] == "default par3 value"
+    assert config.parameters["par4"] == "default par4 value"
+
+    # Not going to check all superclass parameters, just one to make
+    # sure that Step was consulted:
+    assert config.parameters["input_dir"] == ""
+
+    assert len(config.steps) == 0
+
+
+def test_export_config_pipeline():
+    pipeline = MakeListPipeline(
+        name="Dorothy",
+        par1="override the atomizer",
+        steps={"make_list": {"par1": 3.14159, "par2": "frabjous"}},
+    )
+    config = export_config(pipeline)
+
+    assert config.class_name == "steps.MakeListPipeline"
+    assert config.name == "Dorothy"
+
+    assert config.parameters["par1"] == "override the atomizer"
+
+    # Not going to check all superclass parameters, just one to make
+    # sure that Step was consulted:
+    assert config.parameters["input_dir"] == ""
+
+    assert len(config.steps) == 1
+    step = config.steps[0]
+
+    assert step.class_name == "steps.MakeListStep"
+    assert step.name == "make_list"
+
+    assert step.parameters["par1"] == 3.14159
+    assert step.parameters["par2"] == "frabjous"
+    assert step.parameters["par3"] is False
+
+    # Check a base class parameter on the step too:
+    assert step.parameters["input_dir"] == ""

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -9,9 +9,12 @@ from typing import ClassVar
 
 import asdf
 import pytest
+from astropy.extern.configobj.configobj import ConfigObj
+from crds.core.exceptions import CrdsLookupError
 
 import stpipe.config_parser as cp
 from stpipe import cmdline, crds_client
+from stpipe.config import StepConfig
 from stpipe.datamodel import AbstractDataModel
 from stpipe.pipeline import Pipeline
 from stpipe.step import Step
@@ -697,3 +700,180 @@ def test_get_stpipe_loggers():
     # The default Step class returns the root logger only
     # as the known logger.
     assert Step.get_stpipe_loggers() == ("root",)
+
+
+@pytest.mark.parametrize(
+    "command_line_pars, command_line_config_pars, reference_pars, expected_pars",
+    [
+        # If nothing else is present, we should use the spec defaults
+        (
+            None,
+            None,
+            None,
+            {
+                "par1": "default par1 value",
+                "par2": "default par2 value",
+                "par3": "default par3 value",
+                "par4": "default par4 value",
+            },
+        ),
+        # Reference file pars > spec defaults
+        (
+            None,
+            None,
+            {
+                "par1": "reference par1 value",
+                "par2": "reference par2 value",
+                "par3": "reference par3 value",
+                "par4": "reference par4 value",
+            },
+            {
+                "par1": "reference par1 value",
+                "par2": "reference par2 value",
+                "par3": "reference par3 value",
+                "par4": "reference par4 value",
+            },
+        ),
+        # Command line config pars > reference pars
+        (
+            None,
+            {
+                "par1": "config par1 value",
+                "par2": "config par2 value",
+                "par3": "config par3 value",
+                "par4": "config par4 value",
+            },
+            {
+                "par1": "reference par1 value",
+                "par2": "reference par2 value",
+                "par3": "reference par3 value",
+                "par4": "reference par4 value",
+            },
+            {
+                "par1": "config par1 value",
+                "par2": "config par2 value",
+                "par3": "config par3 value",
+                "par4": "config par4 value",
+            },
+        ),
+        # Command line override pars > all other pars
+        (
+            {
+                "par1": "override par1 value",
+                "par2": "override par2 value",
+                "par3": "override par3 value",
+                "par4": "override par4 value",
+            },
+            {
+                "par1": "config par1 value",
+                "par2": "config par2 value",
+                "par3": "config par3 value",
+                "par4": "config par4 value",
+            },
+            {
+                "par1": "reference par1 value",
+                "par2": "reference par2 value",
+                "par3": "reference par3 value",
+                "par4": "reference par4 value",
+            },
+            {
+                "par1": "override par1 value",
+                "par2": "override par2 value",
+                "par3": "override par3 value",
+                "par4": "override par4 value",
+            },
+        ),
+        # Test complex merging of parameters (one parameter per source)
+        (
+            {"par1": "override par1 value"},
+            {"par2": "config par2 value"},
+            {"par3": "reference par3 value"},
+            {
+                "par1": "override par1 value",
+                "par2": "config par2 value",
+                "par3": "reference par3 value",
+                "par4": "default par4 value",
+            },
+        ),
+        # Test complex merging of parameters (more parameters
+        # specified on the lower-precedence sources)
+        (
+            {"par1": "override par1 value"},
+            {"par1": "config par1 value", "par2": "config par2 value"},
+            {
+                "par1": "reference par1 value",
+                "par2": "reference par2 value",
+                "par3": "reference par3 value",
+            },
+            {
+                "par1": "override par1 value",
+                "par2": "config par2 value",
+                "par3": "reference par3 value",
+                "par4": "default par4 value",
+            },
+        ),
+    ],
+)
+def test_step_from_commandline_par_precedence(
+    command_line_pars,
+    command_line_config_pars,
+    reference_pars,
+    expected_pars,
+    tmp_path,
+    monkeypatch,
+):
+    args = []
+
+    class_name = "steps.WithDefaultsStep"
+    config_name = "WithDefaultsStep"
+    reference_type = f"pars-{config_name.lower()}"
+    input_path = str(tmp_path / "input.asdf")
+
+    if command_line_config_pars:
+        command_line_config_path = tmp_path / "with_defaults_step.cfg"
+        config = ConfigObj(str(command_line_config_path))
+        config["class"] = class_name
+        config["name"] = config_name
+        for key, value in command_line_config_pars.items():
+            config[key] = value
+        config.write()
+        args.append(str(command_line_config_path.absolute()))
+    else:
+        args.append(class_name)
+
+    args.append(input_path)
+
+    if command_line_pars:
+        for key, value in command_line_pars.items():
+            args.append(f"--{key}={value}")
+
+    reference_file_map = {}
+    if reference_pars:
+        reference_path = tmp_path / f"{reference_type}.asdf"
+        reference_config = StepConfig(class_name, config_name, reference_pars, [])
+        with reference_config.to_asdf() as af:
+            af.write_to(reference_path)
+
+        reference_file_map[reference_type] = str(reference_path)
+
+    def mock_get_reference_file(
+        dataset, reference_file_type, observatory=None, asn_exptypes=None
+    ):
+        if reference_file_type in reference_file_map:
+            return reference_file_map[reference_file_type]
+        else:
+            raise CrdsLookupError(
+                f"Error determining best reference for '{reference_file_type}'  = \
+  Unknown reference type '{reference_file_type}'"
+            )
+
+    def mock_get_parameters(dataset):
+        return {}, "jwst"
+
+    monkeypatch.setattr(Step, "_get_crds_parameters", mock_get_parameters)
+    monkeypatch.setattr(crds_client, "get_reference_file", mock_get_reference_file)
+
+    step = Step.from_cmdline(args)
+
+    for key, value in expected_pars.items():
+        assert getattr(step, key) == value

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -13,6 +13,7 @@ from astropy.extern.configobj.configobj import ConfigObj
 from crds.core.exceptions import CrdsLookupError
 
 import stpipe.config_parser as cp
+from steps import EmptyPipeline, MakeListPipeline, MakeListStep
 from stpipe import cmdline, crds_client
 from stpipe.config import StepConfig
 from stpipe.datamodel import AbstractDataModel
@@ -877,3 +878,138 @@ def test_step_from_commandline_par_precedence(
 
     for key, value in expected_pars.items():
         assert getattr(step, key) == value
+
+
+@pytest.mark.parametrize(
+    "step_obj, full_spec, expected",
+    [
+        # #############################################
+        # Test with `full_spec = True`
+        # #############################################
+        # Mix of required and optional parameters
+        (
+            MakeListStep(par1=0.0, par2="from args"),
+            True,
+            {
+                "pre_hooks": [],
+                "post_hooks": [],
+                "output_file": None,
+                "output_dir": None,
+                "output_ext": ".asdf",
+                "output_use_model": False,
+                "output_use_index": True,
+                "save_results": False,
+                "skip": False,
+                "suffix": None,
+                "search_output_file": True,
+                "input_dir": "",
+                "par1": 0.0,
+                "par2": "from args",
+                "par3": False,
+            },
+        ),
+        #
+        # All parameters set
+        #
+        (
+            MakeListPipeline(
+                par1="Instantiated",
+                steps={"make_list": {"par1": 0.0, "par2": "sub-instantiated"}},
+            ),
+            True,
+            {
+                "pre_hooks": [],
+                "post_hooks": [],
+                "output_file": None,
+                "output_dir": None,
+                "output_ext": ".asdf",
+                "output_use_model": False,
+                "output_use_index": True,
+                "save_results": False,
+                "skip": False,
+                "suffix": None,
+                "search_output_file": True,
+                "input_dir": "",
+                "par1": "Instantiated",
+                "steps": {
+                    "make_list": {
+                        "pre_hooks": [],
+                        "post_hooks": [],
+                        "output_file": None,
+                        "output_dir": None,
+                        "output_ext": ".asdf",
+                        "output_use_model": False,
+                        "output_use_index": True,
+                        "save_results": False,
+                        "skip": False,
+                        "suffix": None,
+                        "search_output_file": True,
+                        "input_dir": "",
+                        "par1": 0.0,
+                        "par2": "sub-instantiated",
+                        "par3": False,
+                    }
+                },
+            },
+        ),
+        #
+        # Pipeline without any sub-steps
+        #
+        (
+            EmptyPipeline(par1="Instantiated"),
+            True,
+            {
+                "pre_hooks": [],
+                "post_hooks": [],
+                "output_file": None,
+                "output_dir": None,
+                "output_ext": ".asdf",
+                "output_use_model": False,
+                "output_use_index": True,
+                "save_results": False,
+                "skip": False,
+                "suffix": None,
+                "search_output_file": True,
+                "input_dir": "",
+                "par1": "Instantiated",
+                "steps": {},
+            },
+        ),
+        # ######################################
+        # Test with `full_spec=False`
+        # ######################################
+        # Mix of required and optional parameters
+        (
+            MakeListStep(par1=0.0, par2="from args"),
+            False,
+            {"par1": 0.0, "par2": "from args", "par3": False},
+        ),
+        # Pipeline with all parameters set
+        (
+            MakeListPipeline(
+                par1="Instantiated",
+                steps={"make_list": {"par1": 0.0, "par2": "sub-instantiated"}},
+            ),
+            False,
+            {
+                "par1": "Instantiated",
+                "steps": {
+                    "make_list": {
+                        "par1": 0.0,
+                        "par2": "sub-instantiated",
+                        "par3": False,
+                    }
+                },
+            },
+        ),
+        # Pipeline without any sub-steps
+        (
+            EmptyPipeline(par1="Instantiated"),
+            False,
+            {"par1": "Instantiated", "steps": {}},
+        ),
+    ],
+)
+def test_getpars(step_obj, full_spec, expected):
+    """Test retrieving of configuration parameters"""
+    assert step_obj.get_pars(full_spec=full_spec) == expected


### PR DESCRIPTION
Move a number of unit tests from jwst to here. See https://github.com/spacetelescope/jwst/pull/10568 for removal of those tests from jwst.

Since this only changes test code I did not run regression tests for this PR.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [x] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [x] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stpipe/blob/main/changes/README.rst) for instructions)
  - [ ] run regression tests with this branch installed (`stpipe@git+https://github.com/<fork>/stpipe.git@<branch>`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
