### PR TITLE
Deprecate merge_config and make it private

### DIFF
--- a/src/stpipe/_cmdline.py
+++ b/src/stpipe/_cmdline.py
@@ -399,7 +399,7 @@ def _build_step_from_args(step_class, config, name, config_file, parser, known, 
     # specified on command line
     _override_config_from_args(config, args)
 
-    config = step_class.merge_config(config, config_file)
+    config = step_class._merge_config(config, config_file)
 
     if len(positional):
         input_file = positional[0]

--- a/src/stpipe/pipeline.py
+++ b/src/stpipe/pipeline.py
@@ -2,8 +2,8 @@
 Pipeline
 """
 
-import warnings
 import logging
+import warnings
 from os.path import dirname, join
 from typing import ClassVar
 

--- a/src/stpipe/pipeline.py
+++ b/src/stpipe/pipeline.py
@@ -2,6 +2,7 @@
 Pipeline
 """
 
+import warnings
 import logging
 from os.path import dirname, join
 from typing import ClassVar
@@ -95,7 +96,7 @@ class Pipeline(Step):
         return None
 
     @classmethod
-    def merge_config(cls, config, config_file):
+    def _merge_config(cls, config, config_file):
         steps = config.get("steps", {})
 
         # Configure all of the steps
@@ -112,6 +113,15 @@ class Pipeline(Step):
                     config_parser.merge_config(cfg2, cfg)
                     steps[key] = cfg2
         return config
+
+    @classmethod
+    def merge_config(cls, config, config_file):
+        warnings.warn(
+            "merge_config is deprecated. Use _merge_config instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return cls._merge_config(config, config_file)
 
     @classmethod
     def load_spec_file(cls, preserve_comments=_not_set):

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -87,8 +87,17 @@ class Step:
         return f"pars-{cls.__name__.lower()}"
 
     @classmethod
-    def merge_config(cls, config, config_file):
+    def _merge_config(cls, config, config_file):
         return config
+
+    @classmethod
+    def merge_config(cls, config, config_file):
+        warnings.warn(
+            "merge_config is deprecated. Use _merge_config instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return cls._merge_config(config, config_file)
 
     @classmethod
     def load_spec_file(cls, preserve_comments=_not_set):
@@ -272,7 +281,7 @@ class Step:
             del config["config_file"]
 
         spec = cls.load_spec_file()
-        config = cls.merge_config(config, config_file)
+        config = cls._merge_config(config, config_file)
         config_parser.validate(config, spec, root_dir=dirname(config_file or ""))
 
         if "config_file" in config:


### PR DESCRIPTION
Closes #324

Rename Step.merge_config and Pipeline.merge_config to _merge_config.
Add deprecated public shims that emit DeprecationWarning and delegate to the private versions.
Update the two internal callers (step.py:275, _cmdline.py:402).

No downstream callers in jwst — the doc reference was already removed in #10583.