### PR TITLE
add 3.15 testing

### DIFF
--- a/.github/workflows/tests_extra.yml
+++ b/.github/workflows/tests_extra.yml
@@ -28,4 +28,6 @@ jobs:
         - macos: py312-xdist
         - macos: py313-xdist
         - linux: py314-devdeps-xdist
+        - linux: py315-devdeps-xdist
+          python-version: 3.15
         - macos: py314-devdeps-xdist


### PR DESCRIPTION
Add devdeps 3.15 job to CI.

All tests pass so 3.15 support LGTM!

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stpipe/blob/main/changes/README.rst) for instructions)
  - [ ] run regression tests with this branch installed (`stpipe@git+https://github.com/<fork>/stpipe.git@<branch>`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
