### PR TITLE
simplify example in docs

### DIFF
--- a/docs/source/user_step.rst
+++ b/docs/source/user_step.rst
@@ -309,9 +309,7 @@ parameter file as follows::
     from stpipe import config_parser
     from mycode.steps import CleanupStep
 
-    config = CleanupStep.get_config_from_reference(input_data)
-    local_config = config_parser.load_config_file('my_config.asdf')
-    config_parser.merge_config(config, local_config)
+    config, _ = CleanupStep.build_config(input_data, config_file='my_config.asdf')
 
     mystep = CleanupStep.from_config_section(config)
     output = mystep.run(input_data)


### PR DESCRIPTION
Simplify an example in the docs to match the simplification to the jwst docs in: https://github.com/spacetelescope/jwst/pull/10583

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stpipe/blob/main/changes/README.rst) for instructions)
  - [ ] run regression tests with this branch installed (`stpipe@git+https://github.com/<fork>/stpipe.git@<branch>`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
