### PR TITLE
[SCSB-273] freeze ruff rules with explicit selection

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,42 @@
+src = [
+  "src",
+  "tests",
+  "docs",
+  "setup.py",
+]
+line-length = 88
+extend-exclude = [
+  "docs",
+  "scripts/strun",
+]
+
+[lint]
+select = [
+  "S",  # flake8-bandit
+  "I",  # isort
+  "E",  # pycodestyle
+  "W",  # pycodestyle
+  "F",  # Pyflakes
+  "UP",  # pyupgrade
+]
+extend-select = [
+  "NPY",  # NumPy-specific checks (recommendations from NumPy)
+]
+
+[lint.extend-per-file-ignores]
+"tests/*.py" = [
+  "S101",
+  "S603",
+  "S607",
+  "INP001",
+  "ARG001",
+]
+"src/stpipe/tests/*.py" = [
+  "S101",
+]
+"src/stpipe/cli/*.py" = [
+  "T201",
+]
+"src/stpipe/cmdline.py" = [
+  "T201",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,50 +77,6 @@ testpaths = ["tests"]
 filterwarnings = ["error"]
 markers = ["soctests"]
 
-[tool.ruff]
-src = [
-    "src",
-    "tests",
-    "docs",
-    "setup.py",
-]
-line-length = 88
-extend-exclude = [
-    "docs",
-    "scripts/strun",
-]
-
-[tool.ruff.lint]
-extend-select = [
-    "F",      # Pyflakes
-    "W", "E", # pycodestyle
-    "I",      # isort
-    "UP",     # pyupgrade
-    "S",      # flake8-bandit
-    "NPY",     # NumPy-specific checks (recommendations from NumPy)
-]
-ignore = [
-    "ISC001",  # conflicts with ruff formatter
-]
-
-[tool.ruff.lint.extend-per-file-ignores]
-"tests/*.py" = [
-    "S101",
-    "S603",
-    "S607",
-    "INP001",
-    "ARG001",
-]
-"src/stpipe/tests/*.py" = [
-    "S101",
-]
-"src/stpipe/cli/*.py" = [
-    "T201",
-]
-"src/stpipe/cmdline.py" = [
-    "T201",
-]
-
 [tool.black]
 line-length = 88
 force-exclude = "^/(\n  (\n      \\.eggs\n    | \\.git\n    | \\.pytest_cache\n    | \\.tox\n  )/\n)\n"


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [SCSB-273](https://jira.stsci.edu/browse/SCSB-273)

<!-- If this PR closes a GitHub issue, reference it here by its number -->

<!-- describe the changes comprising this PR here -->
[`ruff 0.16.0` added a lot more default rules](https://astral.sh/blog/ruff-v0.16.0); to avoid a bunch of new Ruff failures, we can explicitly set the rules we're using with `select`. The pre-0.16.0 default rules were `select = ["E4", "E7", "E9", "F"]`

<!-- if you can't perform these tasks due to permissions, please ask a maintainer to do them -->
## Tasks
- [ ] update or add relevant tests
- [ ] update relevant docstrings and / or `docs/` page
- [ ] Does this PR change any API used downstream? (if not, label with `no-changelog-entry-needed`)
  - [ ] write news fragment(s) in `changes/`: `echo "changed something" > changes/<PR#>.<changetype>.rst` (see [changelog readme](https://github.com/spacetelescope/stpipe/blob/main/changes/README.rst) for instructions)
  - [ ] run regression tests with this branch installed (`stpipe@git+https://github.com/<fork>/stpipe.git@<branch>`)
    - [ ] [`jwst` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/jwst.yml)
    - [ ] [`romancal` regression test](https://github.com/spacetelescope/RegressionTests/actions/workflows/romancal.yml)
