### PR TITLE
Simplify parameter handling

### DIFF
--- a/src/stpipe/pipeline.py
+++ b/src/stpipe/pipeline.py
@@ -202,7 +202,8 @@ class Pipeline(Step):
         pipeline_cfg = cls._get_config_from_parameters(
             crds_parameters, crds_observatory
         )
-        return config_parser.merge_config(refcfg, pipeline_cfg)
+        config_parser.merge_config(refcfg, pipeline_cfg)
+        return refcfg
 
     @classmethod
     def merge_pipeline_config(cls, refcfg, ref_file):

--- a/src/stpipe/pipeline.py
+++ b/src/stpipe/pipeline.py
@@ -3,6 +3,7 @@ Pipeline
 """
 
 import logging
+import warnings
 from os.path import dirname, join
 from typing import ClassVar
 
@@ -226,7 +227,12 @@ class Pipeline(Step):
         ConfigObj of the merged parameters, with those from the pipeline cfg having
         precedence over those from the individual steps
         """
-
+        warnings.warn(
+            "merge_pipeline_config is deprecated. "
+            "Use config_parser.load_config_file and merge_config",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         pipeline_cfg = config_parser.load_config_file(ref_file)
         config_parser.merge_config(refcfg, pipeline_cfg)
         return refcfg

--- a/src/stpipe/pipeline.py
+++ b/src/stpipe/pipeline.py
@@ -140,6 +140,26 @@ class Pipeline(Step):
         return spec
 
     @classmethod
+    def _get_config_from_parameters(cls, crds_parameters, crds_observatory):
+        refcfg = ConfigObj()
+        refcfg["steps"] = Section(refcfg, refcfg.depth + 1, refcfg.main, name="steps")
+
+        # first apply step configs, then pipeline
+        for cal_step in cls.step_defs.keys():
+            cal_step_class = cls.step_defs[cal_step]
+            refcfg["steps"][cal_step] = cal_step_class._get_config_from_parameters(
+                crds_parameters,
+                crds_observatory,
+            )
+        #
+        # Now merge any config parameters from the step cfg file
+        pipeline_cfg = super()._get_config_from_parameters(
+            crds_parameters, crds_observatory
+        )
+        config_parser.merge_config(refcfg, pipeline_cfg)
+        return refcfg
+
+    @classmethod
     def get_config_from_reference(cls, dataset, disable=None, crds_observatory=None):
         """Retrieve step parameters from reference database
 

--- a/src/stpipe/pipeline.py
+++ b/src/stpipe/pipeline.py
@@ -10,7 +10,7 @@ from typing import ClassVar
 from astropy.extern.configobj.configobj import ConfigObj, Section
 
 from . import config_parser, crds_client
-from .step import Step, get_disable_crds_steppars
+from .step import Step
 from .utilities import _not_set
 
 logger = logging.getLogger(__name__)
@@ -140,8 +140,14 @@ class Pipeline(Step):
         return spec
 
     @classmethod
-    def _get_config_from_parameters(cls, crds_parameters, crds_observatory):
+    def _empty_config(cls):
         refcfg = ConfigObj()
+        refcfg["steps"] = Section(refcfg, refcfg.depth + 1, refcfg.main, name="steps")
+        return refcfg
+
+    @classmethod
+    def _get_config_from_parameters(cls, crds_parameters, crds_observatory):
+        refcfg = cls._empty_config()
         refcfg["steps"] = Section(refcfg, refcfg.depth + 1, refcfg.main, name="steps")
 
         # first apply step configs, then pipeline
@@ -152,74 +158,8 @@ class Pipeline(Step):
                 crds_observatory,
             )
         #
-        # Now merge any config parameters from the step cfg file
+        # Now merge any config parameters from the pipeline cfg file
         pipeline_cfg = super()._get_config_from_parameters(
-            crds_parameters, crds_observatory
-        )
-        config_parser.merge_config(refcfg, pipeline_cfg)
-        return refcfg
-
-    @classmethod
-    def get_config_from_reference(cls, dataset, disable=None, crds_observatory=None):
-        """Retrieve step parameters from reference database
-
-        Parameters
-        ----------
-        cls : `stpipe.step.Step`
-            Either a class or instance of a class derived
-            from `Step`.
-
-        dataset : `stpipe.datamodel.AbstractDataModel` or dict
-            A model of the input file.  Metadata on this input file will
-            be used by the CRDS "bestref" algorithm to obtain a reference
-            file. If dict, crds_observatory must be a non-None value.
-
-        disable: bool or None
-            Do not retrieve parameters from CRDS. If None, check global settings.
-
-        crds_observatory : str
-            Observatory name ('jwst' or 'roman').
-
-        Returns
-        -------
-        step_parameters : configobj
-            The parameters as retrieved from CRDS. If there is an issue, log as such
-            and return an empty config obj.
-        """
-        reftype = cls.get_config_reftype()
-        refcfg = ConfigObj()
-        refcfg["steps"] = Section(refcfg, refcfg.depth + 1, refcfg.main, name="steps")
-
-        # Check if retrieval should be attempted.
-        if disable is None:
-            disable = get_disable_crds_steppars()
-        if disable:
-            logger.debug(
-                "%s: CRDS parameter reference retrieval disabled.", reftype.upper()
-            )
-            return refcfg
-
-        logger.debug("Retrieving all substep parameters from CRDS")
-        #
-        # Iterate over the steps in the pipeline
-        if isinstance(dataset, dict):
-            # crds_parameters was passed as input from pipeline.py
-            crds_parameters = dataset
-            if crds_observatory is None:
-                raise ValueError("Need a valid name for crds_observatory.")
-        else:
-            crds_parameters, crds_observatory = cls._get_crds_parameters(dataset)
-
-        for cal_step in cls.step_defs.keys():
-            cal_step_class = cls.step_defs[cal_step]
-            refcfg["steps"][cal_step] = cal_step_class._get_config_from_parameters(
-                crds_parameters,
-                crds_observatory,
-            )
-        #
-        # Now merge any config parameters from the step cfg file
-        logger.debug("Retrieving pipeline %s parameters from CRDS", reftype.upper())
-        pipeline_cfg = cls._get_config_from_parameters(
             crds_parameters, crds_observatory
         )
         config_parser.merge_config(refcfg, pipeline_cfg)

--- a/src/stpipe/pipeline.py
+++ b/src/stpipe/pipeline.py
@@ -191,29 +191,17 @@ class Pipeline(Step):
 
         for cal_step in cls.step_defs.keys():
             cal_step_class = cls.step_defs[cal_step]
-            refcfg["steps"][cal_step] = cal_step_class.get_config_from_reference(
+            refcfg["steps"][cal_step] = cal_step_class._get_config_from_parameters(
                 crds_parameters,
-                crds_observatory=crds_observatory,
+                crds_observatory,
             )
         #
         # Now merge any config parameters from the step cfg file
         logger.debug("Retrieving pipeline %s parameters from CRDS", reftype.upper())
-        try:
-            ref_file = crds_client.get_reference_file(
-                crds_parameters,
-                reftype,
-                crds_observatory,
-            )
-        except (AttributeError, crds_client.CrdsError):
-            logger.debug("%s: No parameters found", reftype.upper())
-        else:
-            if ref_file != "N/A":
-                logger.info("%s parameters found: %s", reftype.upper(), ref_file)
-                refcfg = cls.merge_pipeline_config(refcfg, ref_file)
-            else:
-                logger.debug("No %s reference files found.", reftype.upper())
-
-        return refcfg
+        pipeline_cfg = cls._get_config_from_parameters(
+            crds_parameters, crds_observatory
+        )
+        return config_parser.merge_config(refcfg, pipeline_cfg)
 
     @classmethod
     def merge_pipeline_config(cls, refcfg, ref_file):

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -922,6 +922,25 @@ class Step:
         return crds_client.check_reference_open(reference_name)
 
     @classmethod
+    def _get_config_from_parameters(cls, crds_parameters, crds_observatory):
+        reftype = cls.get_config_reftype()
+        refcfg = config_parser.ConfigObj()
+        try:
+            ref_file = crds_client.get_reference_file(
+                crds_parameters,
+                reftype,
+                crds_observatory,
+            )
+        except (AttributeError, crds_client.CrdsError):
+            logger.debug("%s: No parameters found", reftype.upper())
+            return refcfg
+        if ref_file == "N/A":
+            logger.debug("No %s reference files found.", reftype.upper())
+            return refcfg
+        logger.info("%s parameters found: %s", reftype.upper(), ref_file)
+        return config_parser.load_config_file(ref_file)
+
+    @classmethod
     def get_config_from_reference(cls, dataset, disable=None, crds_observatory=None):
         """Retrieve step parameters from reference database
 
@@ -945,7 +964,6 @@ class Step:
             The parameters as retrieved from CRDS. If there is an issue, log as such
             and return an empty config obj.
         """
-
         reftype = cls.get_config_reftype()
 
         if isinstance(dataset, dict):
@@ -973,30 +991,12 @@ class Step:
 
         # Retrieve step parameters from CRDS
         logger.debug("Retrieving step %s parameters from CRDS", reftype.upper())
-        try:
-            ref_file = crds_client.get_reference_file(
-                crds_parameters,
-                reftype,
-                crds_observatory,
-            )
-        except (AttributeError, crds_client.CrdsError):
-            logger.debug("%s: No parameters found", reftype.upper())
-            return config_parser.ConfigObj()
-        if ref_file != "N/A":
-            logger.info("%s parameters found: %s", reftype.upper(), ref_file)
-            ref = config_parser.load_config_file(ref_file)
-
-            ref_pars = {
-                par: value for par, value in ref.items() if par not in ["class", "name"]
-            }
-            logger.debug(
-                "%s parameters retrieved from CRDS: %s", reftype.upper(), ref_pars
-            )
-
-            return ref
-
-        logger.debug("No %s reference files found.", reftype.upper())
-        return config_parser.ConfigObj()
+        ref = cls._get_config_from_parameters(crds_parameters, crds_observatory)
+        ref_pars = {
+            par: value for par, value in ref.items() if par not in ["class", "name"]
+        }
+        logger.debug("%s parameters retrieved from CRDS: %s", reftype.upper(), ref_pars)
+        return ref
 
     @staticmethod
     def get_stpipe_loggers():

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -1438,11 +1438,17 @@ class Step:
         """
         logger_name = cls.__name__
         log_cls = logging.getLogger(logger_name)
+        config = config_parser.ConfigObj()
         if input:
-            config = cls.get_config_from_reference(input)
+            try:
+                crds_parameters, crds_observatory = cls._get_crds_parameters(input)
+                config = cls.get_config_from_reference(
+                    crds_parameters, crds_observatory=crds_observatory
+                )
+            except (OSError, TypeError, ValueError):
+                logger.warning("Input dataset is not an instance of AbstractDataModel.")
         else:
             log_cls.info("No filename given, cannot retrieve config from CRDS")
-            config = config_parser.ConfigObj()
 
         if "config_file" in kwargs:
             config_file = kwargs["config_file"]

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -922,6 +922,10 @@ class Step:
         return crds_client.check_reference_open(reference_name)
 
     @classmethod
+    def _empty_config(cls):
+        return config_parser.ConfigObj()
+
+    @classmethod
     def _get_config_from_parameters(cls, crds_parameters, crds_observatory):
         reftype = cls.get_config_reftype()
         refcfg = config_parser.ConfigObj()
@@ -965,6 +969,16 @@ class Step:
             and return an empty config obj.
         """
         reftype = cls.get_config_reftype()
+        refcfg = cls._empty_config()
+
+        # Check if retrieval should be attempted.
+        if disable is None:
+            disable = get_disable_crds_steppars()
+        if disable:
+            logger.debug(
+                "%s: CRDS parameter reference retrieval disabled.", reftype.upper()
+            )
+            return refcfg
 
         if isinstance(dataset, dict):
             # crds_parameters was passed as input from pipeline.py
@@ -978,16 +992,8 @@ class Step:
                 crds_parameters, crds_observatory = cls._get_crds_parameters(dataset)
             except (OSError, TypeError, ValueError):
                 logger.warning("Input dataset is not an instance of AbstractDataModel.")
+                return refcfg
                 disable = True
-
-        # Check if retrieval should be attempted.
-        if disable is None:
-            disable = get_disable_crds_steppars()
-        if disable:
-            logger.info(
-                "%s: CRDS parameter reference retrieval disabled.", reftype.upper()
-            )
-            return config_parser.ConfigObj()
 
         # Retrieve step parameters from CRDS
         logger.debug("Retrieving step %s parameters from CRDS", reftype.upper())

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -35,6 +35,10 @@ class SimpleStep(Step):
         output_ext = string(default='simplestep')
     """
 
+    @classmethod
+    def _datamodels_open(cls, init, **kwargs):
+        return SimpleDataModel()
+
 
 class SimplePipe(Pipeline):
     """A Pipeline with parameters and one step"""
@@ -49,6 +53,10 @@ class SimplePipe(Pipeline):
 
     step_defs: ClassVar = {"step1": SimpleStep}
 
+    @classmethod
+    def _datamodels_open(cls, init, **kwargs):
+        return SimpleDataModel()
+
 
 class PipeWithPipe(Pipeline):
     """A Pipeline with a pipeline as a step"""
@@ -58,6 +66,10 @@ class PipeWithPipe(Pipeline):
     """
 
     step_defs: ClassVar = {"step1": SimpleStep, "pipe1": SimplePipe}
+
+    @classmethod
+    def _datamodels_open(cls, init, **kwargs):
+        return SimpleDataModel()
 
 
 class ListArgStep(Step):
@@ -76,6 +88,10 @@ class ListArgStep(Step):
 
     def process(self, *args, **kwargs):
         pass
+
+    @classmethod
+    def _datamodels_open(cls, init, **kwargs):
+        return SimpleDataModel()
 
 
 @pytest.fixture()
@@ -146,7 +162,9 @@ def config_file_list_arg_step(tmp_path):
 def _mock_step_crds(monkeypatch):
     """Mock various crds calls from Step"""
 
-    def mock_get_config_from_reference_pipe(dataset, disable=None):
+    def mock_get_config_from_reference_pipe(
+        dataset, disable=None, crds_observatory=None
+    ):
         return cp.config_from_dict(
             {
                 "str1": "from crds",
@@ -162,12 +180,16 @@ def _mock_step_crds(monkeypatch):
             }
         )
 
-    def mock_get_config_from_reference_step(dataset, disable=None):
+    def mock_get_config_from_reference_step(
+        dataset, disable=None, crds_observatory=None
+    ):
         return cp.config_from_dict(
             {"str1": "from crds", "str2": "from crds", "str3": "from crds"}
         )
 
-    def mock_get_config_from_reference_list_arg_step(dataset, disable=None):
+    def mock_get_config_from_reference_list_arg_step(
+        dataset, disable=None, crds_observatory=None
+    ):
         return cp.config_from_dict({"rotation": "15", "pixel_scale": "0.85"})
 
     monkeypatch.setattr(
@@ -457,6 +479,12 @@ class SimpleDataModel(AbstractDataModel):
         with open(path, "w") as f:
             f.write(f"{path}\n")
         return path
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return
 
 
 def test_save_results(tmp_cwd):

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -1006,3 +1006,12 @@ def test_step_from_commandline_par_precedence(
 def test_getpars(step_obj, full_spec, expected):
     """Test retrieving of configuration parameters"""
     assert step_obj.get_pars(full_spec=full_spec) == expected
+
+
+def test_merge_pipeline_config_deprecation(tmp_path):
+    fn = tmp_path / "other.cfg"
+    cfg = ConfigObj()
+    with open(fn, "wb") as f:
+        cfg.write(f)
+    with pytest.warns(DeprecationWarning, match="merge_pipeline_config is deprecated"):
+        SimplePipe.merge_pipeline_config(cfg, str(fn))


### PR DESCRIPTION
Simplify parameter handling related to `get_config_from_reference`.

Regtests pass:
jwst: https://github.com/spacetelescope/RegressionTests/actions/runs/29507271938
romancal: https://github.com/spacetelescope/RegressionTests/actions/runs/29507256409

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stpipe/blob/main/changes/README.rst) for instructions)
  - [ ] run regression tests with this branch installed (`stpipe@git+https://github.com/<fork>/stpipe.git@<branch>`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
