### PR TITLE
DOC: Add hyphen for "On-Disk Mode" section title

### DIFF
--- a/docs/source/model_library.rst
+++ b/docs/source/model_library.rst
@@ -63,7 +63,7 @@ Iteration is also supported (but don't forget to return your models!).
 
 .. _library_on_disk:
 
-On Disk Mode
+On-Disk Mode
 ------------
 
 For large associations (like those larger than memory) it is important


### PR DESCRIPTION
<!-- describe the changes comprising this PR here -->
This PR adds hyphen for "On-Disk Mode" section title as @emolter suggested in https://github.com/spacetelescope/jwst/pull/10711#discussion_r3589596001

No need for change log nor RT. This really just need RTD build to pass.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [x] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stpipe/blob/main/changes/README.rst) for instructions)
  - [ ] run regression tests with this branch installed (`stpipe@git+https://github.com/<fork>/stpipe.git@<branch>`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
