### PR TITLE
remove use of format_template

### DIFF
--- a/changes/320.bugfix.rst
+++ b/changes/320.bugfix.rst
@@ -1,0 +1,1 @@
+Switch internal use of format_template to f-strings. The plan is to deprecate format_template.

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -28,7 +28,6 @@ import yaml
 
 from . import config, config_parser, crds_client, log, utilities
 from .datamodel import AbstractDataModel
-from .format_template import FormatTemplate
 from .library import AbstractModelLibrary
 from .utilities import _not_set
 
@@ -1226,19 +1225,14 @@ class Step:
             suffix = None
             suffix_sep = None
 
-        # Setup formatting
-        formatter = FormatTemplate(
-            separator=separator,
-            remove_unused=True,
-        )
-
         if len(components):
-            component_str = formatter("", **components)
+            component_str = separator.join(
+                ["", *(str(v) for v in components.values() if v is not None)]
+            )
         else:
             component_str = ""
 
-        basename = formatter(
-            default_name_format,
+        basename = default_name_format.format(
             basename=basename,
             suffix=suffix,
             suffix_sep=suffix_sep,


### PR DESCRIPTION
Remove the stpipe usage of format_template. This is one step towards removing format_template. Next steps are:

- move format_template to jwst (or perhaps replace the usage there)
- remove format_template usage in romancal (it's referenced in unused code)
- deprecate format_template for stpipe 1.x
- remove format_template in stpipe 2.0.0

jwst regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/26529266041 (show 2 unrelated failures)
roman regtests: https://github.com/spacetelescope/RegressionTests/actions/runs/26540115039

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stpipe/blob/main/changes/README.rst) for instructions)
  - [ ] run regression tests with this branch installed (`stpipe@git+https://github.com/<fork>/stpipe.git@<branch>`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
