### PR TITLE
Mock crds client directly

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 import pytest
 
+import stpipe.crds_client
+
 
 @pytest.fixture()
 def tmp_cwd(tmp_path):
@@ -22,3 +24,32 @@ def disable_crds_steppars(monkeypatch):
     """
     monkeypatch.setitem(os.environ, "STPIPE_DISABLE_CRDS_STEPPARS", "True")
     yield
+
+
+@pytest.fixture()
+def mock_crds(monkeypatch, tmp_path):
+    crds_path = tmp_path / "crds"
+    crds_path.mkdir()
+
+    class MockCRDSClient:
+        def __init__(self, path):
+            self.path = path
+
+        def _reftype_to_fn(self, reftype):
+            return self.path / reftype
+
+        def add_config(self, reftype, config):
+            fn = self._reftype_to_fn(reftype)
+            config.to_asdf().write_to(fn)
+
+        def _get_refpaths(self, data_dict, reference_file_types, observatory):
+            paths = {}
+            for reftype in reference_file_types:
+                fn = self._reftype_to_fn(reftype)
+                paths[reftype] = fn if fn.exists() else "N/A"
+            return paths
+
+    mock = MockCRDSClient(crds_path)
+
+    monkeypatch.setattr(stpipe.crds_client, "_get_refpaths", mock._get_refpaths)
+    yield mock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,10 @@
 import os
+from contextlib import nullcontext
 from pathlib import Path
 
+import crds
 import pytest
-
-import stpipe.crds_client
+from crds.core import crds_cache_locking
 
 
 @pytest.fixture()
@@ -34,22 +35,50 @@ def mock_crds(monkeypatch, tmp_path):
     class MockCRDSClient:
         def __init__(self, path):
             self.path = path
+            self.mappings = {}
 
-        def _reftype_to_fn(self, reftype):
-            return self.path / reftype
+        def add_mapping(self, reftype, match=None, filename=None, observatory="jwst"):
+            if match is None:
 
-        def add_config(self, reftype, config):
-            fn = self._reftype_to_fn(reftype)
+                def match(parameters):
+                    return True
+
+            fn = (
+                self.path
+                / "crds"
+                / observatory
+                / (reftype if filename is None else filename)
+            )
+            fn.parent.mkdir(parents=True, exist_ok=True)
+            if observatory not in self.mappings:
+                self.mappings[observatory] = {}
+            if reftype not in self.mappings[observatory]:
+                self.mappings[observatory][reftype] = []
+            self.mappings[observatory][reftype].append((match, fn))
+            # create the file so check_open works
+            fn.touch()
+            return fn
+
+        def lookup(self, observatory, reftype, parameters):
+            for mapping in self.mappings.get(observatory, {}).get(reftype, []):
+                match, filename = mapping
+                if match(parameters):
+                    return str(filename)
+            return "N/A"
+
+        def add_config(self, reftype, config, observatory="jwst"):
+            fn = self.add_mapping(reftype, observatory=observatory)
             config.to_asdf().write_to(fn)
 
-        def _get_refpaths(self, data_dict, reference_file_types, observatory):
+        def _getreferences(self, data_dict, reftypes, observatory):
             paths = {}
-            for reftype in reference_file_types:
-                fn = self._reftype_to_fn(reftype)
-                paths[reftype] = fn if fn.exists() else "N/A"
+            for reftype in reftypes:
+                paths[reftype] = self.lookup(observatory, reftype, data_dict)
             return paths
 
     mock = MockCRDSClient(crds_path)
 
-    monkeypatch.setattr(stpipe.crds_client, "_get_refpaths", mock._get_refpaths)
+    # mock cache locking, this fixture is function scoped so no need for locking
+    monkeypatch.setattr(crds_cache_locking, "get_cache_lock", nullcontext)
+    monkeypatch.setattr(crds, "getreferences", mock._getreferences)
     yield mock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,9 @@ def disable_crds_steppars(monkeypatch):
 
 @pytest.fixture()
 def mock_crds(monkeypatch, tmp_path):
+    """
+    Mock the used portion of the crds client so tests can be run without a crds server.
+    """
     crds_path = tmp_path / "crds"
     crds_path.mkdir()
 
@@ -38,6 +41,31 @@ def mock_crds(monkeypatch, tmp_path):
             self.mappings = {}
 
         def add_mapping(self, reftype, match=None, filename=None, observatory="jwst"):
+            """
+            Add a mapping to a reference in the mock crds.
+
+            Parameters
+            ---------
+            reftype : str
+                Reference type name.
+
+            match : callable
+                An optional callable with crds parameters as an argument and
+                returning True/False if the parameters should return the filename
+                for the added mapping.
+
+            filename : str
+                An optional filename to use for the reference. If not provided
+                reftype will be used as the filename.
+
+            observatory : str
+                An optional observatory for the reference mapping.
+
+            Returns
+            -------
+            path
+                Path to the reference (created as an empty file if it doesn't exist).
+            """
             if match is None:
 
                 def match(parameters):
@@ -60,6 +88,25 @@ def mock_crds(monkeypatch, tmp_path):
             return fn
 
         def lookup(self, observatory, reftype, parameters):
+            """
+            Look up a reference file (or "N/A" if it doesn't exist).
+
+            Parameters
+            ----------
+            observatory : str
+                Name of observatory.
+
+            reftype : str
+                Reference type name.
+
+            parameters : dict
+                Parameters to test against available mappings.
+
+            Returns
+            -------
+            str
+                Filename of reference or "N/A".
+            """
             for mapping in self.mappings.get(observatory, {}).get(reftype, []):
                 match, filename = mapping
                 if match(parameters):
@@ -67,6 +114,20 @@ def mock_crds(monkeypatch, tmp_path):
             return "N/A"
 
         def add_config(self, reftype, config, observatory="jwst"):
+            """
+            Add a step configuration reference mapping.
+
+            Parameters
+            ----------
+            reftype : str
+                Reference type name.
+
+            config : StepConfig
+                StepConfig instance to save as a reference file.
+
+            observatory : str
+                Name of observatory
+            """
             fn = self.add_mapping(reftype, observatory=observatory)
             config.to_asdf().write_to(fn)
 

--- a/tests/steps/__init__.py
+++ b/tests/steps/__init__.py
@@ -39,6 +39,10 @@ class WithDefaultsStep(BaseStep):
 
         return input_data
 
+    @classmethod
+    def _get_crds_parameters(self, dataset):
+        return {}, "jwst"
+
 
 class MakeListStep(BaseStep):
     """Make a list of all arguments and parameters."""

--- a/tests/test_crds.py
+++ b/tests/test_crds.py
@@ -1,0 +1,48 @@
+import crds
+import pytest
+from crds.core.exceptions import CrdsError
+
+import stpipe.crds_client
+
+
+def test_get_multiple_reference_paths_empty_reference_file_types():
+    assert stpipe.crds_client.get_multiple_reference_paths({}, [], "jwst") == {}
+
+
+def test_get_multiple_reference_paths_invalid_parameters():
+    with pytest.raises(TypeError, match="must be a dict"):
+        stpipe.crds_client.get_multiple_reference_paths(None, [], "jwst")
+
+
+@pytest.mark.parametrize(
+    "name, override",
+    [
+        ("dark", "override_dark"),
+        ("read_noise", "override_read_noise"),
+        ("Mask", "override_Mask"),
+    ],
+)
+def test_get_override_name(name, override):
+    assert stpipe.crds_client.get_override_name(name) == override
+
+
+def test_invalid_get_override_name():
+    with pytest.raises(ValueError, match="not a valid reference"):
+        stpipe.crds_client.get_override_name("1mask")
+
+
+def test_crds_version():
+    assert stpipe.crds_client.get_svn_version() == crds.__version__
+
+
+def test_reference_uri_to_cache_path(monkeypatch):
+    monkeypatch.setattr(crds, "locate_file", lambda basename, observatory: basename)
+    assert (
+        stpipe.crds_client.reference_uri_to_cache_path("crds://foo.fits", "")
+        == "foo.fits"
+    )
+
+
+def test_invalid_reference_uri_to_cache_path():
+    with pytest.raises(CrdsError, match="should start with"):
+        stpipe.crds_client.reference_uri_to_cache_path("foo.fits", "")

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -12,7 +12,6 @@ import pytest
 from astropy.extern.configobj.configobj import ConfigObj
 from crds.core.exceptions import CrdsLookupError
 
-import stpipe.config_parser as cp
 from steps import EmptyPipeline, MakeListPipeline, MakeListStep
 from stpipe import crds_client
 from stpipe._config import StepConfig
@@ -159,57 +158,52 @@ def config_file_list_arg_step(tmp_path):
 
 
 @pytest.fixture()
-def _mock_step_crds(monkeypatch):
-    """Mock various crds calls from Step"""
-
-    def mock_get_config_from_reference_pipe(
-        dataset, disable=None, crds_observatory=None
-    ):
-        return cp.config_from_dict(
+def mock_step_crds(mock_crds):
+    """Configure a mock crds for these tests"""
+    mock_crds.add_config(
+        "pars-simplepipe",
+        StepConfig(
+            "SimplePipe",
+            "simplepipe",
             {
                 "str1": "from crds",
                 "str2": "from crds",
                 "str3": "from crds",
-                "steps": {
-                    "step1": {
-                        "str1": "from crds",
-                        "str2": "from crds",
-                        "str3": "from crds",
-                    },
-                },
-            }
-        )
-
-    def mock_get_config_from_reference_step(
-        dataset, disable=None, crds_observatory=None
-    ):
-        return cp.config_from_dict(
-            {"str1": "from crds", "str2": "from crds", "str3": "from crds"}
-        )
-
-    def mock_get_config_from_reference_list_arg_step(
-        dataset, disable=None, crds_observatory=None
-    ):
-        return cp.config_from_dict({"rotation": "15", "pixel_scale": "0.85"})
-
-    monkeypatch.setattr(
-        SimplePipe, "get_config_from_reference", mock_get_config_from_reference_pipe
+            },
+            [
+                StepConfig(
+                    "SimpleStep",
+                    "step1",
+                    {"str1": "from crds", "str2": "from crds", "str3": "from crds"},
+                    [],
+                ),
+            ],
+        ),
     )
-    monkeypatch.setattr(
-        SimpleStep, "get_config_from_reference", mock_get_config_from_reference_step
+    mock_crds.add_config(
+        "pars-simplestep",
+        StepConfig(
+            "SimpleStep",
+            "step1",
+            {"str1": "from crds", "str2": "from crds", "str3": "from crds"},
+            [],
+        ),
     )
-    monkeypatch.setattr(
-        ListArgStep,
-        "get_config_from_reference",
-        mock_get_config_from_reference_list_arg_step,
+
+    mock_crds.add_config(
+        "pars-listargstep",
+        StepConfig(
+            "ListArgStep", "ListArgStep", {"rotation": "15", "pixel_scale": "0.85"}, []
+        ),
     )
+
+    yield mock_crds
 
 
 # #####
 # Tests
 # #####
-@pytest.mark.usefixtures("_mock_step_crds")
-def test_build_config_pipe_config_file(config_file_pipe):
+def test_build_config_pipe_config_file(config_file_pipe, mock_step_crds):
     """Test that local config overrides defaults and CRDS-supplied file"""
     config, returned_config_file = SimplePipe.build_config(
         "science.fits", config_file=config_file_pipe
@@ -223,8 +217,7 @@ def test_build_config_pipe_config_file(config_file_pipe):
     assert config["steps"]["step1"]["str3"] == "from crds"
 
 
-@pytest.mark.usefixtures("_mock_step_crds")
-def test_build_config_pipe_crds():
+def test_build_config_pipe_crds(mock_step_crds):
     """Test that CRDS param reffile overrides a default CRDS configuration"""
     config, config_file = SimplePipe.build_config("science.fits")
     assert not config_file
@@ -243,8 +236,7 @@ def test_build_config_pipe_default():
     assert len(config) == 0
 
 
-@pytest.mark.usefixtures("_mock_step_crds")
-def test_build_config_pipe_kwarg(config_file_pipe):
+def test_build_config_pipe_kwarg(config_file_pipe, mock_step_crds):
     """Test that kwargs override CRDS and local param reffiles"""
     config, returned_config_file = SimplePipe.build_config(
         "science.fits",
@@ -261,8 +253,7 @@ def test_build_config_pipe_kwarg(config_file_pipe):
     assert config["steps"]["step1"]["str3"] == "from crds"
 
 
-@pytest.mark.usefixtures("_mock_step_crds")
-def test_build_config_step_config_file(config_file_step):
+def test_build_config_step_config_file(config_file_step, mock_step_crds):
     """Test that local config overrides defaults and CRDS-supplied file"""
     config, returned_config_file = SimpleStep.build_config(
         "science.fits", config_file=config_file_step
@@ -273,12 +264,10 @@ def test_build_config_step_config_file(config_file_step):
     assert config["str3"] == "from crds"
 
 
-@pytest.mark.usefixtures("_mock_step_crds")
-def test_build_config_step_crds():
+def test_build_config_step_crds(mock_step_crds):
     """Test override of a CRDS configuration"""
     config, config_file = SimpleStep.build_config("science.fits")
     assert config_file is None
-    assert len(config) == 3
     assert config["str1"] == "from crds"
     assert config["str2"] == "from crds"
     assert config["str3"] == "from crds"
@@ -291,8 +280,7 @@ def test_build_config_step_default():
     assert len(config) == 0
 
 
-@pytest.mark.usefixtures("_mock_step_crds")
-def test_build_config_step_kwarg(config_file_step):
+def test_build_config_step_kwarg(config_file_step, mock_step_crds):
     """Test that kwargs override everything"""
     config, returned_config_file = SimpleStep.build_config(
         "science.fits", config_file=config_file_step, str1="from kwarg"
@@ -303,8 +291,7 @@ def test_build_config_step_kwarg(config_file_step):
     assert config["str3"] == "from crds"
 
 
-@pytest.mark.usefixtures("_mock_step_crds")
-def test_step_list_args(config_file_list_arg_step):
+def test_step_list_args(config_file_list_arg_step, mock_step_crds):
     """Test that list arguments, provided as comma-separated values are parsed
     correctly.
     """

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -10,10 +10,8 @@ from typing import ClassVar
 import asdf
 import pytest
 from astropy.extern.configobj.configobj import ConfigObj
-from crds.core.exceptions import CrdsLookupError
 
 from steps import EmptyPipeline, MakeListPipeline, MakeListStep
-from stpipe import crds_client
 from stpipe._config import StepConfig
 from stpipe.datamodel import AbstractDataModel
 from stpipe.pipeline import Pipeline
@@ -640,31 +638,25 @@ def test_get_filename(dataset, filename):
     "observatory, error",
     [
         (None, True),
-        (None, True),
-        ("jwst", False),
         ("jwst", False),
     ],
 )
-def test_get_config_from_reference_dict(monkeypatch, klass, observatory, error):
+def test_get_config_from_reference_dict(mock_crds, klass, observatory, error):
     """Test that config_from_reference accepts a dict"""
-    called = False
-
-    def always_na(*args):
-        nonlocal called
-        called = True
-        return "N/A"
-
-    monkeypatch.setattr(crds_client, "get_reference_file", always_na)
     if error:
         ctx = pytest.raises(ValueError, match="Need a valid name for crds_observatory")
     else:
         ctx = nullcontext()
 
+    mock_crds.add_config(
+        klass.get_config_reftype(),
+        StepConfig(klass.__name__, klass.__name__, {"foo": 1}, []),
+    )
     with ctx:
-        klass.get_config_from_reference({}, crds_observatory=observatory)
+        ref = klass.get_config_from_reference({}, crds_observatory=observatory)
 
     if not error:
-        assert called
+        assert ref["foo"] == 1
 
 
 @pytest.mark.parametrize("klass", (SimpleStep, SimplePipe, PipeWithPipe))
@@ -825,7 +817,7 @@ def test_step_from_commandline_par_precedence(
     reference_pars,
     expected_pars,
     tmp_path,
-    monkeypatch,
+    mock_crds,
 ):
     args = []
 
@@ -852,31 +844,10 @@ def test_step_from_commandline_par_precedence(
         for key, value in command_line_pars.items():
             args.append(f"--{key}={value}")
 
-    reference_file_map = {}
     if reference_pars:
-        reference_path = tmp_path / f"{reference_type}.asdf"
-        reference_config = StepConfig(class_name, config_name, reference_pars, [])
-        with reference_config.to_asdf() as af:
-            af.write_to(reference_path)
-
-        reference_file_map[reference_type] = str(reference_path)
-
-    def mock_get_reference_file(
-        dataset, reference_file_type, observatory=None, asn_exptypes=None
-    ):
-        if reference_file_type in reference_file_map:
-            return reference_file_map[reference_file_type]
-        else:
-            raise CrdsLookupError(
-                f"Error determining best reference for '{reference_file_type}'  = \
-  Unknown reference type '{reference_file_type}'"
-            )
-
-    def mock_get_parameters(dataset):
-        return {}, "jwst"
-
-    monkeypatch.setattr(Step, "_get_crds_parameters", mock_get_parameters)
-    monkeypatch.setattr(crds_client, "get_reference_file", mock_get_reference_file)
+        mock_crds.add_config(
+            reference_type, StepConfig(class_name, config_name, reference_pars, [])
+        )
 
     step = Step.from_cmdline(args)
 

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -417,7 +417,7 @@ class StepWithGetCRDSParameters(Step):
 
     @classmethod
     def _get_crds_parameters(cls, dataset):
-        return cls._TEST_PARAMETERS, "fake"
+        return cls._TEST_PARAMETERS, "jwst"
 
     def process(self, input_model):
         # make a change to ensure step skip is working
@@ -603,20 +603,16 @@ def test_save_tuple_with_nested_list(tmp_cwd, model_list):
         assert not (tmp_cwd / f"test{i}-saved.txt").exists()
 
 
-def test_subclass_get_crds_parameters(monkeypatch):
+def test_subclass_get_crds_parameters(mock_crds):
     """Test that _get_crds_parameters for a subclass is called"""
+
+    def match(parameters):
+        return parameters == StepWithGetCRDSParameters._TEST_PARAMETERS
+
+    mock_crds.add_mapping("reftype", match=match, filename="bar")
     step = StepWithGetCRDSParameters()
-
-    called = False
-
-    def get_reference_file(parameters, reference_file_type, observatory):
-        nonlocal called
-        called = True
-        return "N/A"
-
-    monkeypatch.setattr(crds_client, "get_reference_file", get_reference_file)
-    step.get_reference_file("foo", "bar")
-    assert called
+    r = step.get_reference_file("some_file.asdf", "reftype")
+    assert "bar" in r
 
 
 @pytest.mark.parametrize(
@@ -645,8 +641,8 @@ def test_get_filename(dataset, filename):
     [
         (None, True),
         (None, True),
-        ("foo", False),
-        ("foo", False),
+        ("jwst", False),
+        ("jwst", False),
     ],
 )
 def test_get_config_from_reference_dict(monkeypatch, klass, observatory, error):


### PR DESCRIPTION
Closes #339
Closes https://github.com/spacetelescope/stpipe/issues/338

Updates tests that previously mocked stpipe functions to work-around not having a test crds to instead mock the crds client allowing the stpipe functions to be called. This exposed one missing `_get_crds_parameters` for a test class.

As these are only test changes no regtests were run.

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stpipe/blob/main/changes/README.rst) for instructions)
  - [ ] run regression tests with this branch installed (`stpipe@git+https://github.com/<fork>/stpipe.git@<branch>`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
