### PR TITLE
deprecate print_configspec

### DIFF
--- a/changes/347.removal.rst
+++ b/changes/347.removal.rst
@@ -1,0 +1,1 @@
+Deprecate ``Step.print_configspec``. Use ``print(Step.spec)`` instead.

--- a/src/stpipe/step.py
+++ b/src/stpipe/step.py
@@ -106,6 +106,11 @@ class Step:
 
     @classmethod
     def print_configspec(cls):
+        warnings.warn(
+            "print_configspec is deprecated. Use print(Step.spec) instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         specfile = cls.load_spec_file()
         specfile.write(sys.stdout.buffer)
 

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -1043,3 +1043,8 @@ def test_merge_pipeline_config_deprecation(tmp_path):
         cfg.write(f)
     with pytest.warns(DeprecationWarning, match="merge_pipeline_config is deprecated"):
         SimplePipe.merge_pipeline_config(cfg, str(fn))
+
+
+def test_print_configspec_deprecation():
+    with pytest.warns(DeprecationWarning, match="print_configspec is deprecated"):
+        SimpleStep.print_configspec()


### PR DESCRIPTION
Closes #323

Deprecate `Step.print_configspec`. Use `print(Step.spec)` instead.

Regtests all pass:
roman: https://github.com/spacetelescope/RegressionTests/actions/runs/30118417184
jwst: https://github.com/spacetelescope/RegressionTests/actions/runs/30118431964

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stpipe/blob/main/changes/README.rst) for instructions)
  - [ ] run regression tests with this branch installed (`stpipe@git+https://github.com/<fork>/stpipe.git@<branch>`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
