### PR TITLE
make test work with pytest 9.1

### DIFF
--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -545,16 +545,21 @@ def test_crds_log(capsys, restore_console):
             return ("stpipe", "CRDS")
 
     crds_logger = logging.getLogger("CRDS")
+
+    def get_crds_handlers():
+        return [h for h in crds_logger.handlers if "pytest" not in h.__module__]
+
     if restore_console:
         # Before the step call, the crds logger has a stream handler
-        assert len(crds_logger.handlers) == 1
-        assert isinstance(crds_logger.handlers[0], logging.StreamHandler)
+        handlers = get_crds_handlers()
+        assert len(handlers) == 1
+        assert isinstance(handlers[0], logging.StreamHandler)
     else:
         # remove any current console handler
         crds_log.remove_console_handler()
 
         # Before the step call, the crds logger has no handlers
-        assert len(crds_logger.handlers) == 0
+        assert len(get_crds_handlers()) == 0
 
     # During the step call, the CRDS handler is removed if necessary and
     # the stpipe handler is attached
@@ -574,9 +579,10 @@ def test_crds_log(capsys, restore_console):
     # After the call is complete, the stpipe logger is removed and the CRDS
     # stream logger is restored if it was previously present
     if restore_console:
-        assert len(crds_logger.handlers) == 1
-        assert isinstance(crds_logger.handlers[0], logging.StreamHandler)
+        handlers = get_crds_handlers()
+        assert len(handlers) == 1
+        assert isinstance(handlers[0], logging.StreamHandler)
     else:
-        assert len(crds_logger.handlers) == 0
+        assert len(get_crds_handlers()) == 0
         # Clean up: restore a console logger
         crds_log.add_console_handler()

--- a/tox.ini
+++ b/tox.ini
@@ -59,6 +59,7 @@ commands_pre =
 commands =
     pytest \
     warnings: -W error \
+    oldestdeps: -p no:asdf_schema_tester \
     nolegacypath: -p no:legacypath \
     xdist: -n auto \
     jwst: jwst \


### PR DESCRIPTION
pytest 9.1 adds some new logging handlers to the crds logger causing a test failure:
https://github.com/spacetelescope/stpipe/actions/runs/27542241679/job/81406699223#step:11:132

This PR updates the test to ignore the new pytest handlers allowing the test to pass.

This PR also fixes an issue where the oldest deps uses a version of asdf that registered the asdf_schema_tester plugin (unused here). oldestdeps pulls in the latest pytest which leads to an error where the plugin with asdf 3.0.0 fails with latest pytest. This was fixed by disabling the unused plugin in the oldestdeps job.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stpipe/blob/main/changes/README.rst) for instructions)
  - [ ] run regression tests with this branch installed (`stpipe@git+https://github.com/<fork>/stpipe.git@<branch>`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
